### PR TITLE
TST: for tag substition, multiple on same line

### DIFF
--- a/testcases/actiontestcase.py
+++ b/testcases/actiontestcase.py
@@ -60,6 +60,13 @@ class ExecuteAction(LogCaptureTestCase):
 		self.assertEqual(Action.substituteRecursiveTags({'A': '<C>'}), {'A': '<C>'})
 		self.assertEqual(Action.substituteRecursiveTags({'A': '<C> <D> <X>','X':'fun'}), {'A': '<C> <D> fun', 'X':'fun'})
 		self.assertEqual(Action.substituteRecursiveTags({'A': '<C> <B>', 'B': 'cool'}), {'A': '<C> cool', 'B': 'cool'})
+		# Multiple stuff on same line is ok
+		self.assertEqual(Action.substituteRecursiveTags({'failregex': 'to=<honeypot> fromip=<IP> evilperson=<honeypot>', 'honeypot': 'pokie', 'ignoreregex': ''}),
+								{ 'failregex': "to=pokie fromip=<IP> evilperson=pokie",
+								  'honeypot': 'pokie',
+								  'ignoreregex': '',
+								})
+
 		# rest is just cool
 		self.assertEqual(Action.substituteRecursiveTags(aInfo),
 								{ 'HOST': "192.0.2.0",


### PR DESCRIPTION
due to the fault discovered in 0.9 this is the same test case for master.
