### PR TITLE
BF: remove broken failcheck on firewall-cmd-direct-new filter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ ver. 0.8.12 (2013/12/XX) - things-can-only-get-better
   - allow for ", referer ..." in apache-* filter for apache error logs.
   - allow for spaces at the beginning of kernel messages. Closes gh-448
   - recidive jail to block all protocols. Closes gh-440. Thanks Ioan Indreias
+  - remove failcheck in firewall-cmd-direct-new action. Thanks Joel (gh-395)
 
 - New Features:
 

--- a/THANKS
+++ b/THANKS
@@ -36,6 +36,7 @@ Hanno 'Rince' Wagner
 Iain Lea
 Jacques Lav!gnotte
 Ioan Indreias
+Joel
 Jonathan Kamens
 Jonathan Lanning
 Jonathan Underwood

--- a/config/action.d/firewall-cmd-direct-new.conf
+++ b/config/action.d/firewall-cmd-direct-new.conf
@@ -20,8 +20,6 @@ actionstop = firewall-cmd --direct --remove-rule ipv4 filter <chain> 0 -m state 
              firewall-cmd --direct --remove-rules ipv4 filter fail2ban-<name>
              firewall-cmd --direct --remove-chain ipv4 filter fail2ban-<name>
 
-actioncheck = firewall-cmd --direct --get-chains ipv4 filter | grep -q 'fail2ban-<name>[ \t]'
-
 actionban = firewall-cmd --direct --add-rule ipv4 filter fail2ban-<name> 0 -s <ip> -j <blocktype>
 
 actionunban = firewall-cmd --direct --remove-rule ipv4 filter fail2ban-<name> 0 -s <ip> -j <blocktype>


### PR DESCRIPTION
as mentioned in #395 I don't think actioncheck performs a useful role here. It executes a shell and two processes to verify if the one actionban command will work. Running the actionban command is sufficient.
