### PR TITLE
ENH: more openssh fail messages from openssh source code (CVS 20121205)

### DIFF
--- a/config/filter.d/sshd-ddos.conf
+++ b/config/filter.d/sshd-ddos.conf
@@ -2,6 +2,13 @@
 #
 # Author: Yaroslav Halchenko
 #
+# The regex here also relates to a exploit:
+#
+#  http://www.securityfocus.com/bid/17958/exploit
+#  The example code here shows the pushing of the exploit straight after
+#  reading the server version. This is where the client version string normally
+#  pushed. As such the server will read this unparsible information as
+#  "Did not receive identification string".
 
 [INCLUDES]
 

--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -24,7 +24,6 @@ _daemon = sshd
 # Values:  TEXT
 #
 failregex = ^%(__prefix_line)s(?:error: PAM: )?Authentication failure for .* from <HOST>\s*$
-            ^%(__prefix_line)sDid not receive identification string from <HOST>$
             ^%(__prefix_line)s(?:error: PAM: )?User not known to the underlying authentication module for .* from <HOST>\s*$
             ^%(__prefix_line)sFailed \S+ for .* from <HOST>(?: port \d*)?(?: ssh\d*)?\s*$
             ^%(__prefix_line)sROOT LOGIN REFUSED.* FROM <HOST>\s*$


### PR DESCRIPTION
These are from the ssh source code.

Inspired to check because of http://svnweb.freebsd.org/ports/head/security/py-fail2ban/files/patch-bsd-sshd.conf?revision=247847&view=markup.

More methods than password and public key exist.
