### PR TITLE
BF: files/redhat-initd from upstream

### DIFF
--- a/files/redhat-initd
+++ b/files/redhat-initd
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# chkconfig: 345 92 08
+# chkconfig: - 92 08
 # processname: fail2ban-server
 # config: /etc/fail2ban/fail2ban.conf
 # pidfile: /var/run/fail2ban/fail2ban.pid


### PR DESCRIPTION
from: http://pkgs.fedoraproject.org/cgit/fail2ban.git/tree/fail2ban-init.patch
