### PR TITLE
iptables-IPset  actions

### DIFF
--- a/config/action.d/iptables-ipset-proto4.conf
+++ b/config/action.d/iptables-ipset-proto4.conf
@@ -2,8 +2,21 @@
 #
 # Author: Daniel Black
 #
-# Tested against protocol 4 (ipset v4.2)
+# This is for ipset protocol 4 (ipset v4.2). If you have a later version
+# of ipset try to use the iptables-ipset-proto6.conf as it does some things
+# nicer.
+# 
+# This requires the program ipset which is normally in package called ipset.
 #
+# IPset was a feature introduced in the linux kernel 2.6.39 and 3.0.0 kernels.
+#
+# If you are running on an older kernel you make need to patch in external
+# modules.
+#
+# On Debian machines this can be done with:
+#
+# apt-get install ipset xtables-addons-source 
+# module-assistant auto-install xtables-addons
 
 [Definition]
 
@@ -28,7 +41,7 @@ actionstop = iptables -D INPUT -p <protocol> -m multiport --dports <port> -m set
 # Tags:    <ip>  IP address
 # Values:  CMD
 #
-actionban = ipset --test fail2ban-<name> <ip> ||  ipset --add fail2ban-<name> <ip> -exist
+actionban = ipset --test fail2ban-<name> <ip> ||  ipset --add fail2ban-<name> <ip>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -40,7 +53,7 @@ actionunban = ipset --test fail2ban-<name> <ip> && ipset --del fail2ban-<name> <
 
 [Init]
 
-# Defaut name of the chain
+# Defaut name of the ipset
 #
 name = default
 

--- a/config/action.d/iptables-ipset-proto6.conf
+++ b/config/action.d/iptables-ipset-proto6.conf
@@ -2,8 +2,21 @@
 #
 # Author: Daniel Black
 #
-# Tested against protocol 6 (ipset v6.14)
+# This is for ipset protocol 6 (and hopefully later) (ipset v6.14).
+# Use ipset -V to see the protocol and version. Version 4 should use
+# iptables-ipset-proto4.conf.
 #
+# This requires the program ipset which is normally in package called ipset.
+#
+# IPset was a feature introduced in the linux kernel 2.6.39 and 3.0.0 kernels.
+#
+# If you are running on an older kernel you make need to patch in external
+# modules.
+#
+# On Debian machines this can be done with:
+#
+# apt-get install ipset xtables-addons-source 
+# module-assistant auto-install xtables-addons
 
 [Definition]
 
@@ -28,7 +41,7 @@ actionstop = iptables -D INPUT -p <protocol> -m multiport --dports <port> -m set
 # Tags:    <ip>  IP address
 # Values:  CMD
 #
-actionban = ipset add fail2ban-<name> <ip> -exist
+actionban = ipset add fail2ban-<name> <ip> timeout <bantime> -exist
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -40,7 +53,7 @@ actionunban = ipset del fail2ban-<name> <ip> -exist
 
 [Init]
 
-# Defaut name of the chain
+# Defaut name of the ipset
 #
 name = default
 


### PR DESCRIPTION
This creates two actions for use with IPsets. IPsets were introduced in kernels 2.6.39 and 3.0.0 however installation on Debian machines is easy.

IP sets facilitate in kernel rapid hash based lookups of IPs.

protocol4 is used by the older ipset currently in Debian squeeze. Protocol 6 is in Fedora and Debian testing/unstable.
