### PR TITLE
BF: grep in mail*-whois-lines.conf also matches end of line to work with the recidive filter (Debian #744774)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@ ver. 0.8.14 (2014/??/??) - take-care-of-the-elderly
 
 - Fixes:
   - minor fixes for claimed Python 2.4 and 2.5 compatibility
+  - grep in mail*-whois-lines.conf now also matches end of line to work
+    with the recidive filter
 
 
 ver. 0.8.13 (2014/03/15) - maintenance-only-from-now-on

--- a/config/action.d/mail-whois-lines.conf
+++ b/config/action.d/mail-whois-lines.conf
@@ -42,7 +42,7 @@ actionban = printf %%b "Hi,\n
             Here is more information about <ip>:\n
             `whois <ip> || echo missing whois program`\n\n
             Lines containing IP:<ip> in <logpath>\n
-            `grep '[^0-9]<ip>[^0-9]' <logpath>`\n\n
+            `grep -E '(^|[^0-9])<ip>([^0-9]|$)' <logpath>`\n\n
             Regards,\n
             Fail2Ban"|mail -s "[Fail2Ban] <name>: banned <ip> from  `uname -n`" <dest>
 

--- a/config/action.d/sendmail-whois-lines.conf
+++ b/config/action.d/sendmail-whois-lines.conf
@@ -58,7 +58,7 @@ actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Here is more information about <ip>:\n
             `/usr/bin/whois <ip> || echo missing whois program`\n\n
             Lines containing IP:<ip> in <logpath>\n
-            `grep '[^0-9]<ip>[^0-9]' <logpath>`\n\n
+            `grep -E '(^|[^0-9])<ip>([^0-9]|$)' <logpath>`\n\n
             Regards,\n
             Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
 


### PR DESCRIPTION
Thanks James Bottomley for the report and tentative solutions
