### PR TITLE
add ignoreregex to avoid startup warning

### DIFF
--- a/config/filter.d/postfix-sasl.conf
+++ b/config/filter.d/postfix-sasl.conf
@@ -11,4 +11,7 @@ _daemon = postfix/smtpd
 
 failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL (?:LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/]*={0,2})?\s*$
 
+ignoreregex =
+
+
 # Author: Yaroslav Halchenko


### PR DESCRIPTION
Fail2ban throws a startup warning that ignoreregex is missing if postfix-sasl filter is used.
