### PR TITLE
3rdparty/ for collection of 3rd-party git submodules

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -1,8 +1,10 @@
-Fail2Ban is an open source project with many contributions from its
-users community. Below is an alphabetically sorted partial list of the
-contributors to the project.  If you have been left off, please let us
-know (preferably send a pull request on github with the "fix") and you
-will be added
+Fail2Ban is an open source project which was conceived and originally
+developed by Cyril Jaquier until 2010.  Since then Fail2Ban grew into
+a community-driven project with many contributions from its users.
+Below is an alphabetically sorted partial list of the contributors to
+the project.  If you have been left off, please let us know
+(preferably send a pull request on github with the "fix") and you will
+be added
 
 Adrien Clerc
 ache
@@ -17,6 +19,7 @@ Christian Rauch
 Christophe Carles
 Christoph Haas
 Christos Psonis
+Cyril Jaquier
 Daniel B. Cid
 Daniel Black
 David Nutter


### PR DESCRIPTION
Actually this is probably more for discussion than for the merge -- although if everyone thinks it is a good idea we could proceed merging it in.

@LyleScott :  I remember some time back someone already made similar "extension" to fail2ban but I even forgot who and where.  

So may be we could keep a 3rdparty/ collection with knowing to work with current version version extensions of various kinds which are not necessarily supported by us?
