### PR TITLE
ENH: new asterisk jail to replace asterisk-(tcp|udp)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -71,6 +71,9 @@ ver. 0.8.11 (2013/XX/XXX) - loves-unittests
   François Boulogne and Frédéric
    * filter.d/lighttpd - auth regexs for lighttpd-1.4.31
   Daniel Black
+   * jail.conf now has asterisk jail - no need for asterisk-tcp and
+	   asterisk-udp. Users should replace existing jails with asterisk to 
+		 reduce duplicate parsing of the asterisk log file.
    * filter.d/suhosin - regex anchor at start
    * filter.d/{asterisk,assp,dovecot,proftpd}.conf -- regex hardening
      and extra failure examples in sample logs

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -333,8 +333,17 @@ action   = iptables-multiport[name=Named, port="domain,953", protocol=tcp]
 logpath  = /var/log/named/security.log
 ignoreip = 168.192.0.1
 
-# Multiple jails, 1 per protocol, are necessary ATM:
-# see https://github.com/fail2ban/fail2ban/issues/37
+[asterisk]
+
+enabled  = false
+filter   = asterisk
+action   = iptables-multiport[name=asterisk-tcp, port="5060,5061", protocol=tcp]
+           iptables-multiport[name=asterisk-udp, port="5060,5061", protocol=udp]
+           sendmail-whois[name=Asterisk, dest=you@example.com, sender=fail2ban@example.com]
+logpath  = /var/log/asterisk/messages
+maxretry = 10
+
+#  Historical support (before https://github.com/fail2ban/fail2ban/issues/37 was fixed )
 [asterisk-tcp]
 
 enabled  = false


### PR DESCRIPTION
now that #37 is fixed.

Old jails maintained for compatibility.
