### PR TITLE
Update postfix-sasl.conf

### DIFF
--- a/config/filter.d/postfix-sasl.conf
+++ b/config/filter.d/postfix-sasl.conf
@@ -9,7 +9,7 @@ before = common.conf
 
 _daemon = postfix/(submission/)?smtp(d|s)
 
-failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL (?:LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/]*={0,2})?\s*$
+failregex = (?i): warning: [-._\w]+\[<HOST>\]: SASL (?:LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [A-Za-z0-9+/ ]*)?$
 
 ignoreregex = 
 


### PR DESCRIPTION
the actual version doesnt work with postfix 2.11.0-1 (part of fully patched Ubuntu 14.04.1 LTS)
auth faiilures look like that:
Dec  7 11:34:38 deep postfix/smtpd[5551]: warning: unknown[75.127.12.202]: SASL LOGIN authentication failed: authentication failure

didn't do that an my own, credits to
http://www.howtoforge.com/forums/member.php?u=81691