### PR TITLE
fixed failregex line for roundcube 0.9+

### DIFF
--- a/config/filter.d/roundcube-auth.conf
+++ b/config/filter.d/roundcube-auth.conf
@@ -1,7 +1,9 @@
 # Fail2Ban configuration file for roundcube web server
 #
-# Author: Teodor Micu & Yaroslav Halchenko
-#
+# Author: Teodor Micu & Yaroslav Halchenko & terence namusonge ver (0.9+)
+# Only works only if  log driver: is set to  'syslog'. this is becoz fail2ban fails to 'read' the line due to the
+# brackets around the date timestamp on logline when logdrive is file
+
 #
 
 [Definition]
@@ -13,7 +15,7 @@
 #          (?:::f{4,6}:)?(?P<host>[\w\-.^_]+)
 # Values:  TEXT
 #
-failregex = FAILED login for .*. from <HOST>\s*$
+failregex = Login failed for *.* from <HOST>
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.


### PR DESCRIPTION
# Only works only if  log driver: is set to  'syslog'. this is becoz fail2ban fails to 'read' the line due to the  brackets around the date timestamp on logline when log driver is set to file
