### PR TITLE
ENH: anchor a bit mor. Use \d and \w where possible. Escape a literal .

### DIFF
--- a/config/filter.d/asterisk.conf
+++ b/config/filter.d/asterisk.conf
@@ -14,25 +14,22 @@ before = common.conf
 [Definition]
 
 # Option:  failregex
-# Notes.:  regex to match the password failures messages in the logfile. The
-#          host must be matched by a group named "host". The tag "<HOST>" can
-#          be used for standard IP/hostname matching and is only an alias for
-#          (?:::f{4,6}:)?(?P<host>\S+)
+# Notes.:  regex to match the password failures messages in the logfile.
 # Values:  TEXT
 #
-failregex = NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:[0-9]+)?' - Wrong password$
-            NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:[0-9]+)?' - No matching peer found$
-            NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:[0-9]+)?' - Username/auth name mismatch$
-            NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:[0-9]+)?' - Device does not match ACL$
-            NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:[0-9]+)?' - Peer is not supposed to register$
-            NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:[0-9]+)?' - ACL error \(permit/deny\)$
-            NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:[0-9]+)?' - Not a local domain$
-            NOTICE%(__pid_re)s\[[^:]+\] [^:]+: Call from '[^']*' \(<HOST>:[0-9]+\) to extension '[0-9]+' rejected because extension not found in context 'default'.$
-            NOTICE%(__pid_re)s [^:]+: Host <HOST> failed to authenticate as '[^']*'$
-            NOTICE%(__pid_re)s [^:]+: No registration for peer '[^']*' \(from <HOST>\)$
-            NOTICE%(__pid_re)s [^:]+: Host <HOST> failed MD5 authentication for '[^']*' \([^)]+\)$
-            NOTICE%(__pid_re)s [^:]+: Failed to authenticate user [^@]+@<HOST>\S*$
-            SECURITY%(__pid_re)s [^:]+: SecurityEvent="InvalidAccountID",EventTV="[0-9-]+",Severity="[a-zA-Z]+",Service="[a-zA-Z]+",EventVersion="[0-9]+",AccountID="[0-9]+",SessionID="0x[0-9a-f]+",LocalAddress="IPV[46]/(UD|TC)P/[0-9a-fA-F:.]+/[0-9]+",RemoteAddress="IPV[46]/(UD|TC)P/<HOST>/[0-9]+"$
+failregex = \]\s*NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:\d+)?' - Wrong password$
+            \]\s*NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:\d+)?' - No matching peer found$
+            \]\s*NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:\d+)?' - Username/auth name mismatch$
+            \]\s*NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:\d+)?' - Device does not match ACL$
+            \]\s*NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:\d+)?' - Peer is not supposed to register$
+            \]\s*NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:\d+)?' - ACL error \(permit/deny\)$
+            \]\s*NOTICE%(__pid_re)s [^:]+: Registration from '[^']*' failed for '<HOST>(:\d+)?' - Not a local domain$
+            \]\s*NOTICE%(__pid_re)s\[[^:]+\] [^:]+: Call from '[^']*' \(<HOST>:\d+\) to extension '\d+' rejected because extension not found in context 'default'\.$
+            \]\s*NOTICE%(__pid_re)s [^:]+: Host <HOST> failed to authenticate as '[^']*'$
+            \]\s*NOTICE%(__pid_re)s [^:]+: No registration for peer '[^']*' \(from <HOST>\)$
+            \]\s*NOTICE%(__pid_re)s [^:]+: Host <HOST> failed MD5 authentication for '[^']*' \([^)]+\)$
+            \]\s*NOTICE%(__pid_re)s [^:]+: Failed to authenticate user [^@]+@<HOST>\S*$
+            \]\s*SECURITY%(__pid_re)s [^:]+: SecurityEvent="InvalidAccountID",EventTV="[\d-]+",Severity="[\w]+",Service="[\w]+",EventVersion="\d+",AccountID="\d+",SessionID="0x[\da-f]+",LocalAddress="IPV[46]/(UD|TC)P/[\da-fA-F:.]+/\d+",RemoteAddress="IPV[46]/(UD|TC)P/<HOST>/\d+"$
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.


### PR DESCRIPTION
contains enhancements to regex.

I think I should of been able to add a ^ at the beginning of each failregex but the fail2ban-regex wasn't matching the tests any more. Thoughts welcome.
