### PR TITLE
Add Oracle Messaging Server filter

### DIFF
--- a/config/filter.d/oracleims.conf
+++ b/config/filter.d/oracleims.conf
@@ -52,7 +52,7 @@ before = common.conf
 # Note that you MUST have LOG_FORMAT=4 for this to work!
 #
 
-failregex = ^.*tr="[A-Z]+\|[0-9.]+\|\d+\|<HOST>\|\d+" ap="[^"]*" mi="Bad password" us="[^"]*" di="535 5.7.8 Bad username or password( \(Authentication failed\))?\."/>$
+failregex = ^.*tr="[A-Z]+\|[0-9.]+\|\d+\|<HOST>\|\d+" .+ Bad username or password.*"/>$
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.


### PR DESCRIPTION
My Github skills are low.  However, I think that I have the two files needed here, the new filter and the test cases.  The modifications to jail.conf, however, I can't figure out how to add to this pull request.  A few lines have to be added to jail.conf.  Note that no "port" argument is here because the server listens on a wide variety of ports, all subject to modification by the system manager (including 25, 110, 143, 993, 995 typically plus commonly others such as 587)

```
# /opt/sun/comms/messaging64/log is the default
# location for Linux installations, but this may vary
# depending on the system manager's configuration and
# how the application was installed.
# Because of how mail clients work, it is desirable to
# have a more "generous" maxretry for this application
# than others. Anything 5 or less is likely to create
# false positives.
[oracleims]

enabled = false
logpath = /opt/sun/comms/messaging64/log/mail.log_current
maxretry = 6
```
