### PR TITLE
BF+DOC: All fail2ban config files are UTF-8 decoded for python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Installation:
 this case, you should use it instead.**
 
 Required:
-- [Python >= 2.4, including 3.x](http://www.python.org)
+- [Python2 >= 2.4 or Python3 >= 3.2](http://www.python.org)
 
 Optional:
 - [pyinotify >= 0.8.3](https://github.com/seb-m/pyinotify)

--- a/fail2ban/client/configparserinc.py
+++ b/fail2ban/client/configparserinc.py
@@ -115,7 +115,14 @@ after = 1.conf
 		SCPWI = SafeConfigParserWithIncludes
 		
 		parser = SafeConfigParser()
-		parser.read(resource)
+		try:
+			if sys.version_info >= (3,2): # pragma: no cover
+				parser.read(resource, encoding='utf-8')
+			else:
+				parser.read(resource)
+		except UnicodeDecodeError, e:
+			logSys.error("Error decoding config file '%s': %s" % (resource, e))
+			return []
 		
 		resourceDir = os.path.dirname(resource)
 
@@ -146,5 +153,8 @@ after = 1.conf
 		for filename in filenames:
 			fileNamesFull += SafeConfigParserWithIncludes.getIncludes(filename)
 		logSys.debug("Reading files: %s" % fileNamesFull)
-		return SafeConfigParser.read(self, fileNamesFull)
+		if sys.version_info >= (3,2): # pragma: no cover
+			return SafeConfigParser.read(self, fileNamesFull, encoding='utf-8')
+		else:
+			return SafeConfigParser.read(self, fileNamesFull)
 

--- a/man/jail.conf.5
+++ b/man/jail.conf.5
@@ -12,6 +12,7 @@ Fail2ban has three configuration file types. Action files are the commands for b
 Filter files tell fail2ban how to detect authentication failures, and Jail configurations combine filters with actions into jails.
 
 There are *.conf files that are distributed by fail2ban and *.local file that contain user customizations.
+All configuration files should be UTF-8 encoded for python3.
 It is recommended that *.conf files should remain unchanged.  If needed, customizations should be provided in *.local files.
 For instance, if you would like to customize the [ssh-iptables-ipset] jail, create a jail.local to extend jail.conf
 (the configuration for the fail2ban server).  The jail.local file will be the following if you only need to enable


### PR DESCRIPTION
ref #273, this change enforces that fail2ban config files are UTF-8.
