### PR TITLE
ENH - Added server name to subject line in email notifications

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -10,6 +10,7 @@ Andrey G. Grozin
 Andy Fragen
 Arturo 'Buanzo' Busleiman
 Axel Thimm
+Beau Raines
 Bill Heaton
 Carlos Alberto Lopez Perez
 Christian Rauch

--- a/config/action.d/mail-buffered.conf
+++ b/config/action.d/mail-buffered.conf
@@ -14,7 +14,7 @@ actionstart = printf %%b "Hi,\n
               The jail <name> has been started successfully.\n
               Output will be buffered until <lines> lines are available.\n
               Regards,\n
-              Fail2Ban"|mail -s "[Fail2Ban] <name>: started" <dest>
+              Fail2Ban"|mail -s "[Fail2Ban] <name>: started on `uname -n`" <dest>
 
 # Option:  actionstop
 # Notes.:  command executed once at the end of Fail2Ban
@@ -25,13 +25,13 @@ actionstop = if [ -f <tmpfile> ]; then
                  These hosts have been banned by Fail2Ban.\n
                  `cat <tmpfile>`
                  Regards,\n
-                 Fail2Ban"|mail -s "[Fail2Ban] <name>: Summary" <dest>
+                 Fail2Ban"|mail -s "[Fail2Ban] <name>: Summary from `uname -n`" <dest>
                  rm <tmpfile>
              fi
              printf %%b "Hi,\n
              The jail <name> has been stopped.\n
              Regards,\n
-             Fail2Ban"|mail -s "[Fail2Ban] <name>: stopped" <dest>
+             Fail2Ban"|mail -s "[Fail2Ban] <name>: stopped on `uname -n`" <dest>
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command

--- a/config/action.d/mail-whois-lines.conf
+++ b/config/action.d/mail-whois-lines.conf
@@ -13,7 +13,7 @@
 actionstart = printf %%b "Hi,\n
               The jail <name> has been started successfully.\n
               Regards,\n
-              Fail2Ban"|mail -s "[Fail2Ban] <name>: started" <dest>
+              Fail2Ban"|mail -s "[Fail2Ban] <name>: started on `uname -n`" <dest>
 
 # Option:  actionstop
 # Notes.:  command executed once at the end of Fail2Ban
@@ -22,7 +22,7 @@ actionstart = printf %%b "Hi,\n
 actionstop = printf %%b "Hi,\n
              The jail <name> has been stopped.\n
              Regards,\n
-             Fail2Ban"|mail -s "[Fail2Ban] <name>: stopped" <dest>
+             Fail2Ban"|mail -s "[Fail2Ban] <name>: stopped on `uname -n`" <dest>
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command
@@ -44,7 +44,7 @@ actionban = printf %%b "Hi,\n
             Lines containing IP:<ip> in <logpath>\n
             `grep '\<<ip>\>' <logpath>`\n\n
             Regards,\n
-            Fail2Ban"|mail -s "[Fail2Ban] <name>: banned <ip>" <dest>
+            Fail2Ban"|mail -s "[Fail2Ban] <name>: banned <ip> from  `uname -n`" <dest>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the

--- a/config/action.d/mail-whois.conf
+++ b/config/action.d/mail-whois.conf
@@ -13,7 +13,7 @@
 actionstart = printf %%b "Hi,\n
               The jail <name> has been started successfully.\n
               Regards,\n
-              Fail2Ban"|mail -s "[Fail2Ban] <name>: started" <dest>
+              Fail2Ban"|mail -s "[Fail2Ban] <name>: started on `uname -n`" <dest>
 
 # Option:  actionstop
 # Notes.:  command executed once at the end of Fail2Ban
@@ -22,7 +22,7 @@ actionstart = printf %%b "Hi,\n
 actionstop = printf %%b "Hi,\n
              The jail <name> has been stopped.\n
              Regards,\n
-             Fail2Ban"|mail -s "[Fail2Ban] <name>: stopped" <dest>
+             Fail2Ban"|mail -s "[Fail2Ban] <name>: stopped on `uname -n`" <dest>
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command
@@ -42,7 +42,7 @@ actionban = printf %%b "Hi,\n
             Here are more information about <ip>:\n
             `whois <ip>`\n
             Regards,\n
-            Fail2Ban"|mail -s "[Fail2Ban] <name>: banned <ip>" <dest>
+            Fail2Ban"|mail -s "[Fail2Ban] <name>: banned <ip> from `uname -n`" <dest>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the

--- a/config/action.d/mail.conf
+++ b/config/action.d/mail.conf
@@ -13,7 +13,7 @@
 actionstart = printf %%b "Hi,\n
               The jail <name> has been started successfully.\n
               Regards,\n
-              Fail2Ban"|mail -s "[Fail2Ban] <name>: started" <dest>
+              Fail2Ban"|mail -s "[Fail2Ban] <name>: started  on `uname -n`" <dest>
 
 # Option:  actionstop
 # Notes.:  command executed once at the end of Fail2Ban
@@ -22,7 +22,7 @@ actionstart = printf %%b "Hi,\n
 actionstop = printf %%b "Hi,\n
              The jail <name> has been stopped.\n
              Regards,\n
-             Fail2Ban"|mail -s "[Fail2Ban] <name>: stopped" <dest>
+             Fail2Ban"|mail -s "[Fail2Ban] <name>: stopped on `uname -n`" <dest>
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command
@@ -40,7 +40,7 @@ actionban = printf %%b "Hi,\n
             The IP <ip> has just been banned by Fail2Ban after
             <failures> attempts against <name>.\n
             Regards,\n
-            Fail2Ban"|mail -s "[Fail2Ban] <name>: banned <ip>" <dest>
+            Fail2Ban"|mail -s "[Fail2Ban] <name>: banned <ip> from `uname -n`" <dest>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the

--- a/config/action.d/sendmail-buffered.conf
+++ b/config/action.d/sendmail-buffered.conf
@@ -14,7 +14,7 @@ before = sendmail-common.conf
 # Notes.:  command executed once at the start of Fail2Ban.
 # Values:  CMD
 #
-actionstart = printf %%b "Subject: [Fail2Ban] <name>: started
+actionstart = printf %%b "Subject: [Fail2Ban] <name>: started on `uname -n`
               From: <sendername> <<sender>>
               To: <dest>\n
               Hi,\n
@@ -28,7 +28,7 @@ actionstart = printf %%b "Subject: [Fail2Ban] <name>: started
 # Values:  CMD
 #
 actionstop = if [ -f <tmpfile> ]; then
-                 printf %%b "Subject: [Fail2Ban] <name>: summary
+                 printf %%b "Subject: [Fail2Ban] <name>: summary from `uname -n`
                  From: <sendername> <<sender>>
                  To: <dest>\n
                  Hi,\n
@@ -38,7 +38,7 @@ actionstop = if [ -f <tmpfile> ]; then
                  Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
                  rm <tmpfile>
              fi
-             printf %%b "Subject: [Fail2Ban] <name>: stopped
+             printf %%b "Subject: [Fail2Ban] <name>: stopped  on `uname -n`
              From: Fail2Ban <<sender>>
              To: <dest>\n
              Hi,\n
@@ -61,7 +61,7 @@ actioncheck =
 actionban = printf %%b "`date`: <ip> (<failures> failures)\n" >> <tmpfile>
             LINE=$( wc -l <tmpfile> | awk '{ print $1 }' )
             if [ $LINE -ge <lines> ]; then
-                printf %%b "Subject: [Fail2Ban] <name>: summary
+                printf %%b "Subject: [Fail2Ban] <name>: summary from `uname -n`
                 From: <sendername> <<sender>>
                 To: <dest>\n
                 Hi,\n

--- a/config/action.d/sendmail-whois-lines.conf
+++ b/config/action.d/sendmail-whois-lines.conf
@@ -14,7 +14,7 @@ before = sendmail-common.conf
 # Notes.:  command executed once at the start of Fail2Ban.
 # Values:  CMD
 #
-actionstart = printf %%b "Subject: [Fail2Ban] <name>: started
+actionstart = printf %%b "Subject: [Fail2Ban] <name>: started on `uname -n`
               Date: `LC_TIME=C date -u +"%%a, %%d %%h %%Y %%T +0000"`
               From: <sendername> <<sender>>
               To: <dest>\n
@@ -27,7 +27,7 @@ actionstart = printf %%b "Subject: [Fail2Ban] <name>: started
 # Notes.:  command executed once at the end of Fail2Ban
 # Values:  CMD
 #
-actionstop = printf %%b "Subject: [Fail2Ban] <name>: stopped
+actionstop = printf %%b "Subject: [Fail2Ban] <name>: stopped on `uname -n`
              Date: `LC_TIME=C date -u +"%%a, %%d %%h %%Y %%T +0000"`
              From: <sendername> <<sender>>
              To: <dest>\n
@@ -48,7 +48,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip>
+actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_TIME=C date -u +"%%a, %%d %%h %%Y %%T +0000"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail-whois.conf
+++ b/config/action.d/sendmail-whois.conf
@@ -14,7 +14,7 @@ before = sendmail-common.conf
 # Notes.:  command executed once at the start of Fail2Ban.
 # Values:  CMD
 #
-actionstart = printf %%b "Subject: [Fail2Ban] <name>: started
+actionstart = printf %%b "Subject: [Fail2Ban] <name>: started on `uname -n`
               Date: `LC_TIME=C date -u +"%%a, %%d %%h %%Y %%T +0000"`
               From: <sendername> <<sender>>
               To: <dest>\n
@@ -27,7 +27,7 @@ actionstart = printf %%b "Subject: [Fail2Ban] <name>: started
 # Notes.:  command executed once at the end of Fail2Ban
 # Values:  CMD
 #
-actionstop = printf %%b "Subject: [Fail2Ban] <name>: stopped
+actionstop = printf %%b "Subject: [Fail2Ban] <name>: stopped on `uname -n`
              Date: `LC_TIME=C date -u +"%%a, %%d %%h %%Y %%T +0000"`
              From: <sendername> <<sender>>
              To: <dest>\n
@@ -48,7 +48,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip>
+actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_TIME=C date -u +"%%a, %%d %%h %%Y %%T +0000"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail.conf
+++ b/config/action.d/sendmail.conf
@@ -14,7 +14,7 @@ before = sendmail-common.conf
 # Notes.:  command executed once at the start of Fail2Ban.
 # Values:  CMD
 #
-actionstart = printf %%b "Subject: [Fail2Ban] <name>: started
+actionstart = printf %%b "Subject: [Fail2Ban] <name>: started on `uname -n`
               Date: `LC_TIME=C date -u +"%%a, %%d %%h %%Y %%T +0000"`
               From: <sendername> <<sender>>
               To: <dest>\n
@@ -27,7 +27,7 @@ actionstart = printf %%b "Subject: [Fail2Ban] <name>: started
 # Notes.:  command executed once at the end of Fail2Ban
 # Values:  CMD
 #
-actionstop = printf %%b "Subject: [Fail2Ban] <name>: stopped
+actionstop = printf %%b "Subject: [Fail2Ban] <name>: stopped on `uname -n`
              Date: `LC_TIME=C date -u +"%%a, %%d %%h %%Y %%T +0000"`
              From: <sendername> <<sender>>
              To: <dest>\n
@@ -48,7 +48,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip>
+actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_TIME=C date -u +"%%a, %%d %%h %%Y %%T +0000"`
             From: <sendername> <<sender>>
             To: <dest>\n


### PR DESCRIPTION
  This is useful when fail2ban is running on multiple servers and
keeping the notifictions separate and knowing which machine is "under
attack".
