### PR TITLE
Support ACL-events without AccountID. Typically happens when a registrat...

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -53,6 +53,7 @@ ver. 0.8.12 (2013/12/XX) - things-can-only-get-better
   - Added to sshd filter expression for "Received disconnect from <HOST>: 3:
     ...: Auth fail". Thanks Marcel Dopita. Closes gh-289
   - Added filter.d/ejabberd-auth
+  - Improved ACL-handling for Asterisk
 
 - New Features:
 

--- a/THANKS
+++ b/THANKS
@@ -80,6 +80,7 @@ Stefan Tatschner
 Stephen Gildea
 Steven Hiscocks
 Tom Pike
+Tomas Pihl
 Tyler
 Vaclav Misek
 Vincent Deffontaines

--- a/config/filter.d/asterisk.conf
+++ b/config/filter.d/asterisk.conf
@@ -15,7 +15,7 @@ failregex = ^%(log_prefix)s Registration from '[^']*' failed for '<HOST>(:\d+)?'
             ^%(log_prefix)s Host <HOST> failed MD5 authentication for '[^']*' \([^)]+\)$
             ^%(log_prefix)s Failed to authenticate (user|device) [^@]+@<HOST>\S*$
             ^%(log_prefix)s (?:handle_request_subscribe: )?Sending fake auth rejection for (device|user) \d*<sip:[^@]+@<HOST>>;tag=\w+\S*$
-            ^%(log_prefix)s SecurityEvent="(FailedACL|InvalidAccountID|ChallengeResponseFailed|InvalidPassword)",EventTV="[\d-]+",Severity="[\w]+",Service="[\w]+",EventVersion="\d+",AccountID="\d+",SessionID="0x[\da-f]+",LocalAddress="IPV[46]/(UD|TC)P/[\da-fA-F:.]+/\d+",RemoteAddress="IPV[46]/(UD|TC)P/<HOST>/\d+"(,Challenge="\w+",ReceivedChallenge="\w+")?(,ReceivedHash="[\da-f]+")?$
+            ^%(log_prefix)s SecurityEvent="(FailedACL|InvalidAccountID|ChallengeResponseFailed|InvalidPassword)",EventTV="[\d-]+",Severity="[\w]+",Service="[\w]+",EventVersion="\d+",AccountID="\d*",SessionID="0x[\da-f]+",LocalAddress="IPV[46]/(UD|TC)P/[\da-fA-F:.]+/\d+",RemoteAddress="IPV[46]/(UD|TC)P/<HOST>/\d+"(,Challenge="\w+",ReceivedChallenge="\w+")?(,ReceivedHash="[\da-f]+")?(,ACLName="\w+")?$
             ^\[\]\s*WARNING%(__pid_re)s:?(?:\[C-[\da-f]*\])? Ext\. s: "Rejecting unknown SIP connection from <HOST>"$
 
 ignoreregex =

--- a/testcases/files/logs/asterisk
+++ b/testcases/files/logs/asterisk
@@ -40,6 +40,8 @@
 [2009-12-22 16:35:24] NOTICE[14916]: chan_sip.c:15644 handle_request_subscribe: Sending fake auth rejection for user <sip:CS@192.168.2.102>;tag=6pwd6erg54
 # failJSON: { "time": "2013-07-06T09:09:25", "match": true , "host": "141.255.164.106" }
 [2013-07-06 09:09:25] SECURITY[3308] res_security_log.c: SecurityEvent="InvalidPassword",EventTV="1373098165-824497",Severity="Error",Service="SIP",EventVersion="2",AccountID="972592891005",SessionID="0x88aab6c",LocalAddress="IPV4/UDP/92.28.73.180/5060",RemoteAddress="IPV4/UDP/141.255.164.106/5084",Challenge="41d26de5",ReceivedChallenge="41d26de5",ReceivedHash="7a6a3a2e95a05260aee612896e1b4a39"
+# failJSON: { "time": "2014-01-10T16:39:06", "match": true , "host": "50.30.42.14" }
+[2014-01-10 16:39:06] SECURITY[1503] res_security_log.c: SecurityEvent="FailedACL",EventTV="1389368346-880526",Severity="Error",Service="SIP",EventVersion="1",AccountID="",SessionID="0x7ff408103b18",LocalAddress="IPV4/UDP/83.11.20.23/5060",RemoteAddress="IPV4/UDP/50.30.42.14/5066",ACLName="domain_must_match"
 
 # failJSON: { "time": "2013-11-11T14:33:38", "match": true , "host": "192.168.55.152" }
 [2013-11-11 14:33:38] WARNING[6756][C-0000001d] Ext. s: "Rejecting unknown SIP connection from 192.168.55.152"


### PR DESCRIPTION
...ion from an unknown domain is performed.
