### PR TITLE
ENH: filter.d/qmail - anchor at start. Add another regex

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -88,6 +88,8 @@ ver. 0.8.11 (2013/XX/XXX) - loves-unittests
    * filter.d/sshd - regex enhancements to support openssh-6.3. Closes Debian
      bug #722970
    * filter.d/webmin - anchored regex at start
+   * filter.d/qmail - rewrote regex to anchor at start. Added regex for
+     another "in the wild" patch to rblsmtp.
   Daniel Black & Georgiy Mernov & ftoppi & Мернов Георгий
    * filter.d/exim.conf -- regex hardening and extra failure examples in
      sample logs

--- a/config/filter.d/qmail.conf
+++ b/config/filter.d/qmail.conf
@@ -1,22 +1,22 @@
 # Fail2Ban configuration file
 #
-# Author: Cyril Jaquier
+# Author: Daniel Black
 #
 #
+
+[INCLUDES]
+
+before = common.conf
 
 [Definition]
 
-# Option:  failregex
-# Notes.:  regex to match the password failures messages in the logfile. The
-#          host must be matched by a group named "host". The tag "<HOST>" can
-#          be used for standard IP/hostname matching and is only an alias for
-#          (?:::f{4,6}:)?(?P<host>[\w\-.^_]+)
-# Values:  TEXT
-#
-failregex = (?:[\d,.]+[\d,.] rblsmtpd: |421 badiprbl: ip )<HOST>
+_daemon = (?:qmail|rblsmtpd)
 
-# Option:  ignoreregex
-# Notes.:  regex to ignore. If this regex matches, the line is ignored.
-# Values:  TEXT
 #
-ignoreregex = 
+# These seem to be for two or 3 different patches to qmail or rblsmtpd
+# so you'll probably only ever see one of these.
+
+failregex = ^%(__prefix_line)s\d+\.\d+ rblsmtpd: <HOST> pid \d+ \S+ 4\d\d \S+\s*$
+            ^%(__prefix_line)s\d+\.\d+ qmail-smtpd: 4\d\d badiprbl: ip <HOST> rbl: \S+\s*$
+            ^%(__prefix_line)s\S+ blocked <HOST> \S+ -\s*$
+

--- a/testcases/files/logs/qmail
+++ b/testcases/files/logs/qmail
@@ -2,3 +2,9 @@
 Sep  6 07:33:33 sd6 qmail: 1157520813.485077 rblsmtpd: 198.51.100.77 pid 19597 sbl-xbl.spamhaus.org: 451 http://www.spamhaus.org/query/bl?ip=198.51.100.77
 # failJSON: { "time": "2004-09-06T07:18:29", "match": true , "host": "198.51.100.54" }
 Sep  6 07:18:29 sd6 qmail: 1157519909.633171 qmail-smtpd: 421 badiprbl: ip 198.51.100.54 rbl: example.com
+
+# http://www.tjsi.com/rblsmtpd/faq/
+# failJSON: { "time": "2005-06-30T15:13:33", "match": true , "host": "193.111.120.47" }
+Jun 30 15:13:33 ns1 rblsmtpd: relays.ordb.org blocked 193.111.120.47 ordb-test.null.dk -
+# failJSON: { "time": "2005-06-30T15:13:55", "match": true , "host": "192.203.178.107" }
+Jun 30 15:13:55 ns1 rblsmtpd: relays.osirusoft.com blocked 192.203.178.107 sbl.crynwr.com -


### PR DESCRIPTION
 for http://www.tjsi.com/rblsmtpd/faq/ patch to rblsmtpd

Note that despite being a djb qmail suite of tools, the default implementation doesn't log any rejections and the patches that I've found in existence seem to log to syslog rather than the daemontools that normally forms part of qmail (and djb utils). I could be proven wrong on this and will gladly admit defeat with a provided log file.

Even if this filter stuffs up the email is still blocked so hopefully no major damage will occur.

This is a clean up for consistency with other filters.
