### PR TITLE
Added Directadmin filter, jail and log test

### DIFF
--- a/config/filter.d/directadmin.conf
+++ b/config/filter.d/directadmin.conf
@@ -1,0 +1,23 @@
+# Fail2Ban configuration file for Directadmin
+#
+#
+#
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+
+failregex = ^: \'<HOST>\' \d{1,3} failed login attempt(s)?. \s*
+
+ignoreregex = 
+
+[Init]
+datepattern = ^%%Y:%%m:%%d-%%H:%%M:%%S
+
+#
+# Requires Directadmin v1.45.3 or higher. http://www.directadmin.com/features.php?id=1590
+#
+# Author: Cyril Roos
+

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -709,3 +709,8 @@ enabled = false
 logpath = /opt/sun/comms/messaging64/log/mail.log_current
 maxretry = 6
 banaction = iptables-allports
+
+[directadmin]
+enabled = false
+logpath = /var/log/directadmin/login.log
+port = 2222

--- a/fail2ban/tests/files/logs/directadmin
+++ b/fail2ban/tests/files/logs/directadmin
@@ -1,0 +1,14 @@
+# failJSON: { "time": "2014-07-02T00:17:45", "match": true , "host": "3.2.1.4" }
+2014:07:02-00:17:45: '3.2.1.4' 2 failed login attempts. Account 'test'
+
+# failJSON: { "time": "2014-07-02T13:07:40", "match": true , "host": "40.40.123.231" }
+2014:07:02-13:07:40: '40.40.123.231' 13 failed login attempts. Account 'admin'
+
+# failJSON: { "time": "2014-07-02T13:07:50", "match": true , "host": "40.40.123.231" }
+2014:07:02-13:07:50: '40.40.123.231' 5 failed login attempt. Invalid account 'user%2Ename'
+
+# failJSON: { "time": "2014-07-02T13:28:39", "match": false , "host": "12.12.123.231" }
+2014:07:02-13:28:39: '12.12.123.231' successful login to 'nobody' after 1 attempts
+
+# failJSON: { "time": "2014-07-02T13:29:38", "match": true , "host": "1.2.3.4" }
+2014:07:02-13:29:38: '1.2.3.4' 2 failed login attempts. Account 'user' via 'admin'


### PR DESCRIPTION
A recent Directadmin version provides a usable log for a fail2ban filter. I wrote a simple filter for it that can be very useful for those who prefer fail2ban over the internal Directadmin brute force monitor. 
