### PR TITLE
TST+BF: Use separate coveragerc for Travis CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 
 [run]
 branch = True
-omit = /usr* /home/travis/virtualenv/*
+omit = /usr*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ install:
   - pip install pyinotify
   - if [[ $TRAVIS_PYTHON_VERSION == 2.[6-7] ]]; then pip install -q coveralls; fi
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.[6-7] ]]; then coverage run fail2ban-testcases; else python ./fail2ban-testcases; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.[6-7] ]]; then coverage run --rcfile=.travis_coveragerc fail2ban-testcases; else python ./fail2ban-testcases; fi
 after_script:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.[6-7] ]]; then coveralls; fi

--- a/.travis_coveragerc
+++ b/.travis_coveragerc
@@ -1,0 +1,7 @@
+
+[run]
+branch = True
+omit =
+    /usr/*
+    /home/travis/virtualenv/*
+    server/filtergamin.py


### PR DESCRIPTION
Should now ignore server/filtergamin.py as gamin is not tested. Also
ignores Travis CI python virtual environments.

Appears my syntax was wrong earlier, as "omit"s must be `,` or new line delimited.

Unfortunately their is no way to test these locally, without pushing commits and hoping you've not made a mistake :frowning:

Looks like all is working now however. Please see: https://coveralls.io/builds/11507
