### PR TITLE
Update postfix-sasl.conf: Different log output on centos.

### DIFF
--- a/config/filter.d/postfix-sasl.conf
+++ b/config/filter.d/postfix-sasl.conf
@@ -1,5 +1,8 @@
 # Fail2Ban filter for postfix authentication failures
 #
+# 04.07.2014: Pixinger77 modified regex because of undetected log message, where "LOGIN" was written in lower case as "login" - CentOS6.
+#             org: FAILREGEX = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL (?:LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/]*={0,2})?\s*$
+#             mod: FAILREGEX = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL \S+ authentication failed(: [ A-Za-z0-9+/]*={0,2})?\s*$
 
 [INCLUDES]
 
@@ -9,6 +12,6 @@ before = common.conf
 
 _daemon = postfix/smtpd
 
-failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL (?:LOGIN|login|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/]*={0,2})?\s*$
+FAILREGEX = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL \S+ authentication failed(: [ A-Za-z0-9+/]*={0,2})?\s*$
 
 # Author: Yaroslav Halchenko

--- a/config/filter.d/postfix-sasl.conf
+++ b/config/filter.d/postfix-sasl.conf
@@ -9,6 +9,6 @@ before = common.conf
 
 _daemon = postfix/smtpd
 
-failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL (?:LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/]*={0,2})?\s*$
+failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL (?:LOGIN|login|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/]*={0,2})?\s*$
 
 # Author: Yaroslav Halchenko


### PR DESCRIPTION
In our logfile in some cases the message is "...SASL login..." instead of "...SASL LOGIN...".
Maybe it makes sense to change the whole "SASL (?:LOGIN|login|PLAIN|(?:CRAM|DIGEST)-MD5)" block to "SASL.*", because when browsing through the internet I have seen other possibilities then "CRAM,DIGEST,..." but I'm not sure how strict the regex should be handled.
Running Centos 6 - happens only sometimes and only if the domainname to the ip is unknown for postfix.