### PR TITLE
do not install foreign distro/OS config files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+fail2ban (0.9.1-1.1) UNRELEASED; urgency=medium
+
+  [ Christoph Anton Mitterer ]
+  * Do not install the following configuration files which are not used within
+    the Debian package of fail2ban:
+    /etc/fail2ban/paths-fedora.conf
+    /etc/fail2ban/paths-freebsd.conf
+    /etc/fail2ban/paths-osx.conf
+    Closes: #767123
+
+ -- Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>  Wed, 12 Nov 2014 05:20:20 +0100
+
 fail2ban (0.9.1-1) unstable; urgency=medium
 
   * To become fresh upstream release (Closes: #742976)

--- a/debian/rules
+++ b/debian/rules
@@ -23,6 +23,9 @@ override_dh_clean:
 
 override_dh_install:
 	rm -f $(DESTDIR)/usr/share/doc/fail2ban/README.Solaris
+	rm -f $(DESTDIR)/etc/fail2ban/paths-fedora.conf
+	rm -f $(DESTDIR)/etc/fail2ban/paths-freebsd.conf
+	rm -f $(DESTDIR)/etc/fail2ban/paths-osx.conf
 	: # Remove explicitely created /var/run/fail2ban
 	: # just to please lintian since init file will
 	: # take care about it anyways


### PR DESCRIPTION
• Do not install the following configuration files which are not used within the
  Debian package of fail2ban:
  /etc/fail2ban/paths-fedora.conf
  /etc/fail2ban/paths-freebsd.conf
  /etc/fail2ban/paths-osx.conf
  Closes: Debian bug #767123 (https://bugs.debian.org/767123).

Signed-off-by: Christoph Anton Mitterer mail@christoph.anton.mitterer.name
