### PR TITLE
ENH: ban also submission port (587) for all smtp-related jails

### DIFF
--- a/config/jail.conf
+++ b/config/jail.conf
@@ -383,12 +383,12 @@ maxretry = 6
 
 [courier-smtp]
 
-port     = smtp,ssmtp
+port     = smtp,ssmtp,submission
 logpath  = /var/log/mail.log
 
 [postfix]
 
-port     = smtp,ssmtp
+port     = smtp,ssmtp,submission
 logpath  = /var/log/mail.log
 
 # The hosts.deny path can be defined with the "file" argument if it is
@@ -409,13 +409,13 @@ bantime  = 300
 
 [courier-auth]
 
-port     = smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s
+port     = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
 logpath  = /var/log/mail.log
 
 
 [sasl]
 
-port     = smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s
+port     = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
 # "warn" level but overall at the smaller filesize.
@@ -423,7 +423,7 @@ logpath  = /var/log/mail.log
 
 [dovecot]
 
-port    = smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s
+port    = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
 logpath = /var/log/mail.log
 
 #


### PR DESCRIPTION
see http://www.rfc-editor.org/rfc/rfc4409.txt
and http://en.wikipedia.org/wiki/Mail_submission_agent

Users of advanced setups might like to split those into multiple jails anyways
to have separate control over submission agents and incoming mail servers.
