### PR TITLE
add nsupdate action

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,7 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
    - Monit config for fail2ban in /files/monit
    - New actions:
      - action.d/firewallcmd-multiport and action.d/firewallcmd-allports Thanks Donald Yandt
+     - action.d/nsupdate Thanks Andrew St. Jean
      
 - Enhancements:
    * Enable multiport for firewallcmd-new action.  Closes gh-834

--- a/THANKS
+++ b/THANKS
@@ -13,6 +13,7 @@ ag4ve (Shawn)
 Alasdair D. Campbell
 Amir Caspi
 Amy
+Andrew St. Jean
 Andrey G. Grozin
 Andy Fragen
 Arturo 'Buanzo' Busleiman

--- a/config/action.d/nsupdate.conf
+++ b/config/action.d/nsupdate.conf
@@ -20,6 +20,9 @@
 # keyfile	Full path to TSIG key file used for authentication between
 #		nsupdate and BIND.
 #
+# Create an nsupdate.local to set at least the <domain> and <keyfile>
+# options as they don't have default values.
+#
 # The ban and unban commands assume nsupdate will authenticate to the BIND
 # server using a TSIG key. The full path to the key file must be specified
 # in the <keyfile> parameter. Use this command to generate your TSIG key.

--- a/config/action.d/nsupdate.conf
+++ b/config/action.d/nsupdate.conf
@@ -1,0 +1,110 @@
+# Fail2Ban configuration file
+#
+# Author: Andrew St. Jean
+#
+# Use nsupdate to perform dynamic DNS updates on a BIND zone file.
+# One may want to do this to update a local RBL with banned IP addresses.
+#
+# Options
+#
+# domain	DNS domain that will appear in nsupdate add and delete
+#		commands.
+#
+# ttl		The time to live (TTL) in seconds of the TXT resource
+#		record.
+#
+# rdata		Data portion of the TXT resource record.
+#
+# nsupdatecmd	Full path to the nsupdate command.
+#
+# keyfile	Full path to TSIG key file used for authentication between
+#		nsupdate and BIND.
+#
+# The ban and unban commands assume nsupdate will authenticate to the BIND
+# server using a TSIG key. The full path to the key file must be specified
+# in the <keyfile> parameter. Use this command to generate your TSIG key.
+#
+# dnssec-keygen -a HMAC-MD5 -b 256 -n HOST <key_name>
+#
+# Replace <key_name> with some meaningful name.
+#
+# This command will generate two files. Specify the .private file in the
+# <keyfile> option. Note that the .key file must also be present in the same
+# directory for nsupdate to use the key.
+#
+# Don't forget to add the key and appropriate allow-update or update-policy
+# option to your named.conf file.
+#
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed once at the start of Fail2Ban.
+# Values:  CMD
+#
+actionstart =
+
+
+# Option:  actionstop
+# Notes.:  command executed once at the end of Fail2Ban
+# Values:  CMD
+#
+actionstop =
+
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+actioncheck =
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionban = echo <ip> | awk -F. '{print "prereq nxrrset "$4"."$3"."$2"."$1".<domain> TXT"; print "update add "$4"."$3"."$2"."$1".<domain> <ttl> IN TXT \"<rdata>\""; print "send"}' | <nsupdatecmd> -k <keyfile>
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionunban = echo <ip> | awk -F. '{print "update delete "$4"."$3"."$2"."$1".<domain>"; print "send"}' | <nsupdatecmd> -k <keyfile>
+
+[Init]
+
+# Option:  domain
+# Notes.:  DNS domain that nsupdate will update.
+# Values:  STRING
+#
+domain = 
+
+# Option:  ttl
+# Notes.:  time to live (TTL) of TXT resource record added by nsupdate.
+# Values:  NUM
+#
+ttl = 600
+
+# Option:  rdata
+# Notes.:  data portion of the TXT resource record added by nsupdate.
+# Values:  STRING
+#
+rdata = Your IP has been banned
+
+# Option:  nsupdatecmd
+# Notes.:  specifies the full path to the nsupdate program that dynamically
+#          updates BIND zone files.
+# Values:  CMD
+#
+nsupdatecmd = /usr/bin/nsupdate
+
+# Option:  keyfile
+# Notes.:  specifies the full path to the file containing the
+#	   TSIG key for communicating with BIND.
+# Values:  STRING
+#
+keyfile = 
+

--- a/config/action.d/nsupdate.conf
+++ b/config/action.d/nsupdate.conf
@@ -86,10 +86,11 @@ actionunban = echo <ip> | awk -F. '{print "update delete "$4"."$3"."$2"."$1".<do
 domain = 
 
 # Option:  ttl
-# Notes.:  time to live (TTL) of TXT resource record added by nsupdate.
+# Notes.:  time to live (TTL) in seconds of TXT resource record
+#          added by nsupdate.
 # Values:  NUM
 #
-ttl = 600
+ttl = 60
 
 # Option:  rdata
 # Notes.:  data portion of the TXT resource record added by nsupdate.


### PR DESCRIPTION
Adds a new action file that uses nsupdate to dynamically update a BIND
zone file with a TXT resource record representing a banned IP address.
Resource record is deleted from the zone when the ban expires.