### PR TITLE
Add option to addlogpath for tail option

### DIFF
--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -151,12 +151,15 @@ class JailReader(ConfigReader):
 					self.__opts.get('backend', None) != "systemd":
 				found_files = 0
 				for path in self.__opts[opt].split("\n"):
+					path = path.rsplit(" ", 1)
+					path, tail = path if len(path) > 1 else (path[0], "false")
 					pathList = JailReader._glob(path)
 					if len(pathList) == 0:
 						logSys.error("No file(s) found for glob %s" % path)
 					for p in pathList:
 						found_files += 1
-						stream.append(["set", self.__name, "addlogpath", p])
+						stream.append(
+							["set", self.__name, "addlogpath", p, tail])
 				if not (found_files or allow_no_files):
 					raise ValueError(
 						"Have not found any log file for %s jail" % self.__name)

--- a/fail2ban/protocol.py
+++ b/fail2ban/protocol.py
@@ -58,7 +58,7 @@ protocol = [
 ["set <JAIL> idle on|off", "sets the idle state of <JAIL>"], 
 ["set <JAIL> addignoreip <IP>", "adds <IP> to the ignore list of <JAIL>"], 
 ["set <JAIL> delignoreip <IP>", "removes <IP> from the ignore list of <JAIL>"], 
-["set <JAIL> addlogpath <FILE>", "adds <FILE> to the monitoring list of <JAIL>"], 
+["set <JAIL> addlogpath <FILE> ['tail']", "adds <FILE> to the monitoring list of <JAIL>, optionally starting at the 'tail' of the file (default 'head')."], 
 ["set <JAIL> dellogpath <FILE>", "removes <FILE> from the monitoring list of <JAIL>"],
 ["set <JAIL> logencoding <ENCODING>", "sets the <ENCODING> of the log files for <JAIL>"],
 ["set <JAIL> addjournalmatch <MATCH>", "adds <MATCH> to the journal filter of <JAIL>"],

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -175,10 +175,10 @@ class Server:
 	def getIgnoreIP(self, name):
 		return self.__jails.getFilter(name).getIgnoreIP()
 	
-	def addLogPath(self, name, fileName):
+	def addLogPath(self, name, fileName, tail=False):
 		filter_ = self.__jails.getFilter(name)
 		if isinstance(filter_, FileFilter):
-			filter_.addLogPath(fileName)
+			filter_.addLogPath(fileName, tail)
 	
 	def delLogPath(self, name, fileName):
 		filter_ = self.__jails.getFilter(name)

--- a/fail2ban/server/transmitter.py
+++ b/fail2ban/server/transmitter.py
@@ -149,9 +149,16 @@ class Transmitter:
 			self.__server.delIgnoreIP(name, value)
 			return self.__server.getIgnoreIP(name)
 		elif command[1] == "addlogpath":
-			value = command[2:]
-			for path in value:
-				self.__server.addLogPath(name, path)
+			value = command[2]
+			tail = False
+			if len(command) == 4:
+				if command[3].lower()  == "tail":
+					tail = True
+				elif command[3].lower() != "head":
+					raise ValueError("File option must be 'head' or 'tail'")
+			elif len(command) > 4:
+				raise ValueError("Only one file can be added at a time")
+			self.__server.addLogPath(name, value, tail)
 			return self.__server.getLogPath(name)
 		elif command[1] == "dellogpath":
 			value = command[2]

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -357,6 +357,22 @@ class Transmitter(TransmitterBase):
 		self.assertEqual(
 			self.transm.proceed(["set", self.jailName, "dellogpath", value]),
 			(0, []))
+		self.assertEqual(
+			self.transm.proceed(
+				["set", self.jailName, "addlogpath", value, "tail"]),
+			(0, [value]))
+		self.assertEqual(
+			self.transm.proceed(
+				["set", self.jailName, "addlogpath", value, "head"]),
+			(0, [value]))
+		self.assertEqual(
+			self.transm.proceed(
+				["set", self.jailName, "addlogpath", value, "badger"])[0],
+			1)
+		self.assertEqual(
+			self.transm.proceed(
+				["set", self.jailName, "addlogpath", value, value, value])[0],
+			1)
 
 	def testJailLogPathInvalidFile(self):
 		# Invalid file

--- a/man/jail.conf.5
+++ b/man/jail.conf.5
@@ -67,6 +67,7 @@ The following options are applicable to all jails. Their meaning is described in
 \fBfilter\fR 
 .TP
 \fBlogpath\fR 
+Specify one or more log files for monitoring for failures, separated by new lines. Optional space separated option 'tail' can be added to the end of the path to cause the log file to be read from the end, else default 'head' option reads file from the beginning
 .TP
 \fBaction\fR 
 .TP


### PR DESCRIPTION
Just a quickish fix for making use of the tail option in `FileFilter.addLogPath`. Needs some documentation, but just wanted feedback on the proposed syntax of adding _yes_, _true_ or _tail_ space separated on the end of the log file name?
