### PR TITLE
BF: Handle case when inotify watch is auto deleted on file deletion

### DIFF
--- a/server/filterpyinotify.py
+++ b/server/filterpyinotify.py
@@ -90,6 +90,9 @@ class FilterPyinotify(FileFilter):
 				self._delFileWatcher(path)
 				# place a new one
 				self._addFileWatcher(path)
+		elif event.mask & pyinotify.IN_IGNORED:
+			# Caused when watch removed, either by rm_watch or file deletion
+			return
 
 		self._process_file(path)
 
@@ -118,9 +121,11 @@ class FilterPyinotify(FileFilter):
 
 	def _delFileWatcher(self, path):
 		wdInt = self.__watches[path]
-		wd = self.__monitor.rm_watch(wdInt)
-		if wd[wdInt]:
-			del self.__watches[path]
+		if wdInt is None:
+			return False
+		elif self.__monitor.get_path(wdInt) is None or \
+			self.__monitor.rm_watch(wdInt)[wdInt]:
+			self.__watches[path] = None
 			logSys.debug("Removed file watcher for %s", path)
 			return True
 		else:
@@ -151,6 +156,7 @@ class FilterPyinotify(FileFilter):
 	def _delLogPath(self, path):
 		if not self._delFileWatcher(path):
 			logSys.error("Failed to remove watch on path: %s", path)
+		del self.__watches[path]
 
 		path_dir = dirname(path)
 		if not len([k for k in self.__watches


### PR DESCRIPTION
When a file is deleted, the watcher for it is automatically removed.
FilterPyinotify is detecting a new file being created with the same
name, and in turn attempts to remove the watch for the deleted file
(which has already been removed automatically).

Also, IN_IGNORED events are generated when a file is deleted, but these
weren't being caught, causing an non-existent file path to be passed to
FilterPyinotify._process_file (which caught the exceptions in
Filter.getFailures).

Closes #660
