### PR TITLE
BF/ENH: asterisk connection ID is a hex not decimal number. Add "Rejecti...

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,6 +32,9 @@ some obscure corner of the Internet.
   those filters were used.
 
 - Fixes:
+  Jonathan Lanning
+   * filter.d/asterisk -- identified another regex for blocking. Also channel
+     ID is hex not decimal as noted in sample logs provided.
   Daniel Black & Marcel Dopita
    * filter.d/apache-auth -- fixed and apache auth samples provide. Closes gh-286
   Yaroslav Halchenko

--- a/THANKS
+++ b/THANKS
@@ -34,6 +34,7 @@ Guillaume Delvit
 Hanno 'Rince' Wagner
 Iain Lea
 Jonathan Kamens
+Jonathan Lanning
 Jonathan Underwood
 Joël Bertrand
 JP Espinosa

--- a/config/filter.d/asterisk.conf
+++ b/config/filter.d/asterisk.conf
@@ -6,7 +6,7 @@
 __pid_re = (?:\[\d+\])
 
 # All Asterisk log messages begin like this:
-log_prefix= \[\]\s*(?:NOTICE|SECURITY)%(__pid_re)s:?(?:\[\S+\d*\])? \S+:\d*
+log_prefix= \[\]\s*(?:NOTICE|SECURITY)%(__pid_re)s:?(?:\[C-[\da-f]*\])? \S+:\d*
 
 failregex = ^%(log_prefix)s Registration from '[^']*' failed for '<HOST>(:\d+)?' - (Wrong password|No matching peer found|Username/auth name mismatch|Device does not match ACL|Peer is not supposed to register|ACL error \(permit/deny\)|Not a local domain)$
             ^%(log_prefix)s Call from '[^']*' \(<HOST>:\d+\) to extension '\d+' rejected because extension not found in context 'default'\.$
@@ -16,6 +16,7 @@ failregex = ^%(log_prefix)s Registration from '[^']*' failed for '<HOST>(:\d+)?'
             ^%(log_prefix)s Failed to authenticate (user|device) [^@]+@<HOST>\S*$
             ^%(log_prefix)s (?:handle_request_subscribe: )?Sending fake auth rejection for (device|user) \d*<sip:[^@]+@<HOST>>;tag=\w+\S*$
             ^%(log_prefix)s SecurityEvent="(FailedACL|InvalidAccountID|ChallengeResponseFailed|InvalidPassword)",EventTV="[\d-]+",Severity="[\w]+",Service="[\w]+",EventVersion="\d+",AccountID="\d+",SessionID="0x[\da-f]+",LocalAddress="IPV[46]/(UD|TC)P/[\da-fA-F:.]+/\d+",RemoteAddress="IPV[46]/(UD|TC)P/<HOST>/\d+"(,Challenge="\w+",ReceivedChallenge="\w+")?(,ReceivedHash="[\da-f]+")?$
+            ^\[\]\s*WARNING%(__pid_re)s:?(?:\[C-[\da-f]*\])? Ext\. s: "Rejecting unknown SIP connection from <HOST>"$
 
 ignoreregex =
 

--- a/testcases/files/logs/asterisk
+++ b/testcases/files/logs/asterisk
@@ -40,3 +40,6 @@
 [2009-12-22 16:35:24] NOTICE[14916]: chan_sip.c:15644 handle_request_subscribe: Sending fake auth rejection for user <sip:CS@192.168.2.102>;tag=6pwd6erg54
 # failJSON: { "time": "2013-07-06T09:09:25", "match": true , "host": "141.255.164.106" }
 [2013-07-06 09:09:25] SECURITY[3308] res_security_log.c: SecurityEvent="InvalidPassword",EventTV="1373098165-824497",Severity="Error",Service="SIP",EventVersion="2",AccountID="972592891005",SessionID="0x88aab6c",LocalAddress="IPV4/UDP/92.28.73.180/5060",RemoteAddress="IPV4/UDP/141.255.164.106/5084",Challenge="41d26de5",ReceivedChallenge="41d26de5",ReceivedHash="7a6a3a2e95a05260aee612896e1b4a39"
+
+# failJSON: { "time": "2013-11-11T14:33:38", "match": true , "host": "192.168.55.152" }
+[2013-11-11 14:33:38] WARNING[6756][C-0000001d] Ext. s: "Rejecting unknown SIP connection from 192.168.55.152"


### PR DESCRIPTION
...ng unknown SIP connection from <HOST>" regex thanks to Jonathan Lanning
