### PR TITLE
Changes to --print-* options and memory use for fail2ban-regex

### DIFF
--- a/fail2ban-regex
+++ b/fail2ban-regex
@@ -182,7 +182,7 @@ class Fail2banRegex(object):
 	def __init__(self, opts):
 		self._verbose = opts.verbose
 		self._debuggex = opts.debuggex
-                self._maxlines = 20
+		self._maxlines = 20
 		self._print_no_missed = opts.print_no_missed
 		self._print_no_ignored = opts.print_no_ignored
 		self._print_all_missed = opts.print_all_missed
@@ -371,6 +371,14 @@ if __name__ == "__main__":
 
 	parser = get_opt_parser()
 	(opts, args) = parser.parse_args()
+	if opts.print_no_missed and opts.print_all_missed:
+		sys.stderr.write("ERROR: --print-no-missed and --print-all-missed are mutually exclusive.\n\n")
+		parser.print_help()
+	        sys.exit(-1)
+	if opts.print_no_ignored and opts.print_all_ignored:
+		sys.stderr.write("ERROR: --print-no-ignored and --print-all-ignored are mutually exclusive.\n\n")
+		parser.print_help()
+	        sys.exit(-1)
 
 	fail2banRegex = Fail2banRegex(opts)
 


### PR DESCRIPTION
This supercedes the issue/patch I submitted via SF earlier today (https://sourceforge.net/p/fail2ban/patches/25/)

fail2ban-regex accumulated all missed & ignored messages into RAM even if they will not be printed because --print-all-{ignored,missed} was not set.  These patches cause it to only save lines if it is going to need to print them.

Also, added --print-no-{ignored,missed} command-line options, so that fail2ban-regex can be told not to bother printing them at all.

Also tweaked the usage text to (hopefully) make the behavior/purpose of the --print-all-\* flags a bit more clear.
