### PR TITLE
Add filter variable __pam_auth

### DIFF
--- a/config/filter.d/common.conf
+++ b/config/filter.d/common.conf
@@ -53,4 +53,8 @@ __bsd_syslog_verbose = (<[^.]+\.[^.]+>)
 # This can be optional (for instance if we match named native log files)
 __prefix_line = \s*%(__bsd_syslog_verbose)s?\s*(?:%(__hostname)s )?(?:%(__kernel_prefix)s )?(?:@vserver_\S+ )?%(__daemon_combs_re)s?\s%(__daemon_extra_re)s?\s*
 
+# PAM authentication mechanism check for failures, e.g.: pam_unix, pam_sss,
+# pam_ldap
+__pam_auth = pam_unix
+
 # Author: Yaroslav Halchenko

--- a/config/filter.d/dovecot.conf
+++ b/config/filter.d/dovecot.conf
@@ -9,7 +9,7 @@ before = common.conf
 
 _daemon = (auth|dovecot(-auth)?|auth-worker)
 
-failregex = ^%(__prefix_line)s(pam_unix(\(dovecot:auth\))?:)?\s+authentication failure; logname=\S* uid=\S* euid=\S* tty=dovecot ruser=\S* rhost=<HOST>(\s+user=\S*)?\s*$
+failregex = ^%(__prefix_line)s(%(__pam_auth)s(\(dovecot:auth\))?:)?\s+authentication failure; logname=\S* uid=\S* euid=\S* tty=dovecot ruser=\S* rhost=<HOST>(\s+user=\S*)?\s*$
             ^%(__prefix_line)s(pop3|imap)-login: (Info: )?(Aborted login|Disconnected)(: Inactivity)? \(((auth failed, \d+ attempts)( in \d+ secs)?|tried to use (disabled|disallowed) \S+ auth)\):( user=<\S*>,)?( method=\S+,)? rip=<HOST>(, lip=(\d{1,3}\.){3}\d{1,3})?(, TLS( handshaking(: SSL_accept\(\) failed: error:[\dA-F]+:SSL routines:[TLS\d]+_GET_CLIENT_HELLO:unknown protocol)?)?(: Disconnected)?)?(, session=<\S+>)?\s*$
             ^%(__prefix_line)s(Info|dovecot: auth\(default\)): pam\(\S+,<HOST>\): pam_authenticate\(\) failed: (User not known to the underlying authentication module: \d+ Time\(s\)|Authentication failure \(password mismatch\?\))\s*$
 

--- a/config/filter.d/pam-generic.conf
+++ b/config/filter.d/pam-generic.conf
@@ -13,7 +13,7 @@ before = common.conf
 # Default: catch all failed logins
 _ttys_re=\S*
 
-__pam_re=\(?pam_unix(?:\(\S+\))?\)?:?
+__pam_re=\(?%(__pam_auth)s(?:\(\S+\))?\)?:?
 _daemon = \S+
 
 failregex = ^%(__prefix_line)s%(__pam_re)s\s+authentication failure; logname=\S* uid=\S* euid=\S* tty=%(_ttys_re)s ruser=\S* rhost=<HOST>(?:\s+user=.*)?\s*$

--- a/config/filter.d/vsftpd.conf
+++ b/config/filter.d/vsftpd.conf
@@ -10,7 +10,7 @@ before = common.conf
 
 [Definition]
 
-__pam_re=\(?pam_unix(?:\(\S+\))?\)?:?
+__pam_re=\(?%(__pam_auth)s(?:\(\S+\))?\)?:?
 _daemon =  vsftpd
 
 failregex = ^%(__prefix_line)s%(__pam_re)s\s+authentication failure; logname=\S* uid=\S* euid=\S* tty=(ftp)? ruser=\S* rhost=<HOST>(?:\s+user=.*)?\s*$

--- a/config/filter.d/wuftpd.conf
+++ b/config/filter.d/wuftpd.conf
@@ -11,7 +11,7 @@ before = common.conf
 [Definition]
 
 _daemon = wu-ftpd
-__pam_re=\(?pam_unix(?:\(wu-ftpd:auth\))?\)?:?
+__pam_re=\(?%(__pam_auth)s(?:\(wu-ftpd:auth\))?\)?:?
 
 failregex = ^%(__prefix_line)sfailed login from \S+ \[<HOST>\]\s*$
             ^%(__prefix_line)s%(__pam_re)s\s+authentication failure; logname=\S* uid=\S* euid=\S* tty=(ftp)? ruser=\S* rhost=<HOST>(?:\s+user=.*)?\s*$


### PR DESCRIPTION
Add filter variable __pam_auth to allow easier changing of pam auth backend.

This is an initial step for fixing issue #928 - would still be nice to auto set this.