### PR TITLE
grep IP at the start of lines

### DIFF
--- a/config/action.d/sendmail-whois-lines.conf
+++ b/config/action.d/sendmail-whois-lines.conf
@@ -26,7 +26,7 @@ actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Here is more information about <ip>:\n
             `/usr/bin/whois <ip> || echo missing whois program`\n\n
             Lines containing IP:<ip> in <logpath>\n
-            `grep '[^0-9]<ip>[^0-9]' <logpath>`\n\n
+            `grep '\([^0-9]\|^\)<ip>[^0-9]' <logpath>`\n\n
             Regards,\n
             Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
 


### PR DESCRIPTION
I'm not sure if this regex works best, so I'm patching this single file as a sample.

Don't forget to update `mail-whois-lines.conf` after this patch got merged.

For the following logs, `grep '[^0-9]199.48.161.87[^0-9]'` will output nothing, while `grep '\([^0-9]\|^\)199.48.161.87[^0-9]'` works:

<pre>199.48.161.87 - - [09/Sep/2014:13:38:54 +0800] "POST /wp-login.php HTTP/1.1" 403 4674 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:38:56 +0800] "POST /wp-login.php HTTP/1.1" 403 4674 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:38:58 +0800] "POST /wp-login.php HTTP/1.1" 403 4674 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:39:00 +0800] "POST /wp-login.php HTTP/1.1" 403 4674 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:39:05 +0800] "POST /wp-login.php HTTP/1.1" 403 4674 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:39:05 +0800] "POST /wp-login.php HTTP/1.1" 403 4674 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:39:13 +0800] "POST /wp-login.php HTTP/1.1" 403 4674 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:39:21 +0800] "POST /wp-login.php HTTP/1.1" 403 4674 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:39:32 +0800] "POST /wp-login.php HTTP/1.1" 403 4674 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:39:34 +0800] "POST /wp-login.php HTTP/1.1" 403 4674 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:39:34 +0800] "POST /wp-login.php HTTP/1.1" 403 168 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:39:34 +0800] "POST /wp-login.php HTTP/1.1" 403 168 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:39:35 +0800] "POST /wp-login.php HTTP/1.1" 403 168 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:39:35 +0800] "POST /wp-login.php HTTP/1.1" 403 168 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com
199.48.161.87 - - [09/Sep/2014:13:39:35 +0800] "POST /wp-login.php HTTP/1.1" 403 168 "-" "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0" - hitsjapan.com</pre>
