### PR TITLE
Add support for postfix/submission/smtpd matching.

### DIFF
--- a/config/filter.d/postfix-sasl.conf
+++ b/config/filter.d/postfix-sasl.conf
@@ -7,7 +7,7 @@ before = common.conf
 
 [Definition]
 
-_daemon = postfix/(submission/)?smtpd
+_daemon = postfix/(submission/)?smtp(d|s)
 
 failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL (?:LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/]*={0,2})?\s*$
 

--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -10,11 +10,13 @@ before = common.conf
 
 [Definition]
 
-_daemon = postfix/(submission/)?smtpd
+_daemon = postfix/(submission/)?smtp(d|s)
 
 failregex = ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 554 5\.7\.1 .*$
             ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 450 4\.7\.1 : Helo command rejected: Host not found; from=<> to=<> proto=ESMTP helo= *$
             ^%(__prefix_line)sNOQUEUE: reject: VRFY from \S+\[<HOST>\]: 550 5\.1\.1 .*$
+            ^%(__prefix_line)swarning: Connection concurrency limit exceeded: \d+ from \S+\[<HOST>\] for service.*$
+            ^%(__prefix_line)slost connection after AUTH from \S+\[<HOST>\]$
             ^%(__prefix_line)simproper command pipelining after \S+ from [^[]*\[<HOST>\]:?$
 
 ignoreregex = 

--- a/fail2ban/tests/files/logs/postfix
+++ b/fail2ban/tests/files/logs/postfix
@@ -20,3 +20,9 @@ Dec 25 02:35:54 platypus postfix/smtpd[9144]: improper command pipelining after 
 
 # failJSON: { "time": "2004-12-18T02:05:46", "match": true , "host": "216.245.198.245" }
 Dec 18 02:05:46 platypus postfix/smtpd[16349]: improper command pipelining after NOOP from unknown[216.245.198.245]
+
+# failJSON: { "time": "2004-09-07T08:24:30", "match": true , "host": "83.110.98.15" }
+Sep  7 08:24:30 umkc postfix/smtpd[2282]: lost connection after AUTH from bba453913.alshamil.net.ae[83.110.98.15]
+
+# failJSON: { "time": "2004-09-05T12:45:53", "match": true , "host": "213.123.185.20" }
+Sep  5 12:45:53 umkc postfix/smtpd[20286]: warning: Connection concurrency limit exceeded: 6 from mail.baileysbodybuilders.co.uk[213.123.185.20] for service smtp

--- a/fail2ban/tests/files/logs/postfix-sasl
+++ b/fail2ban/tests/files/logs/postfix-sasl
@@ -5,3 +5,6 @@ Dec  2 22:24:22 hel postfix/smtpd[7676]: warning: 114-44-142-233.dynamic.hinet.n
 # failJSON: { "time": "2005-03-10T13:33:30", "match": true , "host": "1.1.1.1" }
 Mar 10 13:33:30 gandalf postfix/smtpd[3937]: warning: HOSTNAME[1.1.1.1]: SASL LOGIN authentication failed: authentication failure
 
+#3 Example from postfix post-debian changes to rename to add "submission" to syslog name
+# failJSON: { "time": "2004-09-06T00:44:56", "match": true , "host": "82.221.106.233" }
+Sep  6 00:44:56 trianon postfix/submission/smtpd[11538]: warning: unknown[82.221.106.233]: SASL LOGIN authentication failed: UGFzc3dvcmQ6


### PR DESCRIPTION
By default, on debian, and perhaps globally, the postfix smtpd daemon running on port 587 logs with the daemon name

postfix/submission/smtpd

instead of

postfix/smtpd

This covers both cases (old, new, port 25, port 587).

Close #803
