### PR TITLE
ENH: dont run samples on filter filenames beginning with .

### DIFF
--- a/fail2ban/tests/samplestestcase.py
+++ b/fail2ban/tests/samplestestcase.py
@@ -151,7 +151,8 @@ def testSampleRegexsFactory(name):
 
 for filter_ in filter(lambda x: not x.endswith('common.conf'), os.listdir(os.path.join(CONFIG_DIR, "filter.d"))):
 	filterName = filter_.rpartition(".")[0]
-	setattr(
-		FilterSamplesRegex,
-		"testSampleRegexs%s" % filterName.upper(),
-		testSampleRegexsFactory(filterName))
+	if not filterName.startswith('.'):
+		setattr(
+			FilterSamplesRegex,
+			"testSampleRegexs%s" % filterName.upper(),
+			testSampleRegexsFactory(filterName))


### PR DESCRIPTION
Got annoyed with test cases failing because I've got vi with a filter open and all of a sudden there is no log samples for .horde.conf
