### PR TITLE
DOC: document rational behind 20 character jail name limit

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,8 @@ ver. 0.8.12 (2013/12/XX) - things-can-only-get-better
   - allow for ", referer ..." in apache-* filter for apache error logs.
   - allow for spaces at the beginning of kernel messages. Closes gh-448
   - recidive jail to block all protocols. Closes gh-440. Thanks Ioan Indreias
+  - long names on jails documented based on iptables limit of 30 less
+    len("fail2ban-").
 
 - New Features:
 

--- a/server/jail.py
+++ b/server/jail.py
@@ -102,9 +102,11 @@ class Jail:
 		self.__filter = FilterPyinotify(self)
 	
 	def setName(self, name):
+		# 20 based on iptable chain name limit of 30 less len('fail2ban-')
 		if len(name) >= 20:
-			logSys.warning("Jail name %r might be too long and some commands "
-							"might not function correctly. Please shorten"
+			logSys.warning("Jail name %r might be too long and some commands"
+							" (e.g. iptables) might not function correctly."
+							" Please shorten"
 							% name)
 		self.__name = name
 	


### PR DESCRIPTION
took a bit of finding but from #222 the chain limit is 30 but "fail2ban-" is used in the creation of chains so 20 is reasonable. Better document this.

http://blog.yo61.com/length-limit-to-iptables-chain-names/
