### PR TITLE
ENH: Clearer warning with lines which failed to decode correctly

### DIFF
--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -790,8 +790,10 @@ class FileContainer:
 		try:
 			line = line.decode(self.getEncoding(), 'strict')
 		except UnicodeDecodeError:
-			logSys.warning("Error decoding line from '%s' with '%s': %s" %
-				(self.getFileName(), self.getEncoding(), `line`))
+			logSys.warning(
+				"Error decoding line from '%s' with '%s'. Continuing "
+				" to process line ignoring invalid characters: %r" %
+				(self.getFileName(), self.getEncoding(), line))
 			if sys.version_info >= (3,): # In python3, must be decoded
 				line = line.decode(self.getEncoding(), 'ignore')
 		return line


### PR DESCRIPTION
This is to make it clear that lines are still processed, even if strict decoding fails. Ref #718
