### PR TITLE
ENH: fix to use upstream --remove-rules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -54,6 +54,7 @@ ver. 0.8.11 (2013/XX/XXX) - loves-unittests
   Edgar Hoch
 	 * action.d/firewall-cmd-direct-new.conf - action for firewalld
      from https://bugzilla.redhat.com/show_bug.cgi?id=979622
+     NOTE: requires firewalld-0.3.8+
   Andy Fragen and Daniel Black
    * filter.d/osx-ipfw.conf - ipfw action for OSX based on random rule
      numbers.

--- a/config/action.d/firewall-cmd-direct-new.conf
+++ b/config/action.d/firewall-cmd-direct-new.conf
@@ -4,7 +4,7 @@
 # Copied from iptables-new.conf and modified for use with firewalld by Edgar Hoch.
 #  It uses "firewall-cmd" instead of "iptables".
 #
-# Because of the --remove-rules in stop it requires a version AFTER (but not including) 0.3.7.1
+# Because of the --remove-rules in stop this action requires firewalld-0.3.8+
 
 [INCLUDES]
 


### PR DESCRIPTION
https://fedorahosted.org/firewalld/ticket/10
