### PR TITLE
Added option to choose between network or local socket

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -17,7 +17,7 @@ client/filterreader.py
 client/actionreader.py
 client/__init__.py
 client/configurator.py
-client/csocket.py
+client/clientcommunicator.py
 server/asyncserver.py
 server/filter.py
 server/filterpyinotify.py

--- a/client/beautifier.py
+++ b/client/beautifier.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 # $Revision$
 
 __author__ = "Cyril Jaquier"
@@ -41,23 +41,23 @@ logSys = logging.getLogger("fail2ban.client.config")
 # converted into user readable messages.
 
 class Beautifier:
-	
+
 	def __init__(self, cmd = None):
 		self.__inputCmd = cmd
 
 	def setInputCmd(self, cmd):
 		self.__inputCmd = cmd
-		
+
 	def getInputCmd(self):
 		return self.__inputCmd
-		
-	def beautify(self, response):
-		logSys.debug("Beautify " + `response` + " with " + `self.__inputCmd`)
+
+	def beautify(self, response, server = ""):
+		logSys.debug("Beautify " + response + " with " + str(self.__inputCmd))
 		inC = self.__inputCmd
 		msg = response
 		try:
 			if inC[0] == "ping":
-				msg = "Server replied: " + response
+				msg = server + " Server replied: " + response
 			elif inC[0] == "start":
 				msg = "Jail started"
 			elif inC[0] == "stop":

--- a/client/clientcommunicator.py
+++ b/client/clientcommunicator.py
@@ -49,7 +49,7 @@ class clientCommunicator:
 		# Determine and set socket type (network/INET or socket/UNIX)
 		self.__determineAndSetSocketType(__socket)
 
-		logSys.info("Socket type: " + self.__sockettype)
+		logSys.debug("Socket type: " + self.__sockettype)
 
 		if self.__sockettype == "socket":
 			self.unixClient(__socket)

--- a/client/clientcommunicator.py
+++ b/client/clientcommunicator.py
@@ -29,7 +29,7 @@ __license__ = "GPL"
 
 #from cPickle import dumps, loads, HIGHEST_PROTOCOL
 from pickle import dumps, loads, HIGHEST_PROTOCOL
-import socket, logging
+import socket, logging, ipaddr
 
 
 # Gets the instance of the logger.
@@ -40,26 +40,39 @@ class clientCommunicator:
 
 	END_STRING = "<F2B_END_COMMAND>"
 
-	def __init__(self, socket, sockettype="socket"):
+	def __init__(self, socket):
 		# sockType: network (AF_INET) or socket (AF_UNIX)
-		self.sockettype = sockettype
-		if self.sockettype == "socket":
-			self.socket = socket
-			self.unixClient(self.socket)
-		elif self.sockettype == "network":
-			self.serverlist = socket
-			self.networkClient(self.serverlist)
-		else:
-			logSys.error("Connection type invalid:" + self.sockettype)
 
+		__socket = socket
+		self.__sockettype = None
+
+		# Determine and set socket type (network/INET or socket/UNIX)
+		self.__determineAndSetSocketType(__socket)
+
+		logSys.info("Socket type: " + self.__sockettype)
+
+		if self.__sockettype == "socket":
+			self.unixClient(__socket)
+		elif self.__sockettype == "network":
+			self.networkClient(__socket)
+		else:
+			logSys.error("Connection type invalid:" + self.__sockettype)
+
+	# Connect to local domain (unix) socket
 	def unixClient(self, socketpath="/var/run/fail2ban/fail2ban.sock"):
-		# Connect to local domain (unix) socket
+
+		logSys.info("Using socket file: " + socketpath)
+
 		self.__clientConn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 		self.__clientConn.connect(socketpath)
 
-	def networkClient(self, serverlist="localhost:2222"):
-		# Create an INET, STREAMing socket
-		HOST, PORT = serverlist.split(':')
+	# Create an INET, STREAMing socket
+	def networkClient(self, server="127.0.0.1:1234"):
+
+		logSys.info("Server(s): " + server)
+
+		server = server.replace(' ', '')
+		HOST, PORT = server.split(':')
 		PORT = int(PORT)
 		self.__clientConn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		self.__clientConn.connect((HOST, PORT))
@@ -68,19 +81,46 @@ class clientCommunicator:
 		# Convert every list member to string
 		obj = dumps([str(m) for m in msg], HIGHEST_PROTOCOL)
 		self.__clientConn.send(obj + clientCommunicator.END_STRING)
-		ret = self.receive(self.__clientConn)
+		ret = self.receive(self,self.__clientConn)
 		self.__clientConn.close()
 		return ret
 
 	#@staticmethod
-	def receive(socket):
+	def receive(self, socket):
 		msg = ''
 		while msg.rfind(clientCommunicator.END_STRING) == -1:
 			# END_STRING is 16 bits
 			# recv buffer should be at least twice the size
 			chunk = socket.recv(64)
 			if chunk == '':
-				raise RuntimeError, "socket connection broken"
+				raise RuntimeError, str(self.__clientConn.getpeername())+" socket connection broken"
 			msg = msg + chunk
 		return loads(msg)
 	receive = staticmethod(receive)
+
+	# Try to determine socket type (network/AF_INET or local/AF_UNIX)
+	# and set socket type in configuration
+	def __determineAndSetSocketType(self, socket):
+		__socket = socket
+
+		# the port will be anything after the last :
+		tempVarA = __socket.rfind(":")
+
+		# ipv6 literals should have a closing brace
+		tempVarB = __socket.rfind("]")
+
+		# if the last : is outside the [addr] part (or if we don't have []'s
+		if (tempVarA > tempVarB):
+			__socket = __socket[:tempVarA]
+
+		# now strip off ipv6 []'s if there are any
+		if __socket and __socket[0] == '[' and __socket[-1] == ']':
+			__socket = __socket[1:-1]
+
+		try:
+			ipaddr.IPAddress(__socket)
+			logSys.debug(__socket + " looks like IP address")
+			self.__sockettype = "network"
+		except ValueError:
+			logSys.debug(__socket + " does not look like IP address")
+			self.__sockettype = "socket"

--- a/client/configreader.py
+++ b/client/configreader.py
@@ -35,24 +35,24 @@ from ConfigParser import NoOptionError, NoSectionError
 logSys = logging.getLogger("fail2ban.client.config")
 
 class ConfigReader(SafeConfigParserWithIncludes):
-	
+
 	BASE_DIRECTORY = "/etc/fail2ban/"
-	
+
 	def __init__(self):
 		SafeConfigParserWithIncludes.__init__(self)
 		self.__opts = None
-	
+
 	#@staticmethod
 	def setBaseDir(folderName):
 		path = folderName.rstrip('/')
 		ConfigReader.BASE_DIRECTORY = path + '/'
 	setBaseDir = staticmethod(setBaseDir)
-		
+
 	#@staticmethod
 	def getBaseDir():
 		return ConfigReader.BASE_DIRECTORY
 	getBaseDir = staticmethod(getBaseDir)
-	
+
 	def read(self, filename):
 		basename = ConfigReader.BASE_DIRECTORY + filename
 		logSys.debug("Reading " + basename)
@@ -64,7 +64,7 @@ class ConfigReader(SafeConfigParserWithIncludes):
 		else:
 			logSys.error(bConf + " and " + bLocal + " do not exist")
 			return False
-	
+
 	##
 	# Read the options.
 	#
@@ -74,7 +74,7 @@ class ConfigReader(SafeConfigParserWithIncludes):
 	# 0 -> the type of the option
 	# 1 -> the name of the option
 	# 2 -> the default value for the option
-	
+
 	def getOptions(self, sec, options, pOptions = None):
 		values = dict()
 		for option in options:

--- a/client/configreader.py
+++ b/client/configreader.py
@@ -90,7 +90,7 @@ class ConfigReader(SafeConfigParserWithIncludes):
 				values[option[1]] = v
 			except NoSectionError, e:
 				# No "Definition" section or wrong basedir
-				logSys.error(e)
+				logSys.error("Error getting options:" + e)
 				values[option[1]] = option[2]
 			except NoOptionError:
 				if not option[2] == None:

--- a/client/configurator.py
+++ b/client/configurator.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 # $Revision$
 
 __author__ = "Cyril Jaquier"
@@ -36,41 +36,41 @@ from jailsreader import JailsReader
 logSys = logging.getLogger("fail2ban.client.config")
 
 class Configurator:
-	
+
 	def __init__(self):
 		self.__settings = dict()
 		self.__streams = dict()
 		self.__fail2ban = Fail2banReader()
 		self.__jails = JailsReader()
-	
+
 	#@staticmethod
 	def setBaseDir(folderName):
 		ConfigReader.setBaseDir(folderName)
 	setBaseDir = staticmethod(setBaseDir)
-	
+
 	#@staticmethod
 	def getBaseDir():
 		return ConfigReader.getBaseDir()
 	getBaseDir = staticmethod(getBaseDir)
-	
+
 	def readEarly(self):
 		self.__fail2ban.read()
-	
+
 	def readAll(self):
 		self.readEarly()
 		self.__jails.read()
-	
+
 	def getEarlyOptions(self):
 		return self.__fail2ban.getEarlyOptions()
 
 	def getOptions(self, jail = None):
 		self.__fail2ban.getOptions()
 		return self.__jails.getOptions(jail)
-		
+
 	def convertToProtocol(self):
 		self.__streams["general"] = self.__fail2ban.convert()
 		self.__streams["jails"] = self.__jails.convert()
-	
+
 	def getConfigStream(self):
 		cmds = list()
 		for opt in self.__streams["general"]:
@@ -78,4 +78,4 @@ class Configurator:
 		for opt in self.__streams["jails"]:
 			cmds.append(opt)
 		return cmds
-	
+

--- a/client/fail2banreader.py
+++ b/client/fail2banreader.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 # $Revision$
 
 __author__ = "Cyril Jaquier"
@@ -34,22 +34,26 @@ from configreader import ConfigReader
 logSys = logging.getLogger("fail2ban.client.config")
 
 class Fail2banReader(ConfigReader):
-	
+
 	def __init__(self):
 		ConfigReader.__init__(self)
-	
+
 	def read(self):
 		ConfigReader.read(self, "fail2ban")
-	
+
 	def getEarlyOptions(self):
-		opts = [["string", "socket", "/tmp/fail2ban.sock"]]
+		opts = [["string", "socket", "/tmp/fail2ban.sock"],
+			["string", "sockettype", "socket"]]
 		return ConfigReader.getOptions(self, "Definition", opts)
-	
+
 	def getOptions(self):
 		opts = [["int", "loglevel", 1],
-				["string", "logtarget", "STDERR"]]
+			["string", "logtarget", "STDERR"],
+			["string", "socket", "/tmp/fail2ban.sock"],
+			["string", "sockettype", "socket"]]
+
 		self.__opts = ConfigReader.getOptions(self, "Definition", opts)
-	
+
 	def convert(self):
 		stream = list()
 		for opt in self.__opts:
@@ -58,4 +62,4 @@ class Fail2banReader(ConfigReader):
 			elif opt == "logtarget":
 				stream.append(["set", "logtarget", self.__opts[opt]])
 		return stream
-	
+

--- a/client/fail2banreader.py
+++ b/client/fail2banreader.py
@@ -42,15 +42,13 @@ class Fail2banReader(ConfigReader):
 		ConfigReader.read(self, "fail2ban")
 
 	def getEarlyOptions(self):
-		opts = [["string", "socket", "/tmp/fail2ban.sock"],
-			["string", "sockettype", "socket"]]
+		opts = [["string", "socket", "/tmp/fail2ban.sock"]]
 		return ConfigReader.getOptions(self, "Definition", opts)
 
 	def getOptions(self):
 		opts = [["int", "loglevel", 1],
 			["string", "logtarget", "STDERR"],
-			["string", "socket", "/tmp/fail2ban.sock"],
-			["string", "sockettype", "socket"]]
+			["string", "socket", "/tmp/fail2ban.sock"]]
 
 		self.__opts = ConfigReader.getOptions(self, "Definition", opts)
 

--- a/config/fail2ban.conf
+++ b/config/fail2ban.conf
@@ -15,7 +15,7 @@
 #          4 = DEBUG
 # Values:  NUM  Default:  3
 #
-loglevel = 3
+loglevel = 4
 
 # Option:  logtarget
 # Notes.:  Set the log target. This could be a file, SYSLOG, STDERR or STDOUT.
@@ -24,24 +24,17 @@ loglevel = 3
 #
 logtarget = /var/log/fail2ban.log
 
-# Option: sockettype
-# Notes.: Type of the socket used to connect client and server.
-#         If this value is modified - option "socket" should be changed respectively too.
-#         If you choose "socket" here, then socket shoud be filepath
-#         If you choose "network" here, then socket should be IP:PORT
-# Values: SOCKET NETWORK  Default:  socket
-#
-#sockettype = network
-sockettype = socket
-
 # Option: socket
-# Notes.: Set the socket file. This is used to communicate with the daemon. Do
-#         not remove this file when Fail2ban runs. It will not be possible to
+# Notes.: Set the socket file or network address. This is used to communicate with the daemon.
+#         Do not remove socket file when Fail2ban runs. It will not be possible to
 #         communicate with the server afterwards.
-# Values: FILE IP:PORT HOSTNAME:PORT Default:  /var/run/fail2ban/fail2ban.sock
+#         *IPv6 address must me in form [address]:port
+#         Network sockets are space or coma delimited
+# Values: FILE HOSTNAME:PORT IPV4ADDRESS:PORT [IPV6ADDRESS]:PORT Default:  /var/run/fail2ban/fail2ban.sock
 #
-#socket = 127.0.0.1:1234 
-socket = /var/run/fail2ban/fail2ban.sock
+#socket = /var/run/fail2ban/fail2ban.sock
+#socket = [2001:cdba:0000:0000:0000:0000:3257:9652]:1234, 127.0.0.254:1234 192.168.0.1:1234
+socket = 127.0.0.1:1234
 
 # Option: allowedclients
 # Notes.: List of clients that are allowed to connect to the server.

--- a/config/fail2ban.conf
+++ b/config/fail2ban.conf
@@ -20,15 +20,32 @@ loglevel = 3
 # Option:  logtarget
 # Notes.:  Set the log target. This could be a file, SYSLOG, STDERR or STDOUT.
 #          Only one log target can be specified.
-# Values:  STDOUT STDERR SYSLOG file  Default:  /var/log/fail2ban.log
+# Values:  STDOUT STDERR SYSLOG FILE  Default:  /var/log/fail2ban.log
 #
 logtarget = /var/log/fail2ban.log
+
+# Option: sockettype
+# Notes.: Type of the socket used to connect client and server.
+#         If this value is modified - option "socket" should be changed respectively too.
+#         If you choose "socket" here, then socket shoud be filepath
+#         If you choose "network" here, then socket should be IP:PORT
+# Values: SOCKET NETWORK  Default:  socket
+#
+#sockettype = network
+sockettype = socket
 
 # Option: socket
 # Notes.: Set the socket file. This is used to communicate with the daemon. Do
 #         not remove this file when Fail2ban runs. It will not be possible to
 #         communicate with the server afterwards.
-# Values: FILE  Default:  /var/run/fail2ban/fail2ban.sock
+# Values: FILE IP:PORT HOSTNAME:PORT Default:  /var/run/fail2ban/fail2ban.sock
 #
+#socket = 127.0.0.1:1234 
 socket = /var/run/fail2ban/fail2ban.sock
 
+# Option: allowedclients
+# Notes.: List of clients that are allowed to connect to the server.
+#         This can be IP address, IP range, Network address. 
+# Values: IP IP_START-IP_END IP/MASK Default: ANY
+#
+allowedclients = ANY

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -264,6 +264,8 @@ action   = iptables-multiport[name=Named, port="domain,953", protocol=tcp]
 logpath  = /var/log/named/security.log
 ignoreip = 168.192.0.1
 
+# Multiple jails, 1 per protocol, are necessary ATM:
+# see https://github.com/fail2ban/fail2ban/issues/37
 [asterisk-tcp]
 
 enabled  = false

--- a/fail2ban-client
+++ b/fail2ban-client
@@ -19,7 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 # $Revision$
 
 __author__ = "Cyril Jaquier"
@@ -38,7 +38,7 @@ sys.path.insert(1, "/usr/share/fail2ban")
 # Now we can import our modules
 from common.version import version
 from common.protocol import printFormatted
-from client.csocket import CSocket
+from client.clientcommunicator import clientCommunicator
 from client.configurator import Configurator
 from client.beautifier import Beautifier
 
@@ -64,8 +64,10 @@ class Fail2banClient:
 		self.__conf["force"] = False
 		self.__conf["verbose"] = 1
 		self.__conf["interactive"] = False
+		self.__conf["sockettype"] = "socket"
 		self.__conf["socket"] = None
-		
+		self.__conf["startserver"] = True
+
 	def dispVersion(self):
 		print "Fail2Ban v" + version
 		print
@@ -75,7 +77,7 @@ class Fail2banClient:
 		print
 		print "Written by Cyril Jaquier <cyril.jaquier@fail2ban.org>."
 		print "Many contributions by Yaroslav O. Halchenko <debian@onerussian.com>."
-	
+
 	def dispUsage(self):
 		""" Prints Fail2Ban command line options and exits
 		"""
@@ -86,27 +88,29 @@ class Fail2banClient:
 		print
 		print "Options:"
 		print "    -c <DIR>                configuration directory"
-		print "    -s <FILE>               socket path"
+		print "    -t                      socket type (network or socket)"
+		print "    -s <FILE|IP:PORT>       socket path"
 		print "    -d                      dump configuration. For debugging"
 		print "    -i                      interactive mode"
 		print "    -v                      increase verbosity"
 		print "    -q                      decrease verbosity"
+		print "    --dontstartserver       don't start server"
 		print "    -x                      force execution of the server (remove socket file)"
 		print "    -h, --help              display this help message"
 		print "    -V, --version           print the version"
 		print
 		print "Command:"
-		
+
 		# Prints the protocol
 		printFormatted()
-		
+
 		print
 		print "Report bugs to <cyril.jaquier@fail2ban.org>"
-	
+
 	def dispInteractive(self):
 		print "Fail2Ban v" + version + " reads log file that contains password failure report"
 		print "and bans the corresponding IP addresses using firewall rules."
-		print 
+		print
 
 	def __sigTERMhandler(self, signum, frame):
 		# Print a new line because we probably come from wait
@@ -122,6 +126,8 @@ class Fail2banClient:
 				self.__conf["conf"] = opt[1]
 			elif opt[0] == "-s":
 				self.__conf["socket"] = opt[1]
+			elif opt[0] == "-t":
+				self.__conf["sockettype"] = opt[1]
 			elif opt[0] == "-d":
 				self.__conf["dump"] = True
 			elif opt[0] == "-v":
@@ -132,22 +138,24 @@ class Fail2banClient:
 				self.__conf["force"] = True
 			elif opt[0] == "-i":
 				self.__conf["interactive"] = True
+			elif opt[0] == "--dontstartserver":
+	 			self.__conf["startserver"] = False
 			elif opt[0] in ["-h", "--help"]:
 	 			self.dispUsage()
 	 			sys.exit(0)
 	 		elif opt[0] in ["-V", "--version"]:
 	 			self.dispVersion()
 	 			sys.exit(0)
-	
+
 	def __ping(self):
 		return self.__processCmd([["ping"]], False)
-	
+
 	def __processCmd(self, cmd, showRet = True):
 		beautifier = Beautifier()
 		for c in cmd:
 			beautifier.setInputCmd(c)
 			try:
-				client = CSocket(self.__conf["socket"])
+				client = clientCommunicator(self.__conf["socket"], self.__conf["sockettype"])
 				ret = client.send(c)
 				if ret[0] == 0:
 					logSys.debug("OK : " + `ret[1]`)
@@ -163,10 +171,10 @@ class Fail2banClient:
 				return False
 			except Exception, e:
 				if showRet:
-					logSys.error(e)
+					logSys.error(str(e))
 				return False
 		return True
-		
+
 	##
 	# Process a command line.
 	#
@@ -174,7 +182,7 @@ class Fail2banClient:
 	# @param cmd the command line
 
 	def __processCommand(self, cmd):
-		if len(cmd) == 1 and cmd[0] == "start":
+		if len(cmd) == 1 and cmd[0] == "start" and self.__conf["startserver"]:
 			if self.__ping():
 				logSys.error("Server already running")
 				return False
@@ -185,8 +193,7 @@ class Fail2banClient:
 				if not ret:
 					return False
 				# Start the server
-				self.__startServerAsync(self.__conf["socket"],
-										self.__conf["force"])
+				self.__startServerAsync(self.__conf["socket"], self.__conf["sockettype"], self.__conf["force"])
 				try:
 					# Wait for the server to start
 					self.__waitOnServer()
@@ -194,12 +201,20 @@ class Fail2banClient:
 					self.__processCmd(self.__stream, False)
 					return True
 				except ServerExecutionException:
-					logSys.error("Could not start server. Maybe an old " +
-								 "socket file is still present. Try to " +
-								 "remove " + self.__conf["socket"] + ". If " +
-								 "you used fail2ban-client to start the " +
-								 "server, adding the -x option will do it")
+					if self.__conf["sockettype"] == "socket":
+						logSys.error("Could not start server. Maybe an old " +
+									"socket file is still present. Try to " +
+									"remove " + self.__conf["socket"] + ". If " +
+									"you used fail2ban-client to start the " +
+									"server, adding the -x option will do it")
+					else:
+						logSys.error("Could not start server. Maybe network connection " +
+									"to the server(s) is broken " +
+									"or server not running: " +
+									self.__conf["socket"])
 					return False
+		elif self.__conf["startserver"] == False:
+			logSys.info("Not starting server (because of configuration or command line option)")
 		elif len(cmd) == 1 and cmd[0] == "reload":
 			if self.__ping():
 				ret = self.__readConfig()
@@ -227,21 +242,25 @@ class Fail2banClient:
 				return False
 		else:
 			return self.__processCmd([cmd])
-	
-	
+
+
 	##
 	# Start Fail2Ban server.
 	#
 	# Start the Fail2ban server in daemon mode.
-	
-	def __startServerAsync(self, socket, force = False):
+
+	def __startServerAsync(self, socket, sockettype, force = False):
 		# Forks the current process.
 		pid = os.fork()
 		if pid == 0:
 			args = list()
+			print self.SERVER
 			args.append(self.SERVER)
 			# Start in background mode.
 			args.append("-b")
+			# Set socket type
+			args.append("-t")
+			args.append(sockettype)
 			# Set the socket path.
 			args.append("-s")
 			args.append(socket)
@@ -251,6 +270,7 @@ class Fail2banClient:
 			try:
 				# Use the current directory.
 				exe = os.path.abspath(os.path.join(sys.path[0], self.SERVER))
+				logSys.debug("Starting server:" + str(exe) + " " + str(args))
 				os.execv(exe, args)
 			except OSError:
 				try:
@@ -259,8 +279,8 @@ class Fail2banClient:
 				except OSError:
 					print "Could not find %s" % self.SERVER
 					os.exit(-1)
-						
-			
+
+
 	def __waitOnServer(self):
 		# Wait for the server to start
 		cnt = 0
@@ -288,27 +308,27 @@ class Fail2banClient:
 			cnt += 1
 		if self.__conf["verbose"] > 1:
 			sys.stdout.write('\n')
-			
-	
+
+
 	def start(self, argv):
 		# Command line options
 		self.__argv = argv
-		
+
 		# Install signal handlers
 		signal.signal(signal.SIGTERM, self.__sigTERMhandler)
 		signal.signal(signal.SIGINT, self.__sigTERMhandler)
-		
+
 		# Reads the command line options.
 		try:
-			cmdOpts = 'hc:s:xdviqV'
-			cmdLongOpts = ['help', 'version']
+			cmdOpts = 'hc:t:s:xdviqV'
+			cmdLongOpts = ['help', 'version', "dontstartserver"]
 			optList, args = getopt.getopt(self.__argv[1:], cmdOpts, cmdLongOpts)
 		except getopt.GetoptError:
 			self.dispUsage()
 			return False
-			
+
 		self.__getCmdLineOptions(optList)
-		
+
 		verbose = self.__conf["verbose"]
 		if verbose <= 0:
 			logSys.setLevel(logging.ERROR)
@@ -328,19 +348,33 @@ class Fail2banClient:
 
 		# Set the configuration path
 		self.__configurator.setBaseDir(self.__conf["conf"])
-		
-		# Set socket path
+
 		self.__configurator.readEarly()
-		socket = self.__configurator.getEarlyOptions()
+		self.earlyOptions = self.__configurator.getEarlyOptions()
+
+		# Set socket type (network/INET or socket/UNIX)
+		self.__conf["sockettype"] = self.earlyOptions["sockettype"]
+		logSys.info("Socket type: " + self.__conf["sockettype"])
+
+		# Set socket path
 		if self.__conf["socket"] == None:
-			self.__conf["socket"] = socket["socket"]
-		logSys.info("Using socket file " + self.__conf["socket"])
+			self.__conf["socket"] = self.earlyOptions["socket"]
+
+		# Output some info
+		if self.__conf["sockettype"] == "socket":
+			logSys.info("Using socket file: " + self.__conf["socket"])
+		elif self.__conf["sockettype"] == "network":
+			logSys.info("Server(s): " + self.__conf["socket"])
+		else:
+			logSys.error("Socket type invalid: "+ self.__conf["sockettype"] +
+					" (Typing error? Use socket or network)")
+			return
 
 		if self.__conf["dump"]:
 			ret = self.__readConfig()
 			self.dumpConfig(self.__stream)
 			return ret
-		
+
 		# Interactive mode
 		if self.__conf["interactive"]:
 			try:
@@ -379,14 +413,14 @@ class Fail2banClient:
 		self.__configurator.convertToProtocol()
 		self.__stream = self.__configurator.getConfigStream()
 		return ret
-	
+
 	def __readJailConfig(self, jail):
 		self.__configurator.readAll()
 		ret = self.__configurator.getOptions(jail)
 		self.__configurator.convertToProtocol()
 		self.__stream = self.__configurator.getConfigStream()
 		return ret
-	
+
 	#@staticmethod
 	def dumpConfig(cmd):
 		for c in cmd:

--- a/fail2ban-client
+++ b/fail2ban-client
@@ -144,9 +144,10 @@ class Fail2banClient:
 	 			sys.exit(0)
 
 	def __ping(self):
-		return self.__processCmd([["ping"]], False)
+		self.__processCmd([["ping"]], False)
+		return self._cmdSendSuccess
 
-	def __processCmd(self, cmd, showRet = True):
+	def __processCmd(self, cmd, showRet = False):
 		beautifier = Beautifier()
 		for c in cmd:
 			beautifier.setInputCmd(c)
@@ -160,6 +161,8 @@ class Fail2banClient:
 
 			# iterate through all servers
 			for __socket in __socketlist:
+				self._cmdSendSuccess = True
+
 				try:
 					client = clientCommunicator(__socket)
 
@@ -169,20 +172,22 @@ class Fail2banClient:
 					if ret[0] == 0:
 						logSys.debug("OK : " + `ret[0]`)
 						if showRet:
-							print beautifier.beautify(ret[1], __socket)
+							print beautifier.beautify(str(ret[1]), __socket)
 					else:
 						logSys.debug("NOK: " + `ret[0].args`)
 						print beautifier.beautifyError(ret[0])
 						return False
 				except socket.error:
-					if showRet:
-						logSys.error(__socket + " Unable to contact server. Is it running?")
-					return False
+						logSys.error("Unable to contact server "+__socket+" Is it running?")
+						self._cmdSendSuccess = False
+						continue
 				except Exception, e:
-					if showRet:
-						logSys.error(str(e))
-					return False
-		return True
+						logSys.error("Error while processing command" + str(c) + " : " + str(e))
+						self._cmdSendSuccess = False
+						continue
+
+		# not necessarily true. maybe one server in a list failed?
+		#return True
 
 	##
 	# Process a command line.
@@ -191,7 +196,7 @@ class Fail2banClient:
 	# @param cmd the command line
 
 	def __processCommand(self, cmd):
-		if len(cmd) == 1 and cmd[0] == "start" and self.__conf["startserver"] == True:
+		if len(cmd) == 1 and cmd[0] == "start":
 			if self.__ping():
 				logSys.error("Server already running")
 				return False
@@ -201,28 +206,33 @@ class Fail2banClient:
 				# Do not continue if configuration is not 100% valid
 				if not ret:
 					return False
+
 				# Start the server
-				self.__startServerAsync(self.__conf["socket"], self.__conf["force"])
-				try:
-					# Wait for the server to start
-					self.__waitOnServer()
-					# Configure the server
-					self.__processCmd(self.__stream, False)
-					return True
-				except ServerExecutionException:
-					logSys.info("Could not start server." +
-							"\n\t" +
-							"Maybe an old socket file is still present." +
-							" Try to remove socket" +
-							"\n\t" +
-							"(If you used fail2ban-client to start the " +
-							"server, adding the -x option will do it)" +
-							"\n\t" +
-							"Maybe network connection to the server(s) is broken " +
-							"or server not running")
-					return False
-		elif self.__conf["startserver"] == False:
-			logSys.info("Not starting server (because of configuration or command line option)")
+				if self.__conf["startserver"] == True:
+
+					self.__startServerAsync(self.__conf["socket"], self.__conf["force"])
+					try:
+						# Wait for the server to start
+						self.__waitOnServer()
+					
+						# Configure the server
+						self.__processCmd(self.__stream, False)
+						return True
+					except ServerExecutionException:
+						logSys.info("Could not start server." +
+								"\n\t" +
+								"Maybe an old socket file is still present." +
+								" Try to remove socket" +
+								"\n\t" +
+								"(If you used fail2ban-client to start the " +
+								"server, adding the -x option will do it)" +
+								"\n\t" +
+								"Maybe network connection to the server(s) is broken " +
+								"or server not running")
+						return False
+				else:
+					logSys.info("Not starting server (because of configuration or command line option)")
+
 		elif len(cmd) == 1 and cmd[0] == "reload":
 			if self.__ping():
 				ret = self.__readConfig()

--- a/fail2ban-client
+++ b/fail2ban-client
@@ -64,7 +64,6 @@ class Fail2banClient:
 		self.__conf["force"] = False
 		self.__conf["verbose"] = 1
 		self.__conf["interactive"] = False
-		self.__conf["sockettype"] = "socket"
 		self.__conf["socket"] = None
 		self.__conf["startserver"] = True
 
@@ -88,7 +87,6 @@ class Fail2banClient:
 		print
 		print "Options:"
 		print "    -c <DIR>                configuration directory"
-		print "    -t                      socket type (network or socket)"
 		print "    -s <FILE|IP:PORT>       socket path"
 		print "    -d                      dump configuration. For debugging"
 		print "    -i                      interactive mode"
@@ -126,8 +124,6 @@ class Fail2banClient:
 				self.__conf["conf"] = opt[1]
 			elif opt[0] == "-s":
 				self.__conf["socket"] = opt[1]
-			elif opt[0] == "-t":
-				self.__conf["sockettype"] = opt[1]
 			elif opt[0] == "-d":
 				self.__conf["dump"] = True
 			elif opt[0] == "-v":
@@ -154,25 +150,38 @@ class Fail2banClient:
 		beautifier = Beautifier()
 		for c in cmd:
 			beautifier.setInputCmd(c)
-			try:
-				client = clientCommunicator(self.__conf["socket"], self.__conf["sockettype"])
-				ret = client.send(c)
-				if ret[0] == 0:
-					logSys.debug("OK : " + `ret[1]`)
+
+			__socketlist = self.__conf["socket"]
+
+			# split multiple socket definitions (delimiters: space and coma)
+			# and remove empty strings from list
+			__socketlist = re.split(' |,',__socketlist)
+			__socketlist = filter(None, __socketlist)
+
+			# iterate through all servers
+			for __socket in __socketlist:
+				try:
+					client = clientCommunicator(__socket)
+
+					# get server address and it's response
+					ret = client.send(c)
+
+					if ret[0] == 0:
+						logSys.debug("OK : " + `ret[0]`)
+						if showRet:
+							print beautifier.beautify(ret[1], __socket)
+					else:
+						logSys.debug("NOK: " + `ret[0].args`)
+						print beautifier.beautifyError(ret[0])
+						return False
+				except socket.error:
 					if showRet:
-						print beautifier.beautify(ret[1])
-				else:
-					logSys.debug("NOK: " + `ret[1].args`)
-					print beautifier.beautifyError(ret[1])
+						logSys.error(__socket + " Unable to contact server. Is it running?")
 					return False
-			except socket.error:
-				if showRet:
-					logSys.error("Unable to contact server. Is it running?")
-				return False
-			except Exception, e:
-				if showRet:
-					logSys.error(str(e))
-				return False
+				except Exception, e:
+					if showRet:
+						logSys.error(str(e))
+					return False
 		return True
 
 	##
@@ -182,7 +191,7 @@ class Fail2banClient:
 	# @param cmd the command line
 
 	def __processCommand(self, cmd):
-		if len(cmd) == 1 and cmd[0] == "start" and self.__conf["startserver"]:
+		if len(cmd) == 1 and cmd[0] == "start" and self.__conf["startserver"] == True:
 			if self.__ping():
 				logSys.error("Server already running")
 				return False
@@ -193,7 +202,7 @@ class Fail2banClient:
 				if not ret:
 					return False
 				# Start the server
-				self.__startServerAsync(self.__conf["socket"], self.__conf["sockettype"], self.__conf["force"])
+				self.__startServerAsync(self.__conf["socket"], self.__conf["force"])
 				try:
 					# Wait for the server to start
 					self.__waitOnServer()
@@ -201,17 +210,16 @@ class Fail2banClient:
 					self.__processCmd(self.__stream, False)
 					return True
 				except ServerExecutionException:
-					if self.__conf["sockettype"] == "socket":
-						logSys.error("Could not start server. Maybe an old " +
-									"socket file is still present. Try to " +
-									"remove " + self.__conf["socket"] + ". If " +
-									"you used fail2ban-client to start the " +
-									"server, adding the -x option will do it")
-					else:
-						logSys.error("Could not start server. Maybe network connection " +
-									"to the server(s) is broken " +
-									"or server not running: " +
-									self.__conf["socket"])
+					logSys.info("Could not start server." +
+							"\n\t" +
+							"Maybe an old socket file is still present." +
+							" Try to remove socket" +
+							"\n\t" +
+							"(If you used fail2ban-client to start the " +
+							"server, adding the -x option will do it)" +
+							"\n\t" +
+							"Maybe network connection to the server(s) is broken " +
+							"or server not running")
 					return False
 		elif self.__conf["startserver"] == False:
 			logSys.info("Not starting server (because of configuration or command line option)")
@@ -249,7 +257,7 @@ class Fail2banClient:
 	#
 	# Start the Fail2ban server in daemon mode.
 
-	def __startServerAsync(self, socket, sockettype, force = False):
+	def __startServerAsync(self, socket, force = False):
 		# Forks the current process.
 		pid = os.fork()
 		if pid == 0:
@@ -257,11 +265,9 @@ class Fail2banClient:
 			print self.SERVER
 			args.append(self.SERVER)
 			# Start in background mode.
-			args.append("-b")
+			#args.append("-b")
 			# Set socket type
-			args.append("-t")
-			args.append(sockettype)
-			# Set the socket path.
+			# Set the socket path or address.
 			args.append("-s")
 			args.append(socket)
 			# Force the execution if needed.
@@ -320,7 +326,7 @@ class Fail2banClient:
 
 		# Reads the command line options.
 		try:
-			cmdOpts = 'hc:t:s:xdviqV'
+			cmdOpts = 'hc:s:xdviqV'
 			cmdLongOpts = ['help', 'version', "dontstartserver"]
 			optList, args = getopt.getopt(self.__argv[1:], cmdOpts, cmdLongOpts)
 		except getopt.GetoptError:
@@ -352,23 +358,9 @@ class Fail2banClient:
 		self.__configurator.readEarly()
 		self.earlyOptions = self.__configurator.getEarlyOptions()
 
-		# Set socket type (network/INET or socket/UNIX)
-		self.__conf["sockettype"] = self.earlyOptions["sockettype"]
-		logSys.info("Socket type: " + self.__conf["sockettype"])
-
-		# Set socket path
+		# Get socket path or network address of server
 		if self.__conf["socket"] == None:
 			self.__conf["socket"] = self.earlyOptions["socket"]
-
-		# Output some info
-		if self.__conf["sockettype"] == "socket":
-			logSys.info("Using socket file: " + self.__conf["socket"])
-		elif self.__conf["sockettype"] == "network":
-			logSys.info("Server(s): " + self.__conf["socket"])
-		else:
-			logSys.error("Socket type invalid: "+ self.__conf["sockettype"] +
-					" (Typing error? Use socket or network)")
-			return
 
 		if self.__conf["dump"]:
 			ret = self.__readConfig()
@@ -405,6 +397,7 @@ class Fail2banClient:
 				self.dispUsage()
 				return False
 			return self.__processCommand(args)
+
 
 	def __readConfig(self):
 		# Read the configuration

--- a/fail2ban-server
+++ b/fail2ban-server
@@ -19,7 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 # $Revision$
 
 __author__ = "Cyril Jaquier"
@@ -49,15 +49,16 @@ logSys = logging.getLogger("fail2ban")
 # Its first goal was to protect a SSH server.
 
 class Fail2banServer:
-	
+
 	def __init__(self):
 		self.__server = None
 		self.__argv = None
 		self.__conf = dict()
 		self.__conf["background"] = True
 		self.__conf["force"] = False
+		self.__conf["sockettype"] = "socket"
 		self.__conf["socket"] = "/var/run/fail2ban/fail2ban.sock"
-	
+
 	def dispVersion(self):
 		print "Fail2Ban v" + version
 		print
@@ -67,7 +68,7 @@ class Fail2banServer:
 		print
 		print "Written by Cyril Jaquier <cyril.jaquier@fail2ban.org>."
 		print "Many contributions by Yaroslav O. Halchenko <debian@onerussian.com>."
-	
+
 	def dispUsage(self):
 		""" Prints Fail2Ban command line options and exits
 		"""
@@ -83,13 +84,14 @@ class Fail2banServer:
 		print "Options:"
 		print "    -b                   start in background"
 		print "    -f                   start in foreground"
-		print "    -s <FILE>            socket path"
+		print "    -t                   socket type"
+		print "    -s <FILE|IP:PORT>    socket path or server ip address and port"
 		print "    -x                   force execution of the server (remove socket file)"
 		print "    -h, --help           display this help message"
 		print "    -V, --version        print the version"
 		print
 		print "Report bugs to <cyril.jaquier@fail2ban.org>"
-	
+
 	def __getCmdLineOptions(self, optList):
 		""" Gets the command line options
 		"""
@@ -98,41 +100,42 @@ class Fail2banServer:
 				self.__conf["background"] = True
 			if opt[0] == "-f":
 				self.__conf["background"] = False
+			if opt[0] == "-t":
+				self.__conf["sockettype"] = opt[1]
 			if opt[0] == "-s":
 				self.__conf["socket"] = opt[1]
 			if opt[0] == "-x":
 				self.__conf["force"] = True
 			if opt[0] in ["-h", "--help"]:
-	 			self.dispUsage()
+				self.dispUsage()
 				sys.exit(0)
 			if opt[0] in ["-V", "--version"]:
-	 			self.dispVersion()
+				self.dispVersion()
 				sys.exit(0)
-		
+
 	def start(self, argv):
 		# Command line options
 		self.__argv = argv
-		
 		# Reads the command line options.
 		try:
-			cmdOpts = 'bfs:xhV'
+			cmdOpts = 'bft:s:xhV'
 			cmdLongOpts = ['help', 'version']
 			optList, args = getopt.getopt(self.__argv[1:], cmdOpts, cmdLongOpts)
 		except getopt.GetoptError:
 			self.dispUsage()
 			sys.exit(-1)
-			
+
 		self.__getCmdLineOptions(optList)
-		
+
 		try:
 			self.__server = Server(self.__conf["background"])
-			self.__server.start(self.__conf["socket"], self.__conf["force"])
+			self.__server.start(self.__conf["socket"], self.__conf["sockettype"], self.__conf["force"])
 			return True
 		except Exception, e:
 			logSys.exception(e)
 			self.__server.quit()
 			return False
-		
+
 if __name__ == "__main__":
 	server = Fail2banServer()
 	if server.start(sys.argv):

--- a/fail2ban-server
+++ b/fail2ban-server
@@ -28,7 +28,7 @@ __date__ = "$Date$"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
 __license__ = "GPL"
 
-import getopt, sys, logging
+import getopt, sys, logging, ipaddr
 
 # Inserts our own modules path first in the list
 # fix for bug #343821
@@ -84,7 +84,6 @@ class Fail2banServer:
 		print "Options:"
 		print "    -b                   start in background"
 		print "    -f                   start in foreground"
-		print "    -t                   socket type"
 		print "    -s <FILE|IP:PORT>    socket path or server ip address and port"
 		print "    -x                   force execution of the server (remove socket file)"
 		print "    -h, --help           display this help message"
@@ -100,8 +99,6 @@ class Fail2banServer:
 				self.__conf["background"] = True
 			if opt[0] == "-f":
 				self.__conf["background"] = False
-			if opt[0] == "-t":
-				self.__conf["sockettype"] = opt[1]
 			if opt[0] == "-s":
 				self.__conf["socket"] = opt[1]
 			if opt[0] == "-x":
@@ -118,7 +115,7 @@ class Fail2banServer:
 		self.__argv = argv
 		# Reads the command line options.
 		try:
-			cmdOpts = 'bft:s:xhV'
+			cmdOpts = 'bfs:xhV'
 			cmdLongOpts = ['help', 'version']
 			optList, args = getopt.getopt(self.__argv[1:], cmdOpts, cmdLongOpts)
 		except getopt.GetoptError:
@@ -129,12 +126,41 @@ class Fail2banServer:
 
 		try:
 			self.__server = Server(self.__conf["background"])
-			self.__server.start(self.__conf["socket"], self.__conf["sockettype"], self.__conf["force"])
+			self.__server.start(self.__conf["socket"], self.__conf["force"])
 			return True
 		except Exception, e:
 			logSys.exception(e)
 			self.__server.quit()
 			return False
+
+
+	# Try to determine socket type (network/AF_INET or local/AF_UNIX)
+	# and set socket type in configuration
+	def __determineAndSetSocketType(self, socket):
+		__socket = socket
+
+		# the port will be anything after the last :
+		tempVarA = __socket.rfind(":")
+
+		# ipv6 literals should have a closing brace
+		tempVarB = __socket.rfind("]")
+
+		# if the last : is outside the [addr] part (or if we don't have []'s
+		if (tempVarA > tempVarB):
+			__socket = __socket[:tempVarA]
+
+		# now strip off ipv6 []'s if there are any
+		if __socket and __socket[0] == '[' and __socket[-1] == ']':
+			__socket = __socket[1:-1]
+
+		try:
+			ipaddr.IPAddress(__socket)
+			logSys.debug(__socket + " looks like IP address")
+			self.__conf["sockettype"] = "network"
+		except ValueError:
+			logSys.debug(__socket + " does not look like IP address")
+			self.__conf["sockettype"] = "socket"
+
 
 if __name__ == "__main__":
 	server = Fail2banServer()

--- a/server/asyncserver.py
+++ b/server/asyncserver.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 # $Revision$
 
 __author__ = "Cyril Jaquier"
@@ -29,7 +29,7 @@ __license__ = "GPL"
 
 from pickle import dumps, loads, HIGHEST_PROTOCOL
 from common import helpers
-import asyncore, asynchat, socket, os, logging, sys, traceback
+import asyncore, asynchat, socket, os, logging, sys, traceback, ipaddr
 
 # Gets the instance of the logger.
 logSys = logging.getLogger("fail2ban.server")
@@ -41,7 +41,7 @@ logSys = logging.getLogger("fail2ban.server")
 # incoming query.
 
 class RequestHandler(asynchat.async_chat):
-	
+
 	END_STRING = "<F2B_END_COMMAND>"
 
 	def __init__(self, conn, transmitter):
@@ -71,13 +71,13 @@ class RequestHandler(asynchat.async_chat):
 		self.send(message + RequestHandler.END_STRING)
 		# Closes the channel.
 		self.close_when_done()
-		
+
 	def handle_error(self):
 		e1,e2 = helpers.formatExceptionInfo()
 		logSys.error("Unexpected communication error: "+e2)
 		logSys.error(traceback.format_exc().splitlines())
 		self.close()
-		
+
 ##
 # Asynchronous server class.
 #
@@ -89,6 +89,7 @@ class AsyncServer(asyncore.dispatcher):
 	def __init__(self, transmitter):
 		asyncore.dispatcher.__init__(self)
 		self.__transmitter = transmitter
+		self.__sockettype = "socket"
 		self.__sock = "/var/run/fail2ban/fail2ban.sock"
 		self.__init = False
 
@@ -101,6 +102,15 @@ class AsyncServer(asyncore.dispatcher):
 	def handle_accept(self):
 		try:
 			conn, addr = self.accept()
+			if self.__sockettype == "network":
+				__client_ip = addr[0] # get IP part from addr
+				__client_ip = ipaddr.IPAddress(__client_ip)
+				__allowedclients = ('127.0.0.1/24', '195.25.2.5/8')
+				for __allowedclient in __allowedclients:
+					if __client_ip not in ipaddr.IP(__allowedclient):
+						logSys.info("Client" + str(__client_ip) +
+							" not in allowed clients list. Ignoring")
+						return
 		except socket.error:
 			logSys.warning("Socket error")
 			return
@@ -110,54 +120,85 @@ class AsyncServer(asyncore.dispatcher):
 		# Creates an instance of the handler class to handle the
 		# request/response on the incoming connection.
 		RequestHandler(conn, self.__transmitter)
-	
+
 	##
 	# Starts the communication server.
 	#
 	# @param sock: socket file.
 	# @param force: remove the socket file if exists.
-	
-	def start(self, sock, force):
-		self.__sock = sock
-		# Remove socket
-		if os.path.exists(sock):
-			logSys.error("Fail2ban seems to be already running")
-			if force:
-				logSys.warn("Forcing execution of the server")
-				os.remove(sock)
-			else:
-				raise AsyncServerException("Server already running")
-		# Creates the socket.
-		self.create_socket(socket.AF_UNIX, socket.SOCK_STREAM)
-		self.set_reuse_addr()
-		try:
-			self.bind(sock)
-		except Exception:
-			raise AsyncServerException("Unable to bind socket %s" % self.__sock)
-		self.listen(1)
-		# Sets the init flag.
-		self.__init = True
+
+	def start(self, sock, sockettype, force):
+		# sockType: network (AF_INET) or socket (AF_UNIX)
+		self.__sockettype = sockettype
+		if self.__sockettype == "socket":
+			# Connect to local domain (unix) socket
+			self.socketpath = sock
+			# Remove socket
+			if os.path.exists(self.socketpath):
+				logSys.error("Fail2ban seems to be already running")
+				if force:
+					logSys.warn("Forcing execution of the server")
+					os.remove(self.socketpath)
+				else:
+					raise AsyncServerException("Server already running")
+
+			# Creates the socket.
+			self.create_socket(socket.AF_UNIX, socket.SOCK_STREAM)
+			self.set_reuse_addr()
+			try:
+				self.bind(self.socketpath)
+			except Exception:
+				raise AsyncServerException("Unable to bind socket %s" % self.socketpath)
+			self.listen(1)
+			# Sets the init flag.
+			self.__init = True
+		elif self.__sockettype == "network":
+			# Create an INET, STREAMing socket
+			self.serveraddress = sock
+			print self.serveraddress
+
+			HOST, PORT = self.serveraddress.split(':')
+			PORT = int(PORT)
+
+			# Creates the socket.
+			self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
+			self.set_reuse_addr()
+			try:
+				self.bind((HOST, PORT))
+			except socket.error, e:
+				logSys.error(e)
+
+			self.listen(1)
+			# Sets the init flag.
+			self.__init = True
+		else:
+			logSys.error("Connection type invalid:" + self.__sockettype)
+
 		# TODO Add try..catch
-		# There's a bug report for Python 2.6/3.0 that use_poll=True yields some 2.5 incompatibilities:
-		if sys.version_info >= (2, 6): # if python 2.6 or greater...
-			logSys.debug("Detected Python 2.6 or greater. asyncore.loop() not using poll")
-			asyncore.loop(use_poll = False) # fixes the "Unexpected communication problem" issue on Python 2.6 and 3.0
+		# There's a bug report for Python 2.6/3.0
+		# that use_poll=True yields some 2.5 incompatibilities:
+		if sys.version_info >= (2, 6):  # if python 2.6 or greater...
+			logSys.debug("Detected Python 2.6 or greater. " +
+						"asyncore.loop() not using poll")
+			# fixes the "Unexpected communication problem" issue on Python 2.6 and 3.0
+			asyncore.loop(use_poll=False)
 		else:
 			logSys.debug("NOT Python 2.6/3.* - asyncore.loop() using poll")
-			asyncore.loop(use_poll = True)
-	
+			asyncore.loop(use_poll=True)
+
 	##
 	# Stops the communication server.
-	
+
 	def stop(self):
 		if self.__init:
 			# Only closes the socket if it was initialized first.
 			self.close()
-		# Remove socket
-		if os.path.exists(self.__sock):
-			logSys.debug("Removed socket file " + self.__sock)
-			os.remove(self.__sock)
-		logSys.debug("Socket shutdown")
+		if self.__sockettype == "socket":
+			# Remove socket
+			if os.path.exists(self.__sock):
+				logSys.debug("Removed socket file " + self.__sock)
+				os.remove(self.__sock)
+			logSys.debug("Socket shutdown")
 
 
 ##

--- a/server/server.py
+++ b/server/server.py
@@ -59,7 +59,7 @@ class Server:
 		logSys.debug("Caught signal %d. Exiting" % signum)
 		self.quit()
 
-	def start(self, sock, sockettype, force=False):
+	def start(self, sock, force=False):
 		logSys.info("Starting Fail2ban v" + version.version)
 
 		# Install signal handlers
@@ -89,7 +89,7 @@ class Server:
 		# Start the communication
 		logSys.debug("Starting communication")
 		try:
-			self.__asyncServer.start(sock, sockettype, force)
+			self.__asyncServer.start(sock, force)
 		except AsyncServerException, e:
 			logSys.error("Could not start server: %s", e)
 		# Removes the PID file.

--- a/server/server.py
+++ b/server/server.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 # $Revision$
 
 __author__ = "Cyril Jaquier"
@@ -39,7 +39,7 @@ import logging, logging.handlers, sys, os, signal
 logSys = logging.getLogger("fail2ban.server")
 
 class Server:
-	
+
 	PID_FILE = "/var/run/fail2ban/fail2ban.pid"
 
 	def __init__(self, daemon = False):
@@ -54,18 +54,18 @@ class Server:
 		# Set logging level
 		self.setLogLevel(3)
 		self.setLogTarget("STDOUT")
-	
+
 	def __sigTERMhandler(self, signum, frame):
 		logSys.debug("Caught signal %d. Exiting" % signum)
 		self.quit()
-	
-	def start(self, sock, force = False):
+
+	def start(self, sock, sockettype, force=False):
 		logSys.info("Starting Fail2ban v" + version.version)
-		
+
 		# Install signal handlers
 		signal.signal(signal.SIGTERM, self.__sigTERMhandler)
 		signal.signal(signal.SIGINT, self.__sigTERMhandler)
-		
+
 		# First set the mask to only allow access to owner
 		os.umask(0077)
 		if self.__daemon:
@@ -76,7 +76,7 @@ class Server:
 			else:
 				logSys.error("Could not create daemon")
 				raise ServerInitializationError("Could not create daemon")
-		
+
 		# Creates a PID file.
 		try:
 			logSys.debug("Creating PID file %s" % Server.PID_FILE)
@@ -85,11 +85,11 @@ class Server:
 			pidFile.close()
 		except IOError, e:
 			logSys.error("Unable to create PID file: %s" % e)
-		
+
 		# Start the communication
 		logSys.debug("Starting communication")
 		try:
-			self.__asyncServer.start(sock, force)
+			self.__asyncServer.start(sock, sockettype, force)
 		except AsyncServerException, e:
 			logSys.error("Could not start server: %s", e)
 		# Removes the PID file.
@@ -105,7 +105,7 @@ class Server:
 			logging.shutdown()
 		finally:
 			self.__loggingLock.release()
-	
+
 	def quit(self):
 		# Stop communication first because if jail's unban action
 		# tries to communicate via fail2ban-client we get a lockup
@@ -116,13 +116,13 @@ class Server:
 		self.__asyncServer.stop()
 		# Now stop all the jails
 		self.stopAllJail()
-	
+
 	def addJail(self, name, backend):
 		self.__jails.add(name, backend)
-		
+
 	def delJail(self, name):
 		self.__jails.remove(name)
-	
+
 	def startJail(self, name):
 		try:
 			self.__lock.acquire()
@@ -130,7 +130,7 @@ class Server:
 				self.__jails.get(name).start()
 		finally:
 			self.__lock.release()
-	
+
 	def stopJail(self, name):
 		logSys.debug("Stopping jail %s" % name)
 		try:
@@ -140,7 +140,7 @@ class Server:
 				self.delJail(name)
 		finally:
 			self.__lock.release()
-	
+
 	def stopAllJail(self):
 		logSys.info("Stopping all jails")
 		try:
@@ -149,131 +149,131 @@ class Server:
 				self.stopJail(jail)
 		finally:
 			self.__lock.release()
-	
+
 	def isAlive(self, name):
 		return self.__jails.get(name).isAlive()
-	
+
 	def setIdleJail(self, name, value):
 		self.__jails.get(name).setIdle(value)
 		return True
 
 	def getIdleJail(self, name):
 		return self.__jails.get(name).getIdle()
-	
+
 	# Filter
 	def addIgnoreIP(self, name, ip):
 		self.__jails.getFilter(name).addIgnoreIP(ip)
-	
+
 	def delIgnoreIP(self, name, ip):
 		self.__jails.getFilter(name).delIgnoreIP(ip)
-	
+
 	def getIgnoreIP(self, name):
 		return self.__jails.getFilter(name).getIgnoreIP()
-	
+
 	def addLogPath(self, name, fileName):
 		self.__jails.getFilter(name).addLogPath(fileName)
-	
+
 	def delLogPath(self, name, fileName):
 		self.__jails.getFilter(name).delLogPath(fileName)
-	
+
 	def getLogPath(self, name):
 		return [m.getFileName()
 				for m in self.__jails.getFilter(name).getLogPath()]
-	
+
 	def setFindTime(self, name, value):
 		self.__jails.getFilter(name).setFindTime(value)
-	
+
 	def getFindTime(self, name):
 		return self.__jails.getFilter(name).getFindTime()
 
 	def addFailRegex(self, name, value):
 		self.__jails.getFilter(name).addFailRegex(value)
-	
+
 	def delFailRegex(self, name, index):
 		self.__jails.getFilter(name).delFailRegex(index)
-	
+
 	def getFailRegex(self, name):
 		return self.__jails.getFilter(name).getFailRegex()
-	
+
 	def addIgnoreRegex(self, name, value):
 		self.__jails.getFilter(name).addIgnoreRegex(value)
-	
+
 	def delIgnoreRegex(self, name, index):
 		self.__jails.getFilter(name).delIgnoreRegex(index)
-	
+
 	def getIgnoreRegex(self, name):
 		return self.__jails.getFilter(name).getIgnoreRegex()
-	
+
 	def setUseDns(self, name, value):
 		self.__jails.getFilter(name).setUseDns(value)
-	
+
 	def getUseDns(self, name):
 		return self.__jails.getFilter(name).getUseDns()
-	
+
 	def setMaxRetry(self, name, value):
 		self.__jails.getFilter(name).setMaxRetry(value)
-	
+
 	def getMaxRetry(self, name):
 		return self.__jails.getFilter(name).getMaxRetry()
-	
+
 	# Action
 	def addAction(self, name, value):
 		self.__jails.getAction(name).addAction(value)
-	
+
 	def getLastAction(self, name):
 		return self.__jails.getAction(name).getLastAction()
-	
+
 	def delAction(self, name, value):
 		self.__jails.getAction(name).delAction(value)
-	
+
 	def setCInfo(self, name, action, key, value):
 		self.__jails.getAction(name).getAction(action).setCInfo(key, value)
-	
+
 	def getCInfo(self, name, action, key):
 		return self.__jails.getAction(name).getAction(action).getCInfo(key)
-	
+
 	def delCInfo(self, name, action, key):
 		self.__jails.getAction(name).getAction(action).delCInfo(key)
-	
+
 	def setBanTime(self, name, value):
 		self.__jails.getAction(name).setBanTime(value)
-	
+
 	def setBanIP(self, name, value):
 		return self.__jails.getFilter(name).addBannedIP(value)
-		
+
 	def getBanTime(self, name):
 		return self.__jails.getAction(name).getBanTime()
-	
+
 	def setActionStart(self, name, action, value):
 		self.__jails.getAction(name).getAction(action).setActionStart(value)
-	
+
 	def getActionStart(self, name, action):
 		return self.__jails.getAction(name).getAction(action).getActionStart()
-		
+
 	def setActionStop(self, name, action, value):
 		self.__jails.getAction(name).getAction(action).setActionStop(value)
-	
+
 	def getActionStop(self, name, action):
 		return self.__jails.getAction(name).getAction(action).getActionStop()
-	
+
 	def setActionCheck(self, name, action, value):
 		self.__jails.getAction(name).getAction(action).setActionCheck(value)
-	
+
 	def getActionCheck(self, name, action):
 		return self.__jails.getAction(name).getAction(action).getActionCheck()
-	
+
 	def setActionBan(self, name, action, value):
 		self.__jails.getAction(name).getAction(action).setActionBan(value)
-	
+
 	def getActionBan(self, name, action):
 		return self.__jails.getAction(name).getAction(action).getActionBan()
-	
+
 	def setActionUnban(self, name, action, value):
 		self.__jails.getAction(name).getAction(action).setActionUnban(value)
-	
+
 	def getActionUnban(self, name, action):
 		return self.__jails.getAction(name).getAction(action).getActionUnban()
-		
+
 	# Status
 	def status(self):
 		try:
@@ -284,17 +284,17 @@ class Server:
 			length = len(jailList)
 			if not length == 0:
 				jailList = jailList[:length-2]
-			ret = [("Number of jail", self.__jails.size()), 
+			ret = [("Number of jail", self.__jails.size()),
 				   ("Jail list", jailList)]
 			return ret
 		finally:
 			self.__lock.release()
-	
+
 	def statusJail(self, name):
 		return self.__jails.get(name).getStatus()
-	
+
 	# Logging
-	
+
 	##
 	# Set the logging level.
 	#
@@ -305,7 +305,7 @@ class Server:
 	# 3 = INFO
 	# 4 = DEBUG
 	# @param value the level
-	
+
 	def setLogLevel(self, value):
 		try:
 			self.__loggingLock.acquire()
@@ -322,26 +322,26 @@ class Server:
 			logging.getLogger("fail2ban").setLevel(logLevel)
 		finally:
 			self.__loggingLock.release()
-	
+
 	##
 	# Get the logging level.
 	#
 	# @see setLogLevel
 	# @return the log level
-	
+
 	def getLogLevel(self):
 		try:
 			self.__loggingLock.acquire()
 			return self.__logLevel
 		finally:
 			self.__loggingLock.release()
-	
+
 	##
 	# Sets the logging target.
 	#
 	# target can be a file, SYSLOG, STDOUT or STDERR.
 	# @param target the logging target
-	
+
 	def setLogTarget(self, target):
 		try:
 			self.__loggingLock.acquire()
@@ -351,7 +351,7 @@ class Server:
 				# Syslog daemons already add date to the message.
 				formatter = logging.Formatter("%(name)-16s: %(levelname)-6s %(message)s")
 				facility = logging.handlers.SysLogHandler.LOG_DAEMON
-				hdlr = logging.handlers.SysLogHandler("/dev/log", 
+				hdlr = logging.handlers.SysLogHandler("/dev/log",
 													  facility = facility)
 			elif target == "STDOUT":
 				hdlr = logging.StreamHandler(sys.stdout)
@@ -383,21 +383,20 @@ class Server:
 			return True
 		finally:
 			self.__loggingLock.release()
-	
+
 	def getLogTarget(self):
 		try:
 			self.__loggingLock.acquire()
 			return self.__logTarget
 		finally:
 			self.__loggingLock.release()
-	
+
 	def __createDaemon(self):
 		""" Detach a process from the controlling terminal and run it in the
 			background as a daemon.
-		
+
 			http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/278731
 		"""
-	
 		try:
 			# Fork a child process so the parent can exit.  This will return control
 			# to the command line or shell.  This is required so that the new process
@@ -408,9 +407,9 @@ class Server:
 			pid = os.fork()
 		except OSError, e:
 			return((e.errno, e.strerror))	 # ERROR (return a tuple)
-		
+
 		if pid == 0:	   # The first child.
-	
+
 			# Next we call os.setsid() to become the session leader of this new
 			# session.  The process also becomes the process group leader of the
 			# new process group.  Since a controlling terminal is associated with a
@@ -419,11 +418,11 @@ class Server:
 			# fail, since we're guaranteed that the child is not a process group
 			# leader.
 			os.setsid()
-		
+
 			# When the first child terminates, all processes in the second child
 			# are sent a SIGHUP, so it's ignored.
 			signal.signal(signal.SIGHUP, signal.SIG_IGN)
-		
+
 			try:
 				# Fork a second child to prevent zombies.  Since the first child is
 				# a session leader without a controlling terminal, it's possible for
@@ -433,7 +432,7 @@ class Server:
 				pid = os.fork()		# Fork a second child.
 			except OSError, e:
 				return((e.errno, e.strerror))  # ERROR (return a tuple)
-		
+
 			if (pid == 0):	  # The second child.
 				# Ensure that the daemon doesn't keep any directory in use.  Failure
 				# to do this could make a filesystem unmountable.
@@ -442,7 +441,7 @@ class Server:
 				os._exit(0)	  # Exit parent (the first child) of the second child.
 		else:
 			os._exit(0)		 # Exit parent of the first child.
-		
+
 		# Close all open files.  Try the system configuration variable, SC_OPEN_MAX,
 		# for the maximum number of open files to close.  If it doesn't exist, use
 		# the default value (configurable).
@@ -450,13 +449,13 @@ class Server:
 			maxfd = os.sysconf("SC_OPEN_MAX")
 		except (AttributeError, ValueError):
 			maxfd = 256	   # default maximum
-	
-		for fd in range(0, maxfd):
+
+		for fd in range(3, maxfd):
 			try:
 				os.close(fd)
-			except OSError:   # ERROR (ignore)
+			except (OSError, ValueError):   # ERROR (ignore)
 				pass
-	
+
 		# Redirect the standard file descriptors to /dev/null.
 		os.open("/dev/null", os.O_RDONLY)	# standard input (0)
 		os.open("/dev/null", os.O_RDWR)		# standard output (1)

--- a/server/transmitter.py
+++ b/server/transmitter.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 # $Revision$
 
 __author__ = "Cyril Jaquier"
@@ -33,21 +33,21 @@ import logging, time
 logSys = logging.getLogger("fail2ban.comm")
 
 class Transmitter:
-	
+
 	##
 	# Constructor.
 	#
 	# @param The server reference
-	
+
 	def __init__(self, server):
 		self.__server = server
-		
+
 	##
 	# Proceeds a command.
 	#
 	# Proceeds an incoming command.
 	# @param command The incoming command
-	
+
 	def proceed(self, command):
 		# Deserialize object
 		logSys.debug("Command: " + `command`)
@@ -58,12 +58,12 @@ class Transmitter:
 			logSys.warn("Invalid command: " + `command`)
 			ack = 1, e
 		return ack
-	
+
 	##
 	# Handle an command.
 	#
-	# 
-	
+	#
+
 	def __commandHandler(self, command):
 		if command[0] == "ping":
 			return "pong"
@@ -99,9 +99,9 @@ class Transmitter:
 		elif command[0] == "get":
 			return self.__commandGet(command[1:])
 		elif command[0] == "status":
-			return self.status(command[1:])			
+			return self.status(command[1:])
 		raise Exception("Invalid command")
-	
+
 	def __commandSet(self, command):
 		name = command[0]
 		# Logging
@@ -218,7 +218,7 @@ class Transmitter:
 			self.__server.setActionUnban(name, act, value)
 			return self.__server.getActionUnban(name, act)
 		raise Exception("Invalid command (no set action or not yet implemented)")
-	
+
 	def __commandGet(self, command):
 		name = command[0]
 		# Logging
@@ -262,7 +262,7 @@ class Transmitter:
 			act = command[2]
 			return self.__server.getActionUnban(name, act)
 		raise Exception("Invalid command (no get action or not yet implemented)")
-	
+
 	def status(self, command):
 		if len(command) == 0:
 			return self.__server.status()
@@ -270,4 +270,4 @@ class Transmitter:
 			name = command[0]
 			return self.__server.statusJail(name)
 		raise Exception("Invalid command (no status)")
-	
+


### PR DESCRIPTION
You can now choose if you want to run fail2ban on local unix socket or network socket. Using of network socket makes it possible to easily pass commands from central syslog server (where client shoud be) to firewall or other machine (where server is), making it possible to stop attackers from scanning your whole server farm.

P.S.
Some minor changes also made, like client receive buffer size which was 6 bits? Maybe a typing error? There should be *at least* 64 bits, otherwise every single command from client to server is split to multiple parts.

TODO:
- make it possible to *properly* send commands from one client to multiple servers
- add some kind of firewall (by IP) at server side (almost done, but I need to rewrite client/server configuration part)
- rewrite client/server configuration part. Client should have separate serverList option. Server should have separate allowedClients option, and be able to configure itself without a client.
~ encrypt traffic?
~ use password to authenticate against server?