### PR TITLE
ENH: Warn when multiline regex used when maxlines not greater than 1

### DIFF
--- a/fail2ban/client/filterreader.py
+++ b/fail2ban/client/filterreader.py
@@ -61,7 +61,9 @@ class FilterReader(DefinitionInitConfigReader):
 						stream.append(["set", self._jailName, "addignoreregex", regex])		
 		if self._initOpts:
 			if 'maxlines' in self._initOpts:
-				stream.append(["set", self._jailName, "maxlines", self._initOpts["maxlines"]])
+				# We warn when multiline regex is used without maxlines > 1
+				# therefore keep sure we set this option first.
+				stream.insert(0, ["set", self._jailName, "maxlines", self._initOpts["maxlines"]])
 			if 'datepattern' in self._initOpts:
 				stream.append(["set", self._jailName, "datepattern", self._initOpts["datepattern"]])
 			# Do not send a command if the match is empty.

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -95,6 +95,10 @@ class Filter(JailThread):
 		try:
 			regex = FailRegex(value)
 			self.__failRegex.append(regex)
+			if "\n" in regex.getRegex() and not self.getMaxLines() > 1:
+				logSys.warning(
+					"Mutliline regex set for jail '%s' "
+					"but maxlines not greater than 1")
 		except RegexException, e:
 			logSys.error(e)
 			raise e


### PR DESCRIPTION
Helpful warning, as per #615
