### PR TITLE
nginx-http-auth: match when "referrer" is present

### DIFF
--- a/config/filter.d/nginx-http-auth.conf
+++ b/config/filter.d/nginx-http-auth.conf
@@ -4,7 +4,7 @@
 [Definition]
 
 
-failregex = ^ \[error\] \d+#\d+: \*\d+ user "\S+":? (password mismatch|was not found in ".*"), client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"\s*$
+failregex = ^ \[error\] \d+#\d+: \*\d+ user "\S+":? (password mismatch|was not found in ".*"), client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"(, referrer: "\S+")?$
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/nginx-http-auth
+++ b/fail2ban/tests/files/logs/nginx-http-auth
@@ -5,4 +5,6 @@
 2012/04/09 11:53:36 [error] 2865#0: *66647 user "xyz": password mismatch, client: 192.0.43.10, server: www.myhost.com, request: "GET / HTTP/1.1", host: "www.myhost.com"
 # failJSON: { "time": "2014-04-01T22:20:38", "match": true, "host": "10.0.2.2" }
 2014/04/01 22:20:38 [error] 30708#0: *3 user "scribendio": password mismatch, client: 10.0.2.2, server: , request: "GET / HTTP/1.1", host: "localhost:8443"
+# failJSON: { "time": "2014-04-02T12:37:58", "match": true, "host": "10.0.2.2" }
+2014/04/02 12:37:58 [error] 6563#0: *1861 user "scribendio": password mismatch, client: 10.0.2.2, server: scribend.io, request: "GET /admin HTTP/1.1", host: "scribend.io", referrer: "https://scribend.io/admin"
 


### PR DESCRIPTION
I think this was broken by ac061155f093464fb6cd2329d3d513b15c68e256 which introduced the anchor at the end of the line, so that log lines with a "referrer" at the end would no longer match.

Please note that I'm fairly inexperienced with regexes, and very inexperienced with defensively designing them - I'd be grateful if you give my change an extra look, to be sure I'm not introducing any vulnerabilities.
