### PR TITLE
BF: Round timeofban before inserting into the persistant database

### DIFF
--- a/fail2ban/server/database.py
+++ b/fail2ban/server/database.py
@@ -368,7 +368,7 @@ class Fail2BanDb(object):
 		#TODO: Implement data parts once arbitrary match keys completed
 		cur.execute(
 			"INSERT INTO bans(jail, ip, timeofban, data) VALUES(?, ?, ?, ?)",
-			(jail.name, ticket.getIP(), ticket.getTime(),
+			(jail.name, ticket.getIP(), round(ticket.getTime()),
 				{"matches": ticket.getMatches(),
 					"failures": ticket.getAttempt()}))
 


### PR DESCRIPTION
This might just be a good example for how to reproduce the bug. 

All other dates are ints, while manually banned IPs are floats. This only causes a problem when this date is inserted into the DB, the timeofban column claims to be an integer but we are storing floats.
