### PR TITLE
BF: Fixed and added error message if no backends initialized...

### DIFF
--- a/server/jail.py
+++ b/server/jail.py
@@ -49,8 +49,10 @@ class Jail:
 		if backend != 'auto':
 			# we have got strict specification of the backend to use
 			if not (backend in self._BACKENDS):
+				logSys.error("Unknown backend %s. Must be among %s or 'auto'"
+					% (backend, backends))
 				raise ValueError("Unknown backend %s. Must be among %s or 'auto'"
-								 % (backend, backends))
+					% (backend, backends))
 			# so explore starting from it till the 'end'
 			backends = backends[backends.index(backend):]
 


### PR DESCRIPTION
INVALID COMMAND is printed when RuntimeError is raised, so we don't get to see the error's message
