### PR TITLE
Add xinetd failure test log.

### DIFF
--- a/testcases/files/logs/xinetd-fail
+++ b/testcases/files/logs/xinetd-fail
@@ -1,0 +1,2 @@
+# failJSON: { "time": "2005-07-27T02:08:16", "match": true , "host": "1.2.3.4" }
+Jul 27 02:08:16 fail2ban-test xinetd[2825]: FAIL: telnet address from=::ffff:1.2.3.4


### PR DESCRIPTION
Add an xinetd test log.

Similar to https://github.com/fail2ban/fail2ban/pull/307 - I'm assuming '2005' is the default year on all platforms, when the log does not expliticitly have a year.  If this is a bad assumption, we'll have to figure something else out.
