### PR TITLE
Fix typos.

### DIFF
--- a/config/action.d/ufw.conf
+++ b/config/action.d/ufw.conf
@@ -1,9 +1,9 @@
 # Fail2Ban action configuration file for ufw
 #
-# You are required to run "ufw enable" before this will have an effect.
+# You are required to run "ufw enable" before this will have any effect.
 #
-# The insert position should be approprate to block the required traffic.
-# A number after an allow rule to the application won't be much use.
+# The insert position should be appropriate to block the required traffic.
+# A number after an allow rule to the application won't be of much use.
 
 [Definition]
 
@@ -19,7 +19,7 @@ actionunban = [ -n "<application>" ] && app="app <application>" ; ufw delete <bl
 
 [Init]
 # Option: insertpos
-# Notes.:  The postition number in the firewall list to insert the block rule
+# Notes.:  The position number in the firewall list to insert the block rule
 insertpos = 1
 
 # Option: blocktype


### PR DESCRIPTION
This fixes a few typos in the comments:
- an -> any
- approprate -> appropriate
- postition -> position
