### PR TITLE
BF: Dovecot auth failures

### DIFF
--- a/testcases/files/logs/dovecot
+++ b/testcases/files/logs/dovecot
@@ -42,3 +42,9 @@ Jul 02 13:49:32 hostname dovecot[442]: dovecot: auth(default): pam(account@MYSER
 # failJSON: { "time": "2005-04-19T05:22:20", "match": true , "host": "80.255.3.104" }
 Apr 19 05:22:20 vm5 auth: pam_unix(dovecot:auth): authentication failure; logname= uid=0 euid=0 tty=dovecot ruser=informix rhost=80.255.3.104
 
+
+# failJSON: { "time": "2014-01-13T20:51:05", "match": true , "host": "1.2.3.4" }
+Jan 13 20:51:05 valhalla dovecot: pop3-login: Disconnected: Inactivity (auth failed, 1 attempts in 178 secs): user=<ivo>, method=PLAIN, rip=1.2.3.4, lip=1.1.2.2, session=<6brQWt/vCADDhP/+>
+# failJSON: { "time": "2014-01-14T15:54:30", "match": true , "host": "1.2.3.4" }
+Jan 14 15:54:30 valhalla dovecot: pop3-login: Disconnected (auth failed, 1 attempts in 2 secs): user=<ivo>, method=PLAIN, rip=1.2.3.4, lip=1.1.2.2, TLS: Disconnected, session=<q454Xu/vMwBZApgg>
+


### PR DESCRIPTION
I am sorry, I installed the Win GIT, but still did not learn how to work with it, so am posting here again. This time, I'll avoid posting two pull requests, so please fix the dovecot.filter for me, if you don't mind.

The current filter does not match authentication errors in my Dovecot logs (two different lines attached). First of all, the session string is at the end (after the optional TLS string), and not in front of it, as it is now in the filter. I don't see it anywhere in the other logs here, in the opposite order, hence I assume it is the rule for all installations. And then, the session ID can include also other characters than those matched by \w+ (i.e. the slash and the plus signs in my case), hence it needs to be \S+ instead. Personally, I'd do the regex much simpler and less restrictive than it is, but if I follow the current logics, the following form works:

<pre>^%(__prefix_line)s(pop3|imap)-login: (Info: )?(Aborted login|Disconnected)(: Inactivity)? \(((no auth attempts|auth failed, \d+ attempts)( in \d+ secs)?|tried to use disabled \S+ auth)\):( user=&lt;\S*&gt;,)?( method=\S+,)? rip=&lt;HOST&gt;, lip=(\d{1,3}\.){3}\d{1,3}(, TLS( handshaking)?(: Disconnected)?)?(, session=&lt;\S+&gt;)?\s*$</pre>
