### PR TITLE
Removed explicit bantime specification

### DIFF
--- a/config/action.d/firewallcmd-ipset.conf
+++ b/config/action.d/firewallcmd-ipset.conf
@@ -38,13 +38,6 @@ actionunban = ipset del fail2ban-<name> <ip> -exist
 #
 chain = INPUT_direct
 
-# Option: bantime
-# Notes:  specifies the bantime in seconds (handled internally rather than by fail2ban)
-# Values:  [ NUM ]  Default: 600
-
-bantime = 600
-
-
 # DEV NOTES:
 #
 # Author: Edgar Hoch and Daniel Black


### PR DESCRIPTION
Explicit bantime spec. is unnecessary since 3d7504c19eb04d4756808805ad34998ed4dbe8e6
