### PR TITLE
Fix for issue #106

### DIFF
--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -30,7 +30,6 @@ failregex = ^%(__prefix_line)s(?:error: PAM: )?Authentication failure for .* fro
             ^%(__prefix_line)s[iI](?:llegal|nvalid) user .* from <HOST>\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because not listed in AllowUsers\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because listed in DenyUsers\s*$
-            ^%(__prefix_line)s(?:pam_unix\(sshd:auth\):\s)?authentication failure; logname=\S* uid=\S* euid=\S* tty=\S* ruser=\S* rhost=<HOST>(?:\s+user=.*)?\s*$
             ^%(__prefix_line)srefused connect from \S+ \(<HOST>\)\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because none of user's groups are listed in AllowGroups\s*$
 


### PR DESCRIPTION
Do not trigger sshd bans on pam_unix authentication failures, this will trigger on successful logins on systems that use non-pam_unix authentication (sssd, ldap, etc.).
