### PR TITLE
Add 'Client host rejected error message' regex

### DIFF
--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -13,6 +13,7 @@ before = common.conf
 _daemon = postfix/(submission/)?smtp(d|s)
 
 failregex = ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 554 5\.7\.1 .*$
+            ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 450 4\.7\.1 Client host rejected: cannot find your hostname, (\[\S*\]); from=<\S*> to=<\S+> proto=ESMTP helo=<\S*>$
             ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 450 4\.7\.1 : Helo command rejected: Host not found; from=<> to=<> proto=ESMTP helo= *$
             ^%(__prefix_line)sNOQUEUE: reject: VRFY from \S+\[<HOST>\]: 550 5\.1\.1 .*$
             ^%(__prefix_line)simproper command pipelining after \S+ from [^[]*\[<HOST>\]:?$


### PR DESCRIPTION
Not sure if it was reworded (using Postfix 2.6) or a slightly different error, but I only have "Client host rejected: cannot find your hostname"
