### PR TITLE
Issue/161

### DIFF
--- a/fail2ban/server/asyncserver.py
+++ b/fail2ban/server/asyncserver.py
@@ -149,8 +149,11 @@ class AsyncServer(asyncore.dispatcher):
 		self.__init = True
 		# TODO Add try..catch
 		# There's a bug report for Python 2.6/3.0 that use_poll=True yields some 2.5 incompatibilities:
-		logSys.debug("Detected Python 2.6 or greater. asyncore.loop() not using poll")
-		asyncore.loop(use_poll=False) # fixes the "Unexpected communication problem" issue on Python 2.6 and 3.0
+		if sys.version_info >= (2, 7) and sys.version_info < (2, 8): # if python 2.7 ...
+			logSys.debug("Detected Python 2.7. asyncore.loop() using poll")
+			asyncore.loop(use_poll=True) # workaround for the "Bad file descriptor" issue on Python 2.7, gh-161
+		else:
+			asyncore.loop(use_poll=False) # fixes the "Unexpected communication problem" issue on Python 2.6 and 3.0
 	
 	##
 	# Stops the communication server.

--- a/fail2ban/tests/misctestcase.py
+++ b/fail2ban/tests/misctestcase.py
@@ -113,7 +113,7 @@ class SetupTest(unittest.TestCase):
 			# clean up
 			shutil.rmtree(tmp)
 			# remove build directory
-			os.system("%s %s clean --all >/dev/null"
+			os.system("%s %s clean --all >/dev/null 2>&1"
 					  % (sys.executable, self.setup))
 
 class TestsUtilsTest(unittest.TestCase):


### PR DESCRIPTION
closes #161
workaround for the "Bad file descriptor" issue on Python 2.7, gh-161 : asyncore.loop() using poll
by the way, prevents to write "'build/bdist.linux-x86_64' does not exist -- can't clean it" into stderr;