### PR TITLE
Removed challenge from regex

### DIFF
--- a/config/filter.d/freeswitch.conf
+++ b/config/filter.d/freeswitch.conf
@@ -11,6 +11,7 @@
 [Definition]
 
 failregex = ^\.\d+ \[WARNING\] sofia_reg\.c:\d+ SIP auth failure \((REGISTER|INVITE)\) on sofia profile \'[^']+\' for \[.*\] from ip <HOST>$
+            ^\.\d+ \[WARNING\] sofia_reg\.c:\d+ SIP auth challenge \((INVITE)\) on sofia profile \'[^']+\' for \[.*\] from ip <HOST>$
             ^\.\d+ \[WARNING\] sofia_reg\.c:\d+ Can't find user \[\d+@\d+\.\d+\.\d+\.\d+\] from <HOST>$
 
 ignoreregex =

--- a/config/filter.d/freeswitch.conf
+++ b/config/filter.d/freeswitch.conf
@@ -10,7 +10,7 @@
 
 [Definition]
 
-failregex = ^\.\d+ \[WARNING\] sofia_reg\.c:\d+ SIP auth (failure|challenge) \((REGISTER|INVITE)\) on sofia profile \'[^']+\' for \[.*\] from ip <HOST>$
+failregex = ^\.\d+ \[WARNING\] sofia_reg\.c:\d+ SIP auth failure \((REGISTER|INVITE)\) on sofia profile \'[^']+\' for \[.*\] from ip <HOST>$
             ^\.\d+ \[WARNING\] sofia_reg\.c:\d+ Can't find user \[\d+@\d+\.\d+\.\d+\.\d+\] from <HOST>$
 
 ignoreregex =


### PR DESCRIPTION
A challenge is just a request being made not if it was successful or not. SIP auth challenges should only be checked for in a DOS filter.
