### PR TITLE
Escape ' and " in matches

### DIFF
--- a/server/action.py
+++ b/server/action.py
@@ -243,7 +243,7 @@ class Action:
 		return Action.executeCmd(stopCmd)
 
 	def escapeTag(tag):
-		for c in '\\#&;`|*?~<>^()[]{}$\n':
+		for c in '\\#&;`|*?~<>^()[]{}$\n\'"':
 			if c in tag:
 				tag = tag.replace(c, '\\' + c)
 		return tag


### PR DESCRIPTION
In addition to the characters currently escaped in matches tag, ' and " should also be escaped. Their presence might cause the call to actionban to fail.
