### PR TITLE
Fixed error datetime detect problem for format like "2013/05/04 09:30:22"

### DIFF
--- a/server/datedetector.py
+++ b/server/datedetector.py
@@ -80,7 +80,7 @@ class DateDetector:
 			# (See http://bugs.debian.org/537610)
 			template = DateStrptime()
 			template.setName("Day/Month/Year2 Hour:Minute:Second")
-			template.setRegex("\d{2}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}")
+			template.setRegex("(?<!\d{2})\d{2}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}")
 			template.setPattern("%d/%m/%y %H:%M:%S")
 			self._appendTemplate(template)
 			# Apache format [31/Oct/2006:09:22:55 -0000]


### PR DESCRIPTION
Datetime such as "2013/05/04 09:30:22" in log may be detected as May 13, 2004,

It's caused by the DateDetector will match "Day/Month/Year2 Hour:Minute:Second" first,

We can simply change the regular expression resolve this problem. 
