### PR TITLE
Socket create directory if absent + error reporting improvements

### DIFF
--- a/fail2ban-client
+++ b/fail2ban-client
@@ -63,6 +63,7 @@ class Fail2banClient:
 		self.__conf["interactive"] = False
 		self.__conf["socket"] = None
 		self.__conf["pidfile"] = None
+		self.__lasterror = None
 
 	def dispVersion(self):
 		print "Fail2Ban v" + version
@@ -147,6 +148,7 @@ class Fail2banClient:
 		beautifier = Beautifier()
 		for c in cmd:
 			beautifier.setInputCmd(c)
+			self.__lasterror = None
 			try:
 				client = CSocket(self.__conf["socket"])
 				ret = client.send(c)
@@ -158,11 +160,13 @@ class Fail2banClient:
 					logSys.debug("NOK: " + `ret[1].args`)
 					print beautifier.beautifyError(ret[1])
 					return False
-			except socket.error:
+			except socket.error, e:
+				self.__lasterror = "Unable to contact server - %s. Is fail2ban running? check the fail2ban.log" % str(e)
 				if showRet:
-					logSys.error("Unable to contact server. Is it running?")
+					logSys.error(self.__lasterror)
 				return False
 			except Exception, e:
+				self.__lasterror = str(e)
 				if showRet:
 					logSys.error(e)
 				return False
@@ -187,16 +191,19 @@ class Fail2banClient:
 					return False
 				# verify that directory for the socket file exists
 				socket_dir = os.path.dirname(self.__conf["socket"])
-				if not os.path.exists(socket_dir):
-					logSys.error(
-						"There is no directory %s to contain the socket file %s."
-						% (socket_dir, self.__conf["socket"]))
-					return False
-				if not os.access(socket_dir, os.W_OK | os.X_OK):
-					logSys.error(
-						"Directory %s exists but not accessible for writing"
-						% (socket_dir,))
-					return False
+				try:
+					os.mkdir(socket_dir)
+				except OSError, e:
+					if e.errno == 17:
+						# File Exists
+						logSys.debug(
+							"Socket directory %s %s - not unexpected",
+							socket_dir,
+							str(e))
+					else:
+						logSys.error(
+							"While attempting to create directory %s: %s", socket_dir, str(e))
+						return False
 				# Start the server
 				self.__startServerAsync(self.__conf["socket"],
 										self.__conf["pidfile"],
@@ -207,12 +214,13 @@ class Fail2banClient:
 					# Configure the server
 					self.__processCmd(self.__stream, False)
 					return True
-				except ServerExecutionException:
+				except ServerExecutionException, e:
 					logSys.error("Could not start server. Maybe an old "
 								 "socket file is still present. Try to "
 								 "remove " + self.__conf["socket"] + ". If "
 								 "you used fail2ban-client to start the "
-								 "server, adding the -x option will do it")
+								 "server, adding the -x option will do it"
+								 "last error: %s" % self.__lasterror)
 					return False
 		elif len(cmd) == 1 and cmd[0] == "reload":
 			if self.__ping():
@@ -301,7 +309,7 @@ class Fail2banClient:
 			if cnt >= 300:
 				if self.__conf["verbose"] > 1:
 					sys.stdout.write('\n')
-				raise ServerExecutionException("Failed to start server")
+				raise ServerExecutionException("Failed to start server - last error: %s" % self.__lasterror)
 			time.sleep(0.1)
 			cnt += 1
 		if self.__conf["verbose"] > 1:

--- a/fail2ban-client
+++ b/fail2ban-client
@@ -197,9 +197,8 @@ class Fail2banClient:
 					if e.errno == 17:
 						# File Exists
 						logSys.debug(
-							"Socket directory %s %s - not unexpected",
-							socket_dir,
-							str(e))
+							"Socket directory %s - already exists",
+							socket_dir)
 					else:
 						logSys.error(
 							"While attempting to create directory %s: %s", socket_dir, str(e))

--- a/fail2ban-client
+++ b/fail2ban-client
@@ -214,12 +214,11 @@ class Fail2banClient:
 					self.__processCmd(self.__stream, False)
 					return True
 				except ServerExecutionException, e:
-					logSys.error("Could not start server. Maybe an old "
+					logSys.error( str(e) + ". Maybe an old "
 								 "socket file is still present. Try to "
 								 "remove " + self.__conf["socket"] + ". If "
 								 "you used fail2ban-client to start the "
-								 "server, adding the -x option will do it"
-								 "last error: %s" % self.__lasterror)
+								 "server, adding the -x option will do it")
 					return False
 		elif len(cmd) == 1 and cmd[0] == "reload":
 			if self.__ping():

--- a/server/asyncserver.py
+++ b/server/asyncserver.py
@@ -117,7 +117,12 @@ class AsyncServer(asyncore.dispatcher):
 	
 	def start(self, sock, force):
 		self.__sock = sock
-		# Remove socket
+		# Remove socket:
+		#   we've replaced the logic here from an exists check to just trying
+		#   and handle the exceptions approprately. This eliminates a race condition
+		#   and allows us to fully handle permission denied and other OSErrors
+		#   associated with its forced removal and allowing the "Not Found error"
+		#   to silently be accepted as the default case that a socket didn't exist.
 		if force:
 			try:
 				os.remove(sock)

--- a/server/asyncserver.py
+++ b/server/asyncserver.py
@@ -118,20 +118,27 @@ class AsyncServer(asyncore.dispatcher):
 	def start(self, sock, force):
 		self.__sock = sock
 		# Remove socket
-		if os.path.exists(sock):
-			logSys.error("Fail2ban seems to be already running")
-			if force:
-				logSys.warn("Forcing execution of the server")
+		if force:
+			try:
 				os.remove(sock)
-			else:
-				raise AsyncServerException("Server already running")
+				logSys.warn("Forced execution of the server by removing socket %s" % sock)
+			except OSError, e:
+				if e.errno == 2:
+					# not found
+					pass
+				else:
+					raise AsyncServerException("Unable to remove socket %s: %s" % self.__sock, e)
 		# Creates the socket.
-		self.create_socket(socket.AF_UNIX, socket.SOCK_STREAM)
-		self.set_reuse_addr()
 		try:
+			self.create_socket(socket.AF_UNIX, socket.SOCK_STREAM)
+			self.set_reuse_addr()
 			self.bind(sock)
-		except Exception:
-			raise AsyncServerException("Unable to bind socket %s" % self.__sock)
+		except socket.error, e:
+			if e.errno == 98:
+				# Address already in use
+				raise AsyncServerException("Server already running on socket %s", self.__sock)
+			else:
+				raise AsyncServerException("Unable to create/bind socket %s: %s" % self.__sock, e)
 		AsyncServer.__markCloseOnExec(self.socket)
 		self.listen(1)
 		# Sets the init flag.


### PR DESCRIPTION
create socket directory and enhance error message. Base very loosely on #168. I'm thinking its quite lasy to depend on initscripts or the user manually to do things that the program can doo.

BF/ENH: remove race conditions by trying to remove force remove socket. Report errors if cannot remove 
socket

Tests:

Creates directory and socket and communicates

<pre>
$ rm -rf /tmp/nonexist && ./fail2ban-client -s /tmp/nonexist/s.sock  -c config/ start
2013-10-15 10:53:17,453 fail2ban.server : INFO   Starting Fail2ban v0.8.10.dev
2013-10-15 10:53:17,453 fail2ban.server : INFO   Starting in daemon mode
$ ./fail2ban-client -s /tmp/nonexist/s.sock stop && rm -rf /tmp/nonexist
Shutdown successful
</pre>


Reports error if can't create a directory

<pre>
$ ./fail2ban-client -s /etc/cant_write/s.sock  -c config/ start
ERROR  While attempting to create directory /etc/cant_write: [Errno 13] Permission denied: '/etc/cant_write'
$ ./fail2ban-client -s /tmp/s.sock  -c config/ start
2013-10-15 10:54:14,101 fail2ban.server : INFO   Starting Fail2ban v0.8.10.dev
2013-10-15 10:54:14,102 fail2ban.server : INFO   Starting in daemon mode
</pre>


Starting a second instance fails when it could ping the remote

<pre>
$ ./fail2ban-client -s /tmp/s.sock  -c config/ start
ERROR  Server already running
</pre>


The force option had no effect above because the server responded to a ping. Correct behaviour?

<pre>
$ ./fail2ban-client -s /tmp/s.sock -x   -c config/ start
ERROR  Server already running
</pre>


Starting second instance when fist instance killed off still fails

<pre>
$ ./fail2ban-client -s /tmp/s.sock   -c config/ start
2013-10-15 11:57:28,998 fail2ban.server : INFO   Starting Fail2ban v0.8.10.dev
2013-10-15 11:57:28,998 fail2ban.server : INFO   Starting in daemon mode
$ killall -9  fail2ban-server
$ ./fail2ban-client -s /tmp/s.sock   -c config/ start
2013-10-15 11:57:43,699 fail2ban.server : INFO   Starting Fail2ban v0.8.10.dev
2013-10-15 11:57:43,700 fail2ban.server : INFO   Starting in daemon mode
ERROR  Could not start server. Maybe an old socket file is still present. Try to remove /tmp/s.sock. If you used fail2ban-client to start the server, adding the -x option will do itlast error: Unable to contact server - [Errno 111] Connection refused. Is fail2ban running? check the fail2ban.log

$ rm /tmp/s.sock
</pre>


Remove permission after started and try.

<pre>
$ ./fail2ban-client -s /tmp/nonexist/s.sock  -c config/ start
2013-10-15 12:02:26,370 fail2ban.server : INFO   Starting Fail2ban v0.8.10.dev
2013-10-15 12:02:26,371 fail2ban.server : INFO   Starting in daemon mode
$ chmod 000 /tmp/nonexist
$ ./fail2ban-client -s /tmp/nonexist/s.sock   -c config/ start
2013-10-15 12:03:03,869 fail2ban.server : INFO   Starting Fail2ban v0.8.10.dev
2013-10-15 12:03:03,870 fail2ban.server : INFO   Starting in daemon mode
ERROR  Could not start server. Maybe an old socket file is still present. Try to remove /tmp/nonexist/s.sock. If you used fail2ban-client to start the server, adding the -x option will do itlast error: Unable to contact server - [Errno 13] Permission denied. Is fail2ban running? check the fail2ban.log
</pre>


Even forcing doesn't get beyond permission denied

<pre>
$ ./fail2ban-client -s /tmp/nonexist/s.sock -x  -c config/ start
2013-10-15 12:03:43,957 fail2ban.server : INFO   Starting Fail2ban v0.8.10.dev
2013-10-15 12:03:43,957 fail2ban.server : INFO   Starting in daemon mode
ERROR  Could not start server. Maybe an old socket file is still present. Try to remove /tmp/nonexist/s.sock. If you used fail2ban-client to start the server, adding the -x option will do itlast error: Unable to contact server - [Errno 13] Permission denied. Is fail2ban running? check the fail2ban.log
</pre>
