### PR TITLE
nginx-http-auth filter: match server_name = ""

### DIFF
--- a/config/filter.d/nginx-http-auth.conf
+++ b/config/filter.d/nginx-http-auth.conf
@@ -4,7 +4,7 @@
 [Definition]
 
 
-failregex = ^ \[error\] \d+#\d+: \*\d+ user "\S+":? (password mismatch|was not found in ".*"), client: <HOST>, server: \S+, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"\s*$
+failregex = ^ \[error\] \d+#\d+: \*\d+ user "\S+":? (password mismatch|was not found in ".*"), client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"\s*$
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/nginx-http-auth
+++ b/fail2ban/tests/files/logs/nginx-http-auth
@@ -3,4 +3,6 @@
 2012/04/09 11:53:29 [error] 2865#0: *66647 user "xyz" was not found in "/var/www/.htpasswd", client: 192.0.43.10, server: www.myhost.com, request: "GET / HTTP/1.1", host: "www.myhost.com"
 # failJSON: { "time": "2012-04-09T11:53:36", "match": true , "host": "192.0.43.10" }
 2012/04/09 11:53:36 [error] 2865#0: *66647 user "xyz": password mismatch, client: 192.0.43.10, server: www.myhost.com, request: "GET / HTTP/1.1", host: "www.myhost.com"
+# failJSON: { "time": "2014-04-01T22:20:38", "match": true, "host": "10.0.2.2" }
+2014/04/01 22:20:38 [error] 30708#0: *3 user "scribendio": password mismatch, client: 10.0.2.2, server: , request: "GET / HTTP/1.1", host: "localhost:8443"
 


### PR DESCRIPTION
As documented at http://nginx.org/en/docs/http/server_names.html#miscellaneous_names "If no server_name is defined in a server block then nginx uses the empty name as the server name." This regex change allows us to match error output for such a configuration.
