### PR TITLE
Separate php-url-fopen logpath by newline

### DIFF
--- a/config/jail.conf
+++ b/config/jail.conf
@@ -302,7 +302,8 @@ logpath = %(nginx_error_log)s
 [php-url-fopen]
 
 port    = http,https
-logpath = %(nginx_access_log)s %(apache_access_log)s
+logpath = %(nginx_access_log)s
+          %(apache_access_log)s
 
 
 [suhosin]


### PR DESCRIPTION
Reported here: https://bugzilla.redhat.com/show_bug.cgi?id=1169026 and apparently mentioned on the users list
