### PR TITLE
Misconfigured DNS should not ban *successful* ssh logins

### DIFF
--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -32,7 +32,6 @@ failregex = ^%(__prefix_line)s(?:error: PAM: )?Authentication failure for .* fro
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because listed in DenyUsers\s*$
             ^%(__prefix_line)sauthentication failure; logname=\S* uid=\S* euid=\S* tty=\S* ruser=\S* rhost=<HOST>(?:\s+user=.*)?\s*$
             ^%(__prefix_line)srefused connect from \S+ \(<HOST>\)\s*$
-            ^%(__prefix_line)sAddress <HOST> .* POSSIBLE BREAK-IN ATTEMPT!*\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because none of user's groups are listed in AllowGroups\s*$
 
 # Option:  ignoreregex


### PR DESCRIPTION
If you accept the removal of this regex, I'll also go and remove the references to it

http://www.fail2ban.org/wiki/index.php/HOWTO_Mac_OS_X_Server_%2810.5%29
http://www.fail2ban.org/wiki/index.php/HOWTO_Mac_OS_X_Server_%2810.4%29
## 

Noticed while looking at the source (to see the point of ssh-ddos).

POSSIBLE BREAK-IN ATTEMPT - sounds scary?  But keep reading
the message.  It's not a login failure.  It's a warning about
reverse-DNS.  The login can still succeed, and if it _does_ fail,
that will be logged as normal.

<exhibit n="1">
Jul  9 05:43:00 brick sshd[18971]: Address 200.41.233.234 maps to host234.advance.com.
ar, but this does not map back to the address - POSSIBLE BREAK-IN ATTEMPT!
Jul  9 05:43:00 brick sshd[18971]: Invalid user html from 200.41.233.234
</exhibit>
## 

Other instances show neither failure nor success messages.
It is speculated that this represents an aborted probe for a certain type of SSH server
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=588431
(possibly looking for a compromised server.  I think it's more likely
checking for a vulnerable version of SSH).  But SSH doesn't complain about
it, so I don't think it's reasonable to expect fail2ban to catch it.
If it bothers you, try running a full IDS, or improving SSH so it _does_
complain :).
## 

The problem (in my mind) is that some users are stuck with bad dns.
The warning won't stop them from logging in.  I'm pretty sure they can't
even see it.  But when they exceed a threshold number of logins -
which could be all successful logins - fail2ban will trigger.

fail2ban shouldn't adding additional checks to successful logins
- it goes against the name fail2ban :)
- the first X "POSSIBLE BREAK-IN ATTEMPT"s would be permitted anyway
- if you want to ban bad DNS, the right way is PARANOID in /etc/hosts.deny

I've checked the source of OpenSSH, and this will only affect the
reverse-DNS error.  (I won't be offended if you want to check
for yourself though ;)

  <exhibit n="2">
  $ grep -r -h -C1 'ATTEMPT' openssh-5.5p1/
                  logit("reverse mapping checking getaddrinfo for %.700s "
                      "[%s] failed - POSSIBLE BREAK-IN ATTEMPT!", name, ntop);
                  return xstrdup(ntop);
  --
                  logit("Address %.100s maps to %.600s, but this does not "
                      "map back to the address - POSSIBLE BREAK-IN ATTEMPT!",
                      ntop, name);
  $
  </exhibit>
