### PR TITLE
Add .idea dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ htmlcov
 *.bak
 __pycache__
 .vagrant/
+.idea/


### PR DESCRIPTION
PyCharm creates .idea directories in the projects' home, which can be ignored by git for this type of project imo
