### PR TITLE
Update config/filter.d/dovecot.conf

### DIFF
--- a/config/filter.d/dovecot.conf
+++ b/config/filter.d/dovecot.conf
@@ -15,7 +15,7 @@
 # Values:  TEXT
 #
 failregex = .*(?:pop3-login|imap-login):.*(?:Authentication failure|Aborted login \(auth failed|Aborted login \(tried to use disabled|Disconnected \(auth failed).*rip=(?P<host>\S*),.*
-            pam.*dovecot.*(?:authentication failure).*rhost=<HOST> 
+            pam.*dovecot.*(?:authentication failure).*rhost=<HOST>(?:\s+user=.*)?\s*$
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.


### PR DESCRIPTION
added failregex line for debian and centos per 
http://www.fail2ban.org/wiki/index.php/Talk:Dovecot
