### PR TITLE
ENH: Add version command to protocol

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,7 @@ ver. 0.9.1 (2014/xx/xx) - better, faster, stronger
 
 - New features:
    - Added monit filter thanks Jason H Martin.
+   - fail2ban-client can fetch the running server version
 
 - Enhancements
    * Fail2ban-regex - add print-all-matched option. Closes gh-652

--- a/THANKS
+++ b/THANKS
@@ -88,6 +88,7 @@ Rolf Fokkens
 Roman Gelfand
 Russell Odom
 SATO Kentaro
+Sean DuBois
 Sebastian Arcus
 Serg G. Brester
 Sireyessire

--- a/fail2ban/client/beautifier.py
+++ b/fail2ban/client/beautifier.py
@@ -51,6 +51,8 @@ class Beautifier:
 		try:
 			if inC[0] == "ping":
 				msg = "Server replied: " + response
+			elif inC[0] == "version":
+				msg = response
 			elif inC[0] == "start":
 				msg = "Jail started"
 			elif inC[0] == "stop":

--- a/fail2ban/protocol.py
+++ b/fail2ban/protocol.py
@@ -38,6 +38,7 @@ protocol = [
 ["status", "gets the current status of the server"], 
 ["ping", "tests if the server is alive"], 
 ["help", "return this output"], 
+["version", "return the server version"],
 ['', "LOGGING", ""],
 ["set loglevel <LEVEL>", "sets logging level to <LEVEL>. Levels: CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG"], 
 ["get loglevel", "gets the logging level"], 

--- a/fail2ban/server/transmitter.py
+++ b/fail2ban/server/transmitter.py
@@ -28,6 +28,7 @@ import time
 import json
 
 from ..helpers import getLogger
+from .. import version
 
 # Gets the instance of the logger.
 logSys = getLogger(__name__)
@@ -102,7 +103,9 @@ class Transmitter:
 		elif command[0] == "get":
 			return self.__commandGet(command[1:])
 		elif command[0] == "status":
-			return self.status(command[1:])			
+			return self.status(command[1:])
+		elif command[0] == "version":
+			return version.version
 		raise Exception("Invalid command")
 	
 	def __commandSet(self, command):

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -37,6 +37,7 @@ from ..server.jail import Jail
 from ..server.jailthread import JailThread
 from .utils import LogCaptureTestCase
 from ..helpers import getLogger
+from .. import version
 
 try:
 	from ..server import filtersystemd
@@ -147,6 +148,9 @@ class Transmitter(TransmitterBase):
 
 	def testPing(self):
 		self.assertEqual(self.transm.proceed(["ping"]), (0, "pong"))
+
+	def testVersion(self):
+		self.assertEqual(self.transm.proceed(["version"]), (0, version.version))
 
 	def testSleep(self):
 		t0 = time.time()

--- a/man/fail2ban-client.1
+++ b/man/fail2ban-client.1
@@ -71,6 +71,9 @@ tests if the server is alive
 .TP
 \fBhelp\fR
 return this output
+.TP
+\fBversion\fR
+return the server version
 .IP
 LOGGING
 .TP


### PR DESCRIPTION
I have a small fail2ban GUI that communicates with fail2ban via the server socket https://github.com/Sean-Der/fail2web. I would like to be able to determine the version of the server so I can then advertise what features are supported (DB support in 0.9 etc..)

Should I add a test for this and then rebase? I didn't know what level of testing is expected etc.. 

thanks!
