### PR TITLE
ASSP Filter Update

### DIFF
--- a/config/filter.d/assp.conf
+++ b/config/filter.d/assp.conf
@@ -1,50 +1,34 @@
 # Fail2Ban filter for Anti-Spam SMTP Proxy Server also known as ASSP
 # 
-#    Honmepage:   http://sourceforge.net/projects/assp/
+#    Homepage:   http://sourceforge.net/projects/assp/
 #    ProjectSite: http://sourceforge.net/projects/assp/?source=directory
 #
 #
 
 [Definition] 
 
-__assp_actions = (?:dropping|refusing)
-
-failregex = ^(:? \[SSL-out\])? <HOST> max sender authentication errors \(\d{,3}\) exceeded -- %(__assp_actions)s connection - after reply: \d{3} \d{1}\.\d{1}.\d{1} Error: authentication failed: \w+;$
-			^(?: \[SSL-out\])? <HOST> SSL negotiation with client failed: SSL accept attempt failed with unknown error.*:unknown protocol;$
-			^ Blocking <HOST> - too much AUTH errors \(\d{,3}\);$
-			^ \[RelayAttempt\] <HOST> \<\S+@\S+\.\S+\> relay attempt blocked for: .+
-			^ <HOST> \[SMTP Error\] 535 5\.7\.8 Error: authentication failed: authentication failure
-			^ <HOST> \<\S+@\S+\.\S+\> \[SMTP Error\] 554 5\.7\.1 too frequent connections for '.+'
-			
+failregex = ^ \[RelayAttempt\] <HOST> \<\S+@\S+\.\S+\> relay attempt blocked for: \S+$
+			^ <HOST> \[SMTP Error\] 535 5\.7\.8 Error: authentication failed: authentication failure$
+		
 ignoreregex = 
 
 # DEV Notes:
 #
 # Update Notes:
+# * For use with ASSP2.
 # * All Timestamps must use "DD-MM-YYYY hh:mm:ss" within ASSP, this can be found in the logging options in ASSP (#LogDateFormat).
 # * Must also disable unique message ids. 
 # * Should disable logging of message content. 
-# * Regex lines 12-14 are untested with newest release of ASSP. I have not seen logs as such. 
 # * ASSP Homepage has been down for a while, falling back the Source Forge's project page
 # * Fixed spelling
+# * Removed out of date? Regex. 
 #
-# New examples: 
-# If an address is a bad enough standing with the server
-#               18-06-2014 11:20:33 [denyExtreme] 0.0.0.0 <user@example.com> connection from 0.0.0.0 denied by PenaltyBox Extreme '0.0.0.0' 
-# 				Just spammers, don't drop (not directly targeting the server)
-#				^ \[denyExtreme\] <HOST> \<\S+@\S+\.\S+\> connection from .+ denied by PenaltyBox Extreme '.+'
-#
+# Examples: 
 # On my server I get the same addresses attempting to relay over and over. I don't understand why. 
 #               18-06-2014 11:20:33 [RelayAttempt] 0.0.0.0 <user@example.com> relay attempt blocked for: user@example.org 
 # Basic bruteforce attempt 
 #               18-06-2014 11:20:33 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: authentication failure 
-# Addresses are now making 10+ connections at once to attempt mail delivery or bruteforce
-#               18-06-2014 11:20:33 0.0.0.0 <user@example.com> [SMTP Error] 554 5.7.1 too frequent connections for '0.0.0.0' 
-#
-# Old examples: Apr-27-13 02:33:09 Blocking 217.194.197.97 - too much AUTH errors (41);
-#           Dec-29-12 17:10:31 [SSL-out] 200.247.87.82 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
-#           Dec-30-12 04:01:47 [SSL-out] 81.82.232.66 max sender authentication errors (5) exceeded 
-#
+
 # Author: Enrico Labedzki (enrico.labedzki@deiwos.de)
 # Updated: Mark Lopez (m@silvenga.com)
 

--- a/config/filter.d/assp.conf
+++ b/config/filter.d/assp.conf
@@ -15,8 +15,6 @@ failregex = ^(:? \[SSL-out\])? <HOST> max sender authentication errors \(\d{,3}\
 			^ \[RelayAttempt\] <HOST> \<\S+@\S+\.\S+\> relay attempt blocked for: .+
 			^ <HOST> \[SMTP Error\] 535 5\.7\.8 Error: authentication failed: authentication failure
 			^ <HOST> \<\S+@\S+\.\S+\> \[SMTP Error\] 554 5\.7\.1 too frequent connections for '.+'
-			# Just spammers, don't drop (not directly targeting the server)
-			#^ \[denyExtreme\] <HOST> \<\S+@\S+\.\S+\> connection from .+ denied by PenaltyBox Extreme '.+'
 			
 ignoreregex = 
 
@@ -33,6 +31,9 @@ ignoreregex =
 # New examples: 
 # If an address is a bad enough standing with the server
 #               18-06-2014 11:20:33 [denyExtreme] 0.0.0.0 <user@example.com> connection from 0.0.0.0 denied by PenaltyBox Extreme '0.0.0.0' 
+# 				Just spammers, don't drop (not directly targeting the server)
+#				^ \[denyExtreme\] <HOST> \<\S+@\S+\.\S+\> connection from .+ denied by PenaltyBox Extreme '.+'
+#
 # On my server I get the same addresses attempting to relay over and over. I don't understand why. 
 #               18-06-2014 11:20:33 [RelayAttempt] 0.0.0.0 <user@example.com> relay attempt blocked for: user@example.org 
 # Basic bruteforce attempt 

--- a/config/filter.d/assp.conf
+++ b/config/filter.d/assp.conf
@@ -9,7 +9,7 @@
 
 __assp_actions = (?:dropping|refusing)
 
-failregex = ^(:? \[SSL-out\])? <HOST> max sender authentication errors \(\d{,3}\) exceeded -- %(__assp_actions)s connection - after reply: \d{3}  \d{1}\.\d{1}.\d{1} Error: authentication failed: \w+;$
+failregex = ^(:? \[SSL-out\])? <HOST> max sender authentication errors \(\d{,3}\) exceeded -- %(__assp_actions)s connection - after reply: \d{3} \d{1}\.\d{1}.\d{1} Error: authentication failed: \w+;$
 			^(?: \[SSL-out\])? <HOST> SSL negotiation with client failed: SSL accept attempt failed with unknown error.*:unknown protocol;$
 			^ Blocking <HOST> - too much AUTH errors \(\d{,3}\);$
 			^ \[denyExtreme\] <HOST> \<.+@.+\..+\> connection from .+ denied by PenaltyBox Extreme '.+'

--- a/config/filter.d/assp.conf
+++ b/config/filter.d/assp.conf
@@ -1,7 +1,7 @@
 # Fail2Ban filter for Anti-Spam SMTP Proxy Server also known as ASSP
 # 
-#    Honmepage:   http://www.magicvillage.de/~Fritz_Borgstedt/assp/0003D91C-8000001C/
-#    ProjektSite: http://sourceforge.net/projects/assp/?source=directory
+#    Honmepage:   http://sourceforge.net/projects/assp/
+#    ProjectSite: http://sourceforge.net/projects/assp/?source=directory
 #
 #
 
@@ -9,16 +9,41 @@
 
 __assp_actions = (?:dropping|refusing)
 
-failregex = ^(:? \[SSL-out\])? <HOST> max sender authentication errors \(\d{,3}\) exceeded -- %(__assp_actions)s connection - after reply: \d{3} \d{1}\.\d{1}.\d{1} Error: authentication failed: \w+;$
+failregex = ^(:? \[SSL-out\])? <HOST> max sender authentication errors \(\d{,3}\) exceeded -- %(__assp_actions)s connection - after reply: \d{3}  \d{1}\.\d{1}.\d{1} Error: authentication failed: \w+;$
 			^(?: \[SSL-out\])? <HOST> SSL negotiation with client failed: SSL accept attempt failed with unknown error.*:unknown protocol;$
 			^ Blocking <HOST> - too much AUTH errors \(\d{,3}\);$
-
+			^ \[denyExtreme\] <HOST> \<.+@.+\..+\> connection from .+ denied by PenaltyBox Extreme '.+'
+			^ \[RelayAttempt\] <HOST> \<.+@.+\..+\> relay attempt blocked for: .+
+			^ <HOST> \[SMTP Error\] 535 5\.7\.8 Error: authentication failed: authentication failure
+			^ <HOST> \<.+@.+\..+\> \[SMTP Error\] 554 5\.7\.1 too frequent connections for '.+'
+			
 ignoreregex = 
 
 # DEV Notes:
 #
-# Examples: Apr-27-13 02:33:09 Blocking 217.194.197.97 - too much AUTH errors (41);
+# Update Notes:
+# * All Timestamps must use "DD-MM-YYYY hh:mm:ss" within ASSP, this can be found in the logging options in ASSP (#LogDateFormat).
+# * Must also disable unique message ids. 
+# * Should disable logging of message content. 
+# * Regex lines 12-14 are untested with newest release of ASSP. I have not seen logs as such. 
+# * ASSP Homepage has been down for a while, falling back the Source Forge's project page
+# * Fixed spelling
+#
+# New examples: 
+# If an address is a bad enough standing with the server
+#               18-06-2014 11:20:33 [denyExtreme] 0.0.0.0 <user@example.com> connection from 0.0.0.0 denied by PenaltyBox Extreme '0.0.0.0' 
+# On my server I get the same addresses attempting to relay over and over. I don't understand why. 
+#               18-06-2014 11:20:33 [RelayAttempt] 0.0.0.0 <user@example.com> relay attempt blocked for: user@example.org 
+# Basic bruteforce attempt 
+#               18-06-2014 11:20:33 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: authentication failure 
+# Addresses are now making 10+ connections at once to attempt mail delivery or bruteforce
+#               18-06-2014 11:20:33 0.0.0.0 <user@example.com> [SMTP Error] 554 5.7.1 too frequent connections for '0.0.0.0' 
+#
+# Old examples: Apr-27-13 02:33:09 Blocking 217.194.197.97 - too much AUTH errors (41);
 #           Dec-29-12 17:10:31 [SSL-out] 200.247.87.82 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
 #           Dec-30-12 04:01:47 [SSL-out] 81.82.232.66 max sender authentication errors (5) exceeded 
 #
 # Author: Enrico Labedzki (enrico.labedzki@deiwos.de)
+# Updated: Mark Lopez (m@silvenga.com)
+
+

--- a/config/filter.d/assp.conf
+++ b/config/filter.d/assp.conf
@@ -12,10 +12,11 @@ __assp_actions = (?:dropping|refusing)
 failregex = ^(:? \[SSL-out\])? <HOST> max sender authentication errors \(\d{,3}\) exceeded -- %(__assp_actions)s connection - after reply: \d{3} \d{1}\.\d{1}.\d{1} Error: authentication failed: \w+;$
 			^(?: \[SSL-out\])? <HOST> SSL negotiation with client failed: SSL accept attempt failed with unknown error.*:unknown protocol;$
 			^ Blocking <HOST> - too much AUTH errors \(\d{,3}\);$
-			^ \[denyExtreme\] <HOST> \<\S+@\S+\.\S+\> connection from .+ denied by PenaltyBox Extreme '.+'
 			^ \[RelayAttempt\] <HOST> \<\S+@\S+\.\S+\> relay attempt blocked for: .+
 			^ <HOST> \[SMTP Error\] 535 5\.7\.8 Error: authentication failed: authentication failure
 			^ <HOST> \<\S+@\S+\.\S+\> \[SMTP Error\] 554 5\.7\.1 too frequent connections for '.+'
+			# Just spammers, don't drop (not directly targeting the server)
+			#^ \[denyExtreme\] <HOST> \<\S+@\S+\.\S+\> connection from .+ denied by PenaltyBox Extreme '.+'
 			
 ignoreregex = 
 

--- a/config/filter.d/assp.conf
+++ b/config/filter.d/assp.conf
@@ -12,10 +12,10 @@ __assp_actions = (?:dropping|refusing)
 failregex = ^(:? \[SSL-out\])? <HOST> max sender authentication errors \(\d{,3}\) exceeded -- %(__assp_actions)s connection - after reply: \d{3} \d{1}\.\d{1}.\d{1} Error: authentication failed: \w+;$
 			^(?: \[SSL-out\])? <HOST> SSL negotiation with client failed: SSL accept attempt failed with unknown error.*:unknown protocol;$
 			^ Blocking <HOST> - too much AUTH errors \(\d{,3}\);$
-			^ \[denyExtreme\] <HOST> \<.+@.+\..+\> connection from .+ denied by PenaltyBox Extreme '.+'
-			^ \[RelayAttempt\] <HOST> \<.+@.+\..+\> relay attempt blocked for: .+
+			^ \[denyExtreme\] <HOST> \<\S+@\S+\.\S+\> connection from .+ denied by PenaltyBox Extreme '.+'
+			^ \[RelayAttempt\] <HOST> \<\S+@\S+\.\S+\> relay attempt blocked for: .+
 			^ <HOST> \[SMTP Error\] 535 5\.7\.8 Error: authentication failed: authentication failure
-			^ <HOST> \<.+@.+\..+\> \[SMTP Error\] 554 5\.7\.1 too frequent connections for '.+'
+			^ <HOST> \<\S+@\S+\.\S+\> \[SMTP Error\] 554 5\.7\.1 too frequent connections for '.+'
 			
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/assp
+++ b/fail2ban/tests/files/logs/assp
@@ -1,4 +1,4 @@
 # failJSON: { "time": "2014-06-18T11:20:33", "match": true , "host": "0.0.0.0" }
-18-06-2014 11:20:33 [RelayAttempt] 0.0.0.0 <user@example.com> relay attempt blocked for: user@example.org 
+18-06-2014 11:20:33 [RelayAttempt] 0.0.0.0 <user@example.com> relay attempt blocked for: user@example.org
 # failJSON: { "time": "2014-06-18T11:20:34", "match": true , "host": "0.0.0.0" }
-18-06-2014 11:20:34 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: authentication failure 
+18-06-2014 11:20:34 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: authentication failure

--- a/fail2ban/tests/files/logs/assp
+++ b/fail2ban/tests/files/logs/assp
@@ -1,25 +1,4 @@
-# failJSON: { "time": "2013-04-07T07:08:36", "match": true , "host": "68.171.223.68" }
-Apr-07-13 07:08:36 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
-# failJSON: { "time": "2013-04-07T07:08:36", "match": true , "host": "68.171.223.68" }
-Apr-07-13 07:08:36 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
-# failJSON: { "time": "2013-04-07T07:10:37", "match": true , "host": "68.171.223.68" }
-Apr-07-13 07:10:37 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
-# failJSON: { "time": "2013-04-07T07:12:37", "match": true , "host": "68.171.223.68" }
-Apr-07-13 07:12:37 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
-# failJSON: { "time": "2013-04-07T07:14:36", "match": true , "host": "68.171.223.68" }
-Apr-07-13 07:14:36 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
-# failJSON: { "time": "2013-04-27T02:25:09", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:09 Blocking 217.194.197.97 - too much AUTH errors (8);
-# failJSON: { "time": "2013-04-27T02:25:09", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:09 Blocking 217.194.197.97 - too much AUTH errors (9);
-# failJSON: { "time": "2013-04-27T02:25:09", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:09 Blocking 217.194.197.97 - too much AUTH errors (10);
-# failJSON: { "time": "2013-04-27T02:25:10", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:10 [SSL-out] 217.194.197.97 max sender authentication errors (5) exceeded -- dropping connection - after reply: 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6;
-# failJSON: { "time": "2013-04-27T02:25:10", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:10 [SSL-out] 217.194.197.97 max sender authentication errors (5) exceeded -- dropping connection - after reply: 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6;
-# failJSON: { "time": "2013-04-27T02:25:10", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:10 [SSL-out] 217.194.197.97 max sender authentication errors (5) exceeded -- dropping connection - after reply: 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6;
-# failJSON: { "time": "2013-04-27T02:25:11", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:11 [SSL-out] 217.194.197.97 max sender authentication errors (5) exceeded -- dropping connection - after reply: 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6;
-
+# failJSON: { "time": "2014-06-18T11:20:33", "match": true , "host": "0.0.0.0" }
+18-06-2014 11:20:33 [RelayAttempt] 0.0.0.0 <user@example.com> relay attempt blocked for: user@example.org 
+# failJSON: { "time": "2014-06-18T11:20:34", "match": true , "host": "0.0.0.0" }
+18-06-2014 11:20:34 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: authentication failure 


### PR DESCRIPTION
Added/Updated detection of:

* RelayAttempt (Scanners looking for open relays, drop to reduce attack surface)
* Auth error (Brute Force attempts, drop to reduce attack surface)
* Too frequent connections (Seen when attempting to deliver SPAM or Brute Force, drop to reduce server load)

Regex lines 12-14 are untested with newest release of ASSP. I personally have not seen anything in my logs that is caught by the Regex (For ASSP1?). 

ASSP Homepage has been down for a while, falling back the Sourceforge project page.

Fixed spelling

I recommend setting the ban time for ASSP to 2+ hours.  