### PR TITLE
BF(2.5): add minimal_python key to failJSON and skip some test lines.

### DIFF
--- a/testcases/files/logs/apache-auth
+++ b/testcases/files/logs/apache-auth
@@ -17,65 +17,69 @@
 # failJSON: { "time": "2013-07-17T23:20:45", "match": true , "host": "127.0.0.1" } 
 [Wed Jul 17 23:20:45 2013] [error] [client 127.0.0.1] client denied by server configuration: /var/www/html/noentry/cant_get_me.html
 
-# failJSON: { "time": "2013-07-20T21:34:49", "match": true , "host": "127.0.0.1" } 
+# failJSON: { "time": "2013-07-20T21:34:49", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sat Jul 20 21:34:49.453232 2013] [access_compat:error] [pid 17512:tid 140123104306944] [client 127.0.0.1:51380] AH01797: client denied by server configuration: /var/www/html/noentry/cant_get_me.html
 
 # wget --http-user='' --http-password='' http://localhost/basic/file/cant_get_me.html -O /dev/null
 # failJSON: { "time": "2013-07-17T23:14:37", "match": true , "host": "127.0.0.1" }
 [Wed Jul 17 23:14:37 2013] [error] [client 127.0.0.1] user  not found: /basic/anon/cant_get_me.html
 
-# failJSON: { "time": "2013-07-20T21:37:32", "match": true , "host": "127.0.0.1" } 
+# failJSON: { "time": "2013-07-20T21:37:32", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sat Jul 20 21:37:32.266605 2013] [auth_basic:error] [pid 17512:tid 140123079128832] [client 127.0.0.1:51386] AH01618: user  not found: /basic/file/cant_get_me.html
 
 # wget --http-user=username --http-password=wrongpass http://localhost/basic/file -O /dev/null
 # failJSON: { "time": "2013-07-17T22:18:52", "match": true , "host": "127.0.0.1" }
 [Wed Jul 17 22:18:52 2013] [error] [client 127.0.0.1] user username: authentication failure for "/basic/file": Password Mismatch
 
-# failJSON: { "time": "2013-07-20T21:39:11", "match": true , "host": "127.0.0.1" } 
+# failJSON: { "time": "2013-07-20T21:39:11", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sat Jul 20 21:39:11.978080 2013] [auth_basic:error] [pid 17512:tid 140123053950720] [client 127.0.0.1:51390] AH01617: user username: authentication failure for "/basic/file": Password Mismatch
 
 # wget --http-user=wrongusername --http-password=wrongpass http://localhost/basic/file -O /dev/null
 # failJSON: { "time": "2013-07-17T22:32:48", "match": true , "host": "127.0.0.1" }
 [Wed Jul 17 22:32:48 2013] [error] [client 127.0.0.1] user wrongusername not found: /basic/file
 
-# failJSON: { "time": "2013-07-20T21:40:33", "match": true , "host": "127.0.0.1" } 
+# failJSON: { "time": "2013-07-20T21:40:33", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sat Jul 20 21:40:33.803528 2013] [auth_basic:error] [pid 17540:tid 140123095914240] [client 127.0.0.1:51395] AH01618: user wrongusername not found: /basic/file
 
 # wget --header='Authorization: Digest username="Mufasa",realm="testrealm@host.com",nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093",uri="/dir/index.html",qop=auth,nc=00000001,cnonce="0a4f113b",response="6629fae49393a05397450978507c4ef1",opaque="5ccc069c403ebaf9f0171e9517f40e41"'  http://localhost/basic/file -O /dev/null
 # failJSON: { "time": "2013-07-17T22:39:55", "match": true , "host": "127.0.0.1" }
 [Wed Jul 17 22:39:55 2013] [error] [client 127.0.0.1] client used wrong authentication scheme: /basic/file
 
-# failJSON: { "time": "2013-07-20T21:41:52", "match": true , "host": "127.0.0.1" } 
+# failJSON: { "time": "2013-07-20T21:41:52", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sat Jul 20 21:41:52.523931 2013] [auth_basic:error] [pid 17512:tid 140122964092672] [client 127.0.0.1:51396] AH01614: client used wrong authentication scheme: /basic/file
 
 # wget --http-user=username --http-password=password http://localhost/basic/authz_owner/cant_get_me.html -O /dev/null
 # failJSON: { "time": "2013-07-17T22:54:32", "match": true , "host": "127.0.0.1" }
 [Wed Jul 17 22:54:32 2013] [error] [client 127.0.0.1] Authorization of user username to access /basic/authz_owner/cant_get_me.html failed, reason: file owner dan does not match.
 
-# failJSON: { "time": "2013-07-20T22:11:43", "match": true , "host": "127.0.0.1" } 
+# failJSON: { "time": "2013-07-20T22:11:43", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sat Jul 20 22:11:43.147674 2013] [authz_owner:error] [pid 17540:tid 140122922129152] [client 127.0.0.1:51548] AH01637: Authorization of user username to access /basic/authz_owner/cant_get_me.html failed, reason: file owner dan does not match
 
 # wget --http-user=username --http-password=password http://localhost/basic/authz_owner/cant_get_me.html -O /dev/null
-# failJSON: { "time": "2013-07-20T21:42:44", "match": true , "host": "127.0.0.1" } 
+# failJSON: { "time": "2013-07-20T21:42:44", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sat Jul 20 21:42:44.304159 2013] [authz_core:error] [pid 17484:tid 140123095914240] [client 127.0.0.1:51397] AH01631: user username: authorization failure for "/basic/authz_owner/cant_get_me.html": 
+# failJSON: { "time": "2013-07-20T21:42:44", "match": true , "host": "127.0.0.1", "desc": "a version of previous case without subsec resolution" }
+[Sat Jul 20 21:42:44 2013] [authz_core:error] [pid 17484:tid 140123095914240] [client 127.0.0.1:51397] AH01631: user username: authorization failure for "/basic/authz_owner/cant_get_me.html":
 
 # wget --http-user='username' --http-password='wrongpassword' http://localhost/digest/cant_get_me.html -O /dev/null
 # failJSON: { "time": "2013-07-17T23:50:37", "match": true , "host": "127.0.0.1" }
 [Wed Jul 17 23:50:37 2013] [error] [client 127.0.0.1] Digest: user username: password mismatch: /digest/cant_get_me.html
 
-# failJSON: { "time": "2013-07-20T21:44:06", "match": true , "host": "127.0.0.1" } 
+# failJSON: { "time": "2013-07-20T21:44:06", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sat Jul 20 21:44:06.867985 2013] [auth_digest:error] [pid 17540:tid 140123070736128] [client 127.0.0.1:51406] AH01792: user username: password mismatch: /digest/cant_get_me.html
 
 # wget --http-user='username' --http-password='password' http://localhost/digest_wrongrelm/cant_get_me.html -O /dev/null
 # failJSON: { "time": "2013-07-18T00:08:39", "match": true , "host": "127.0.0.1" }
 [Thu Jul 18 00:08:39 2013] [error] [client 127.0.0.1] Digest: user `username' in realm `digest private area' not found: /digest_wrongrelm/cant_get_me.html
 
-# failJSON: { "time": "2013-07-20T21:45:28", "match": true , "host": "127.0.0.1" } 
+# failJSON: { "time": "2013-07-20T21:45:28", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sat Jul 20 21:45:28.890523 2013] [auth_digest:error] [pid 17540:tid 140122972485376] [client 127.0.0.1:51408] AH01790: user `username' in realm `digest private area' not found: /digest_wrongrelm/cant_get_me.html
 
 # ./testcases/files/config/apache-auth/digest.py
-# failJSON: { "time": "2013-07-28T21:05:31", "match": true , "host": "127.0.0.1" }
+# failJSON: { "time": "2013-07-28T21:05:31", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sun Jul 28 21:05:31.178340 2013] [auth_digest:error] [pid 24224:tid 139895539455744] [client 127.0.0.1:56906] AH01793: invalid qop `auth' received: /digest/qop_none/
+# failJSON: { "time": "2013-07-28T21:05:31", "match": true , "host": "127.0.0.1", "desc": "a version of previous case without subsec resolution" }
+[Sun Jul 28 21:05:31 2013] [auth_digest:error] [pid 24224:tid 139895539455744] [client 127.0.0.1:56906] AH01793: invalid qop `auth' received: /digest/qop_none/
 
 # ./testcases/files/config/apache-auth/digest.py
 # failJSON: { "time": "2013-07-28T21:12:44", "match": true , "host": "127.0.0.1" }
@@ -88,14 +92,14 @@
 [Sun Jul 28 21:16:37 2013] [error] [client 127.0.0.1] Digest: invalid nonce l19lgpDiBAZZZf1ec3d9613f3b3ef43660e3628d78455fd8b937 received - hash is not 6fda8bbcbcf85ff1ebfe7d1c43faba583bc53a02
 
 # ./testcases/files/config/apache-auth/digest.py
-# failJSON: { "time": "2013-07-28T21:18:11", "match": false , "host": "127.0.0.1" }
+# failJSON: { "time": "2013-07-28T21:18:11", "match": false , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sun Jul 28 21:18:11.769228 2013] [auth_digest:error] [pid 24752:tid 139895505884928] [client 127.0.0.1:56964] AH01776: invalid nonce b9YAiJDiBAZZZ1b1abe02d20063ea3b16b544ea1b0d981c1bafe received - hash is not d42d824dee7aaf50c3ba0a7c6290bd453e3dd35b
 
 # ./testcases/files/config/apache-auth/digest.py
 # failJSON: { "time": "2013-07-28T21:30:02", "match": true , "host": "127.0.0.1" }
 [Sun Jul 28 21:30:02 2013] [error] [client 127.0.0.1] Digest: realm mismatch - got `so far away' but expected `digest private area'
 
-# failJSON: { "time": "2013-07-28T21:27:56", "match": true , "host": "127.0.0.1" }
+# failJSON: { "time": "2013-07-28T21:27:56", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sun Jul 28 21:27:56.549667 2013] [auth_digest:error] [pid 24835:tid 139895297222400] [client 127.0.0.1:57052] AH01788: realm mismatch - got `so far away' but expected `digest private area'
 
 
@@ -103,14 +107,14 @@
 # failJSON: { "time": "2013-07-28T21:41:20", "match": true , "host": "127.0.0.1" }
 [Sun Jul 28 21:41:20 2013] [error] [client 127.0.0.1] Digest: unknown algorithm `super funky chicken' received: /digest/
 
-# failJSON: { "time": "2013-07-28T21:42:03", "match": true , "host": "127.0.0.1" }
+# failJSON: { "time": "2013-07-28T21:42:03", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Sun Jul 28 21:42:03.930190 2013] [auth_digest:error] [pid 24835:tid 139895505884928] [client 127.0.0.1:57115] AH01789: unknown algorithm `super funky chicken' received: /digest/
 
 # ./testcases/files/config/apache-auth/digest.py
 # failJSON: { "time": "2013-07-29T02:15:26", "match": true , "host": "127.0.0.1" }
 [Mon Jul 29 02:15:26 2013] [error] [client 127.0.0.1] Digest: invalid nonce LWEDr5TiBAA=ceddd011628c30e3646f7acda4f1a0ab6b7c5ae6 received - user attempted time travel
 
-# failJSON: { "time": "2013-07-29T02:12:55", "match": true , "host": "127.0.0.1" }
+# failJSON: { "time": "2013-07-29T02:12:55", "match": true , "host": "127.0.0.1", "minimal_python": "2.6" }
 [Mon Jul 29 02:12:55.539813 2013] [auth_digest:error] [pid 9647:tid 139895522670336] [client 127.0.0.1:58474] AH01777: invalid nonce 59QJppTiBAA=b08983fd166ade9840407df1b0f75b9e6e07d88d received - user attempted time travel
 
 # failJSON: { "time": "2013-06-01T02:17:42", "match": true , "host": "192.168.0.2" }

--- a/testcases/files/logs/apache-nohome
+++ b/testcases/files/logs/apache-nohome
@@ -2,5 +2,5 @@
 # failJSON: { "time": "2013-06-01T11:23:08", "match": true , "host": "1.2.3.4" }
 [Sat Jun 01 11:23:08 2013] [error] [client 1.2.3.4] File does not exist: /xxx/~
 # Apache 2.4
-# failJSON: { "time": "2013-06-27T11:55:44", "match": true , "host": "192.0.2.12" }
+# failJSON: { "time": "2013-06-27T11:55:44", "match": true , "host": "192.0.2.12", "minimal_python": "2.6" }
 [Thu Jun 27 11:55:44.569531 2013] [core:info] [pid 4101:tid 2992634688] [client 192.0.2.12:46652] AH00128: File does not exist: /xxx/~

--- a/testcases/files/logs/apache-noscript
+++ b/testcases/files/logs/apache-noscript
@@ -14,5 +14,5 @@
 # failJSON: { "time": "2008-07-22T06:48:30", "match": true , "host": "198.51.100.86" }
 [Tue Jul 22 06:48:30 2008] [error] [client 198.51.100.86] script not found or unable to stat: /home/e-smith/files/ibays/Primary/cgi-bin/php4
 # apache 2.4
-# failJSON: { "time": "2013-12-23T07:49:01", "match": true , "host": "204.232.202.107" }
+# failJSON: { "time": "2013-12-23T07:49:01", "match": true , "host": "204.232.202.107", "minimal_python": "2.6" }
 [Mon Dec 23 07:49:01.981912 2013] [:error] [pid 3790] [client 204.232.202.107:46301] script '/var/www/timthumb.php' not found or unable to stat

--- a/testcases/samplestestcase.py
+++ b/testcases/samplestestcase.py
@@ -25,7 +25,10 @@ __license__ = "GPL"
 import unittest, sys, os, fileinput, re, datetime, inspect
 from ConfigParser import InterpolationMissingOptionError
 
-if sys.version_info >= (2, 6):
+from distutils.version import LooseVersion
+python_version = LooseVersion(sys.version)
+
+if python_version >= "2.6":
 	import json
 else:
 	import simplejson as json
@@ -108,6 +111,10 @@ def testSampleRegexsFactory(name):
 				self.assertEqual(len(ret), 1, "Multiple regexs matched %r - %s:%i" %
 								 (map(lambda x: x[0], ret),logFile.filename(), logFile.filelineno()))
 
+				# Some dates matching might not be supported on by a given Python
+				if python_version < str(faildata.get("minimal_python", "2")):
+					print "Skipped testing the date for line #%s" % (line,)
+					continue # skipping this test
 				# Verify timestamp and host as expected
 				failregex, host, time = ret[0]
 				self.assertEqual(host, faildata.get("host", None))


### PR DESCRIPTION
with date format which includes sub-seconds

For tests to pass also duplicated representative ones just without subsec timing
