### PR TITLE
Fix dropbear regex for new versions. Add testcase log.

### DIFF
--- a/config/filter.d/dropbear.conf
+++ b/config/filter.d/dropbear.conf
@@ -27,8 +27,9 @@ _daemon = dropbear
 # These match the unmodified dropbear messages. It isn't possible to
 # match the source of the 'exit before auth' messages from dropbear.
 #
-failregex = ^%(__prefix_line)slogin attempt for nonexistent user ('.*' )?from <HOST>:.*\s*$
-            ^%(__prefix_line)sbad password attempt for .+ from <HOST>:.*\s*$
+failregex = ^%(__prefix_line)s(L|l)ogin attempt for nonexistent user ('.*' )?from <HOST>:.*\s*$
+            ^%(__prefix_line)s(B|b)ad password attempt for .+ from <HOST>:.*\s*$
+	     ^%(__prefix_line)sExit before auth \(user .+, \d+ fails\): Max auth tries reached - user .+ from <HOST>:.*\s*$
 
 # The only line we need to match with the modified dropbear.
 

--- a/testcases/files/logs/dropbear
+++ b/testcases/files/logs/dropbear
@@ -1,0 +1,6 @@
+# failJSON: { "time": "2005-07-27T01:04:12", "match": true , "host": "1.2.3.4" }
+Jul 27 01:04:12 fail2ban-test dropbear[1335]: Bad password attempt for 'root' from 1.2.3.4:60588
+# failJSON: { "time": "2005-07-27T01:04:22", "match": true , "host": "1.2.3.4" }
+Jul 27 01:04:22 fail2ban-test dropbear[1335]: Exit before auth (user 'root', 10 fails): Max auth tries reached - user 'root' from 1.2.3.4:60588
+# failJSON: { "time": "2005-07-27T01:18:59", "match": true , "host": "1.2.3.4" }
+Jul 27 01:18:59 fail2ban-test dropbear[1477]: Login attempt for nonexistent user from 1.2.3.4:60794


### PR DESCRIPTION
https://github.com/fail2ban/fail2ban/issues/306

Fix regex for latest dropbear (keep backwards compatibility).  Add additional filter and log for "Max auth tries reached". Add test case logfiles.

I have one concern, and would appreciate some dev review here:

The dropbear service does not log the YEAR by default, but the test logs MUST have a year. My initial research indicates the year will default to 2005 (in the fail2ban parser) if no year is provided, so I've set that in my test logs. However, I'm not 100% sure it will behave identically on all systems (ie: I'm not sure if the 2005 default is consistent across all platforms). If it is, great. If not, is there a way to provide a test log without a year? My attempts to do so resulted in error.

Signed-off-by: Jamyn Shanley jshanley@gmail.com
