### PR TITLE
BF: anchor introduced nginx-http-auth at the end

### DIFF
--- a/config/filter.d/nginx-http-auth.conf
+++ b/config/filter.d/nginx-http-auth.conf
@@ -4,7 +4,7 @@
 [Definition]
 
 
-failregex = ^ \[error\] \d+#\d+: \*\d+ user "\S+":? (password mismatch|was not found in ".*"), client: <HOST>, server: \S+, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"
+failregex = ^ \[error\] \d+#\d+: \*\d+ user "\S+":? (password mismatch|was not found in ".*"), client: <HOST>, server: \S+, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"\s*$
 
 ignoreregex = 
 


### PR DESCRIPTION
needed since request probably could be not a correct HTTP statement but continue with
all those to match till the end and then injected ", client: VICTIM, server..." thus allowing
injection.  We better anchor at the end then

sorry that I haven't done timely feedback on the PR
