### PR TITLE
Improve cyrus-imap (and pop) filter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -55,6 +55,7 @@ ver. 0.9.1 (2014/xx/xx) - better, faster, stronger
    * Realign fail2ban log output with white space to improve readability. Does
      not affect SYSLOG output
    * Log unhandled exceptions
+   * cyrus-imap: catch "user not found" attempts
 
 ver. 0.9.0 (2014/03/14) - beta
 ----------

--- a/THANKS
+++ b/THANKS
@@ -80,6 +80,7 @@ onorua
 Paul Marrapese
 Noel Butler
 Patrick Börjesson
+Pressy
 Raphaël Marichez
 RealRancor
 René Berber

--- a/config/filter.d/cyrus-imap.conf
+++ b/config/filter.d/cyrus-imap.conf
@@ -13,7 +13,7 @@ before = common.conf
 
 _daemon = (?:cyrus/)?(?:imap(d|s)?|pop3(d|s)?)
 
-failregex = ^%(__prefix_line)sbadlogin: \S+ ?\[<HOST>\] \S+ .*?\[?SASL\(-13\): authentication failure: .*\]?$
+failregex = ^%(__prefix_line)sbadlogin: \S+ ?\[<HOST>\] \S+ .*?\[?SASL\(-13\): (authentication failure|user not found): .*\]?$
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/cyrus-imap
+++ b/fail2ban/tests/files/logs/cyrus-imap
@@ -12,4 +12,7 @@ Jun 8 18:11:13 lampserver imap[4480]: badlogin: example.com [198.51.100.45] DIGE
 Dec 21 10:01:57 hostname imapd[18454]: badlogin: example.com [198.51.100.57] CRAM-MD5 [SASL(-13): authentication failure: incorrect digest response]
 # failJSON: { "time": "2004-12-30T16:03:27", "match": true , "host": "1.2.3.4" }
 Dec 30 16:03:27 somehost imapd[2517]: badlogin: local-somehost[1.2.3.4] OTP [SASL(-13): authentication failure: External SSF not good enough]
-
+# failJSON: { "time": "2005-07-17T22:55:56", "match": true , "host": "1.2.3.4" }
+Jul 17 22:55:56 derry cyrus/imaps[7568]: badlogin: serafinat.xxxxxx [1.2.3.4] plain [SASL(-13): user not found: user: pressy@derry property: cmusaslsecretPLAIN not found in sasldb]
+# failJSON: { "time": "2005-07-18T16:46:42", "match": true , "host": "1.2.3.4" }
+Jul 18 16:46:42 derry cyrus/imaps[27449]: badlogin: serafinat.xxxxxx [1.2.3.4] PLAIN [SASL(-13): user not found: Password verification failed]


### PR DESCRIPTION
Apparently we had a regression, which was caught when I have pushed a security update into wheezy
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=755173
So the first commit should address that (allow for imaps and pop3s) and should be cherry picked into 0.8 (and Debian wheezy patches), and 2nd one adds "user not found" entries to be caught as a new enhancement.
