### PR TITLE
port[s] typo fixed in jail.conf/nginx-http-auth, issue gh-913

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
 -----------
 
 - Fixes:
+   * port[s] typo in jail.conf/nginx-http-auth gh-913. Thanks Frederik Wagner (fnerdwq)
    * $ typo in jail.conf. Thanks Skibbi. Debian bug #767255
    * grep'ing for IP in *mail-whois-lines.conf should now match also
      at the begginning and EOL.  Thanks Dean Lee

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -291,7 +291,7 @@ maxretry = 1
 
 [nginx-http-auth]
 
-ports   = http,https
+port    = http,https
 logpath = %(nginx_error_log)s
 
 


### PR DESCRIPTION
closes #913 