### PR TITLE
add zpanel-auth filter and jail

### DIFF
--- a/config/filter.d/zpanel-auth.conf
+++ b/config/filter.d/zpanel-auth.conf
@@ -1,0 +1,33 @@
+# Fail2Ban configuration file
+#
+# Author: Alex Creek
+#
+# $Revision$
+#
+
+[INCLUDES]
+
+# Read common prefixes. If any customizations available -- read them from
+# common.local
+before =
+
+[Definition]
+
+# Option:  failregex
+# Notes.:  regex to match the password failure messages in the logfile. The
+#          host must be matched by a group named "host". The tag "<HOST>" can
+#          be used for standard IP/hostname matching and is only an alias for
+#          (?:::f{4,6}:)?(?P<host>[\w\-.^_]+)
+# Values:  TEXT
+#
+
+failregex = ^.*:[0-9]{1,5} <HOST> - - \[.*\] "GET /\?invalidlogin HTTP/1\.[0-9]"
+            ^<HOST> - - \[.*\] "GET /\?invalidlogin HTTP/1\.[0-9]"
+
+
+# Option:  ignoreregex
+# Notes.:  regex to ignore. If this regex matches, the line is ignored.
+# Values:  TEXT
+#
+ignoreregex =
+

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -719,3 +719,12 @@ banaction = iptables-allports
 enabled = false
 logpath = /var/log/directadmin/login.log
 port = 2222
+
+[zpanel-auth]
+
+enabled  = false
+logpath  = /var/log/apache2/other_vhosts_access.log
+filter   = zpanel-auth
+port     = http,https
+maxretry = 6
+

--- a/fail2ban/tests/files/logs/zpanel-auth
+++ b/fail2ban/tests/files/logs/zpanel-auth
@@ -1,0 +1,18 @@
+#zpanel-auth
+
+# apache combined log format
+# failJSON: { "time": "2014-10-24T18:20:42", "match": true , "host": "1.2.3.4" }
+1.2.3.4 - - [24/Oct/2014:16:20:42 -0000] "GET /?invalidlogin HTTP/1.1" 200 7078 "http://4.3.2.1/?invalidlogin" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36"
+
+# POST instead of GET
+# failJSON: { "time": "2014-10-24T18:20:42", "match": false , "host": "5.6.7.8" }
+5.6.7.8 - - [24/Oct/2014:16:20:42 -0000] "POST /?invalidlogin HTTP/1.1" 200 7078 "http://4.3.2.1/?invalidlogin" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36"
+
+# apache combined log format with vhost:port prefixed
+# failJSON: { "time": "2014-10-24T18:20:42", "match": true , "host": "1.2.3.4" }
+falcon:80 1.2.3.4 - - [24/Oct/2014:16:20:42 -0000] "GET /?invalidlogin HTTP/1.1" 200 7078 "http://4.3.2.1/?invalidlogin" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36"
+
+# invalidlogin in referrer instead of request
+# failJSON: { "time": "2014-10-24T18:20:42", "match": false , "host": "5.6.7.8" }
+falcon:80 5.6.7.8 - - [24/Oct/2014:16:20:42 -0000] "GET /etc/styles/zpanelx/images/my_account/assets/icon.png HTTP/1.1" 200 1877 "http://4.3.2.1/?invalidlogin" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36"
+


### PR DESCRIPTION
I've added a filter for the zpanel web hosting panel login page.  When a login request fails, 'GET /?invalidlogin' is logged to the access log.  

In zpanel's default configuration, it's apache vhost doesn't specify logging so the requests are sent to /var/log/apache2/other_vhosts_access.log as a default action.  In this configuration, each log entry is prefixed with the respective vhost and listening port.  The failregex checks for the vhost:port prefix as well as the traditional apache combined format. 
