### PR TITLE
BF: filter.d/dropbear

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,8 @@ ver. 0.8.11 (2013/XX/XXX) - loves-unittests
    * filter.d/roundcube-auth - timezone offset can be positive or negative
    * action.d/bsd-ipfw - action option unsed. Fixed to blocktype for
      consistency. default to port unreach instead of deny
+   * filter.d/dropbear - fix regexs to match standard dropbear and the patched
+     http://www.unchartedbackwaters.co.uk/files/dropbear/dropbear-0.52.patch
   Rolf Fokkens
    * action.d/dshield.conf and complain.conf -- reorder mailx arguments.
      https://bugzilla.redhat.com/show_bug.cgi?id=998020
@@ -104,6 +106,7 @@ ver. 0.8.11 (2013/XX/XXX) - loves-unittests
    * filter.d/webmin - anchored regex at start
    * filter.d/qmail - rewrote regex to anchor at start. Added regex for
      another "in the wild" patch to rblsmtp.
+   * filter.d/dropbear - add PAM is in dropbear-2013.60
   Daniel Black & Georgiy Mernov & ftoppi & Мернов Георгий
    * filter.d/exim.conf -- regex hardening and extra failure examples in
      sample logs

--- a/config/filter.d/dropbear.conf
+++ b/config/filter.d/dropbear.conf
@@ -1,8 +1,15 @@
-# Fail2Ban configuration file
+# Fail2Ban filter for dropbear
 #
-# Author: Francis Russell
-#         Zak B. Elep
+# NOTE: The regex below is ONLY intended to work with a patched
+# version of Dropbear as described here:
+# http://www.unchartedbackwaters.co.uk/pyblosxom/static/patches
+#            ^%(__prefix_line)sexit before auth from <HOST>.*\s*$
 #
+# The standard Dropbear output doesn't provide enough information to
+# ban all types of attack.  The Dropbear patch adds IP address
+# information to the 'exit before auth' message which is always
+# produced for any form of non-successful login. It is that message
+# which this file matches.
 #
 # More information: http://bugs.debian.org/546913
 
@@ -12,41 +19,23 @@
 # common.local
 before = common.conf
 
-
 [Definition]
 
 _daemon = dropbear
 
-# Option:  failregex
-# Notes.:  regex to match the password failures messages in the logfile. The
-#          host must be matched by a group named "host". The tag "<HOST>" can
-#          be used for standard IP/hostname matching and is only an alias for
-#          (?:::f{4,6}:)?(?P<host>\S+)
-# Values:  TEXT
+failregex = ^%(__prefix_line)s[Ll]ogin attempt for nonexistent user ('.*' )?from <HOST>:.*$
+            ^%(__prefix_line)s[Bb]ad (PAM )?password attempt for .+ from <HOST>.*$
+            ^%(__prefix_line)s[Ee]xit before auth \(user '.+', \d+ fails\): Max auth tries reached - user '.+' from <HOST>:\d+\s*$
 
-# These match the unmodified dropbear messages. It isn't possible to
-# match the source of the 'exit before auth' messages from dropbear.
-#
-failregex = ^%(__prefix_line)s(L|l)ogin attempt for nonexistent user ('.*' )?from <HOST>:.*\s*$
-            ^%(__prefix_line)s(B|b)ad password attempt for .+ from <HOST>:.*\s*$
-            ^%(__prefix_line)sExit before auth \(user '.+', \d+ fails\): Max auth tries reached - user '.+' from <HOST>:\d+\s*$
-
-# The only line we need to match with the modified dropbear.
-
-# NOTE: The failregex below is ONLY intended to work with a patched
-# version of Dropbear as described here:
-# http://www.unchartedbackwaters.co.uk/pyblosxom/static/patches
-#
-# The standard Dropbear output doesn't provide enough information to
-# ban all types of attack.  The Dropbear patch adds IP address
-# information to the 'exit before auth' message which is always
-# produced for any form of non-successful login. It is that message
-# which this file matches.
-
-# failregex = ^%(__prefix_line)sexit before auth from <HOST>.*\s*$
-
-# Option:  ignoreregex
-# Notes.:  regex to ignore. If this regex matches, the line is ignored.
-# Values:  TEXT
-#
 ignoreregex = 
+
+# DEV Notes:
+#
+# The first two regexs here match the unmodified dropbear messages. It isn't
+# possible to match the source of the 'exit before auth' messages from dropbear
+# as they don't include the "from <HOST>" bit.
+#
+# The second last failregex line we need to match with the modified dropbear.
+#
+# Author: Francis Russell
+#         Zak B. Elep


### PR DESCRIPTION
Add PAM failures which is in dropbear-2013.60 in srv-authpam.c

Patch
http://www.unchartedbackwaters.co.uk/files/dropbear/dropbear-0.52.patch
obviously has exit with lower case e so adjust regex for both.

svr-authpasswd.c in 2013.60 (at bottom) for second regex ends after the
IP so the regex was altered.

._\s_ can be compressed to .*
