### PR TITLE
Fix sieve filter to use correct option

### DIFF
--- a/config/filter.d/sieve.conf
+++ b/config/filter.d/sieve.conf
@@ -9,7 +9,7 @@ before = common.conf
 
 [Definition]
 
-_deamon = (?:cyrus/)?(?:tim)?sieved?
+_daemon = (?:cyrus/)?(?:tim)?sieved?
 
 failregex = ^%(__prefix_line)sbadlogin: \S+ ?\[<HOST>\] \S+ authentication failure$
 


### PR DESCRIPTION
Just a typo - but consequently, how about warning or raising an exception about undefined options?
