### PR TITLE
Install empty /etc/fail2ban/jail.d directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,9 @@ setup(
 						('/etc/fail2ban/action.d',
 							glob("config/action.d/*.conf")
 						),
+						('/etc/fail2ban/fail2ban.d',
+							''
+						),
 						('/etc/fail2ban/jail.d',
 							''
 						),


### PR DESCRIPTION
Seems like we should ship this by default to encourage its use.
