### PR TITLE
TST: skip the test if a known problem with Python 2.6 is detected

### DIFF
--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -530,11 +530,27 @@ class Transmitter(TransmitterBase):
 
 	def testPythonActionMethodsAndProperties(self):
 		action = "TestCaseAction"
-		self.assertEqual(
-			self.transm.proceed(["set", self.jailName, "addaction", action,
-				os.path.join(TEST_FILES_DIR, "action.d", "action.py"),
-				'{"opt1": "value"}']),
-			(0, action))
+		try:
+			out = self.transm.proceed(
+				["set", self.jailName, "addaction", action,
+				 os.path.join(TEST_FILES_DIR, "action.d", "action.py"),
+				'{"opt1": "value"}'])
+			self.assertEqual(out, (0, action))
+		except AssertionError:
+			if ((2, 6) <= sys.version_info < (2, 6, 5)) \
+				and '__init__() keywords must be strings' in out[1]:
+				# known issue http://bugs.python.org/issue2646 in 2.6 series
+				# since general Fail2Ban warnings are suppressed in normal
+				# operation -- let's issue Python's native warning here
+				import warnings
+				warnings.warn(
+					"Your version of Python %s seems to experience a known "
+					"issue forbidding correct operation of Fail2Ban: "
+					"http://bugs.python.org/issue2646  Upgrade your Python and "
+					"meanwhile other intestPythonActionMethodsAndProperties will "
+					"be skipped" % (sys.version))
+				return
+			raise
 		self.assertEqual(
 			sorted(self.transm.proceed(["get", self.jailName,
 				"actionproperties", action])[1]),


### PR DESCRIPTION
As was original "discovered" while running tests on OSX with python2.6:
http://nipy.bic.berkeley.edu/builders/fail2ban-py2.7-osx-10.6_master/builds/6/steps/shell_2/logs/stdio

I was not sure if we should just indeed just skip it here or actually add some similar basic test into fail2ban-client to warn users trying to run fail2ban... but then guessed that if it fails to start for them on such rare systems -- then can bother to look into the log... although it would be not that enlightening about the problem
