### PR TITLE
Fix addBannedIP/banip command

### DIFF
--- a/server/filter.py
+++ b/server/filter.py
@@ -214,7 +214,9 @@ class Filter(JailThread):
 	
 	def addBannedIP(self, ip):
 		unixTime = time.time()
-		self.failManager.addFailure(FailTicket(ip, unixTime))
+		for i in xrange(self.failManager.getMaxRetry()):
+			self.failManager.addFailure(FailTicket(ip, unixTime))
+
 		return ip
 	
 	##


### PR DESCRIPTION
I've patched addBannedIP, called by banip, so that when banip <IP> is called it registers exactly enough failures for that IP to trigger a ban, rather than just adding one failure.
