### PR TITLE
Lighttpd: support auth.backend = "htdigest"

### DIFF
--- a/config/filter.d/lighttpd-auth.conf
+++ b/config/filter.d/lighttpd-auth.conf
@@ -10,7 +10,7 @@
 # Values:  TEXT
 #
 failregex = .*http_auth.*password doesn\'t match.*IP: <HOST>\s*$
-
+            .*http_auth.*wrong password.*IP: <HOST>\s*$
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.

--- a/testcases/files/logs/lighttpd
+++ b/testcases/files/logs/lighttpd
@@ -1,2 +1,3 @@
 #authentification failure (mod_auth)
 2011-12-25 17:09:20: (http_auth.c.875) password doesn't match for /gitweb/ username: francois, IP: 4.4.4.4
+2012-09-26 10:24:35: (http_auth.c.1136) digest: auth failed for  xxx : wrong password, IP: 4.4.4.4


### PR DESCRIPTION
Hi, 

A user sent me a bug report about the filter lighttpd-auth. It appears that the original one does not handle the case for which htdigest backend is enable.
This patch correct that by adding a new regexp + the testcase.

Thank you.
