### PR TITLE
added osx specific ipfw action with random rulenum

### DIFF
--- a/config/action.d/osx-ipfw.conf
+++ b/config/action.d/osx-ipfw.conf
@@ -71,7 +71,7 @@ block = tcp
 #          Common values: deny, unreach port, reset
 # Values:  STRING
 #
-blocktype = deny
+blocktype = unreach port
 
 # Option:  set number
 # Notes.:  The ipset number this is added to.


### PR DESCRIPTION
I created an OS X specific ipfw action filter to allow for random rulenum.
