### PR TITLE
Minor improvement to sshd filter

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -76,6 +76,7 @@ Michael Hanselmann
 Mika (mkl)
 Nick Munger
 onorua
+Paul Marrapese
 Noel Butler
 Patrick Börjesson
 Raphaël Marichez

--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -32,7 +32,7 @@ failregex = ^%(__prefix_line)s(?:error: PAM: )?[aA]uthentication (?:failure|erro
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because none of user's groups are listed in AllowGroups\s*$
             ^(?P<__prefix>%(__prefix_line)s)User .+ not allowed because account is locked<SKIPLINES>(?P=__prefix)(?:error: )?Received disconnect from <HOST>: 11: .+ \[preauth\]$
             ^(?P<__prefix>%(__prefix_line)s)Disconnecting: Too many authentication failures for .+? \[preauth\]<SKIPLINES>(?P=__prefix)(?:error: )?Connection closed by <HOST> \[preauth\]$
-            ^(?P<__prefix>%(__prefix_line)s)Connection from <HOST> port \d+.*<SKIPLINES>(?P=__prefix)Disconnecting: Too many authentication failures for .+? \[preauth\]$
+            ^(?P<__prefix>%(__prefix_line)s)Connection from <HOST> port \d+(?: on \S+ port \d+)?<SKIPLINES>(?P=__prefix)Disconnecting: Too many authentication failures for .+? \[preauth\]$
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/sshd
+++ b/fail2ban/tests/files/logs/sshd
@@ -138,6 +138,11 @@ Feb 12 04:09:18 localhost sshd[26713]: Connection from 115.249.163.77 port 51353
 Feb 12 04:09:21 localhost sshd[26713]: Disconnecting: Too many authentication failures for root [preauth]
 
 # failJSON: { "match": false }
+Feb 12 04:09:18 localhost sshd[26713]: Connection from 115.249.163.77 port 51353 on 127.0.0.1 port 22
+# failJSON: { "time": "2005-02-12T04:09:21", "match": true , "host": "115.249.163.77", "desc": "Multiline match with interface address" }
+Feb 12 04:09:21 localhost sshd[26713]: Disconnecting: Too many authentication failures for root [preauth]
+
+# failJSON: { "match": false }
 Apr 27 13:02:04 host sshd[29116]: User root not allowed because account is locked
 # failJSON: { "match": false }
 Apr 27 13:02:04 host sshd[29116]: input_userauth_request: invalid user root [preauth]


### PR DESCRIPTION
I'm running OpenSSH (6.6p1, OpenSSL 1.0.1g 7 Apr 2014), loglevel verbose. My logs tend to look like this:

May 18 16:37:34 localhost sshd[758]: Connection from x.x.x.x port 55302 on x.x.x.x port 22
May 18 16:37:35 localhost sshd[758]: Disconnecting: Too many authentication failures for root [preauth]

The current filter will not catch this -- I added a small change that will match the additional info if it exists. Tests pass.
