### PR TITLE
tests: Add function to utils to calculate CONFIG_DIR

### DIFF
--- a/fail2ban/tests/action_d/test_badips.py
+++ b/fail2ban/tests/action_d/test_badips.py
@@ -22,11 +22,7 @@ import unittest
 import sys
 
 from ..dummyjail import DummyJail
-
-if os.path.exists('config/fail2ban.conf'):
-	CONFIG_DIR = "config"
-else:
-	CONFIG_DIR='/etc/fail2ban'
+from ..utils import CONFIG_DIR
 
 if sys.version_info >= (2,7):
 	class BadIPsActionTest(unittest.TestCase):

--- a/fail2ban/tests/action_d/test_smtp.py
+++ b/fail2ban/tests/action_d/test_smtp.py
@@ -30,10 +30,7 @@ else:
 
 from ..dummyjail import DummyJail
 
-if os.path.exists('config/fail2ban.conf'):
-	CONFIG_DIR = "config"
-else:
-	CONFIG_DIR='/etc/fail2ban'
+from ..utils import CONFIG_DIR
 
 class TestSMTPServer(smtpd.SMTPServer):
 

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -32,8 +32,10 @@ from ..client.configurator import Configurator
 from .utils import LogCaptureTestCase
 
 TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "files")
+
+from .utils import CONFIG_DIR
+
 STOCK = os.path.exists(os.path.join('config','fail2ban.conf'))
-CONFIG_DIR='config' if STOCK else '/etc/fail2ban'
 
 IMPERFECT_CONFIG = os.path.join(os.path.dirname(__file__), 'config')
 

--- a/fail2ban/tests/samplestestcase.py
+++ b/fail2ban/tests/samplestestcase.py
@@ -32,13 +32,9 @@ else:
 
 from ..server.filter import Filter
 from ..client.filterreader import FilterReader
-from .utils import setUpMyTime, tearDownMyTime
+from .utils import setUpMyTime, tearDownMyTime, CONFIG_DIR
 
 TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "files")
-if os.path.exists('config/fail2ban.conf'):
-	CONFIG_DIR = "config"
-else:
-	CONFIG_DIR='/etc/fail2ban'
 
 class FilterSamplesRegex(unittest.TestCase):
 

--- a/fail2ban/tests/utils.py
+++ b/fail2ban/tests/utils.py
@@ -34,6 +34,15 @@ from ..helpers import getLogger
 
 logSys = getLogger(__name__)
 
+CONFIG_DIR = os.environ.get('FAIL2BAN_CONFIG_DIR', None)
+
+if not CONFIG_DIR:
+# Use heuristic to figure out where configuration files are
+	if os.path.exists(os.path.join('config','fail2ban.conf')):
+		CONFIG_DIR = 'config'
+	else:
+		CONFIG_DIR = '/etc/fail2ban'
+
 def mtimesleep():
 	# no sleep now should be necessary since polling tracks now not only
 	# mtime but also ino and size


### PR DESCRIPTION
Based on pull request #809, which doesn't change all tests.

This PR adds a common function to be used by tests to figure out the configdir and adapts the tests to use it.
