### PR TITLE
ENH: filter gssftpd is a syslog based service so anchor it using syslog ...

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -68,6 +68,7 @@ ver. 0.8.11 (2013/XX/XXX) - loves-unittests
      and extra failure examples in sample logs
    * filter.d/apache-auth - added expressions for mod_authz, mod_auth and
      mod_auth_digest failures.
+   * filter.d/gssftpd - anchored regex at start
   Daniel Black & Georgiy Mernov & ftoppi & Мернов Георгий
    * filter.d/exim.conf -- regex hardening and extra failure examples in
      sample logs

--- a/config/filter.d/gssftpd.conf
+++ b/config/filter.d/gssftpd.conf
@@ -1,19 +1,18 @@
-# Fail2Ban configuration file for wuftpd
+# Fail2Ban configuration file for gssftp
 #
-# Author: Kevin Zembower (copied from wsftpd.conf)
+# Author: Kevin Zembower
+# Edited: Daniel Black - syslog based daemon
 #
+# Note: gssftp is part of the krb5-appl-servers in Fedora
 #
+[INCLUDES]
+
+before = common.conf
 
 [Definition]
 
-# Option: failregex
-# Notes.: regex to match the password failures messages in the logfile.
-# Values: TEXT
-#
-failregex = ftpd(?:\[\d+\])?:\s+repeated login failures from <HOST> \(\S+\)$
+_daemon = ftpd
 
-# Option:  ignoreregex
-# Notes.:  regex to ignore. If this regex matches, the line is ignored.
-# Values:  TEXT
-#
+failregex = ^%(__prefix_line)srepeated login failures from <HOST> \(\S+\)$
+
 ignoreregex = 


### PR DESCRIPTION
...prefix
