### PR TITLE
Dovecot - dovecot auth failure from EL7

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,7 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
      Avoids problems with iptables versions not understanding 'all' for
      protocols and ports
    * filter.d/dovecot.conf - match pam_authenticate line from EL7
+   * filter.d/dovecot.conf - match unknown user line from EL7
 
 - New Features:
    - New filter:

--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,7 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
    * recidive uses iptables-allports banaction by default now.
      Avoids problems with iptables versions not understanding 'all' for
      protocols and ports
+   * filter.d/dovecot.conf - match pam_authenticate line from EL7
 
 - New Features:
    - New filter:

--- a/THANKS
+++ b/THANKS
@@ -83,6 +83,7 @@ Michael Hanselmann
 Mika (mkl)
 Nick Munger
 onorua
+Orion Poplawski
 Paul Marrapese
 Paul Traina
 Noel Butler

--- a/config/filter.d/dovecot.conf
+++ b/config/filter.d/dovecot.conf
@@ -11,7 +11,7 @@ _daemon = (auth|dovecot(-auth)?|auth-worker)
 
 failregex = ^%(__prefix_line)s(pam_unix(\(dovecot:auth\))?:)?\s+authentication failure; logname=\S* uid=\S* euid=\S* tty=dovecot ruser=\S* rhost=<HOST>(\s+user=\S*)?\s*$
             ^%(__prefix_line)s(pop3|imap)-login: (Info: )?(Aborted login|Disconnected)(: Inactivity)? \(((auth failed, \d+ attempts)( in \d+ secs)?|tried to use (disabled|disallowed) \S+ auth)\):( user=<\S*>,)?( method=\S+,)? rip=<HOST>(, lip=(\d{1,3}\.){3}\d{1,3})?(, TLS( handshaking(: SSL_accept\(\) failed: error:[\dA-F]+:SSL routines:[TLS\d]+_GET_CLIENT_HELLO:unknown protocol)?)?(: Disconnected)?)?(, session=<\S+>)?\s*$
-            ^%(__prefix_line)s(Info|dovecot: auth\(default\)): pam\(\S+,<HOST>\): pam_authenticate\(\) failed: (User not known to the underlying authentication module: \d+ Time\(s\)|Authentication failure \(password mismatch\?\))\s*$
+            ^%(__prefix_line)s(Info|dovecot: auth\(default\)|auth-worker\(\d+\)): pam\(\S+,<HOST>\): pam_authenticate\(\) failed: (User not known to the underlying authentication module: \d+ Time\(s\)|Authentication failure \(password mismatch\?\))\s*$
 
 ignoreregex = 
 

--- a/config/filter.d/dovecot.conf
+++ b/config/filter.d/dovecot.conf
@@ -12,6 +12,7 @@ _daemon = (auth|dovecot(-auth)?|auth-worker)
 failregex = ^%(__prefix_line)s(pam_unix(\(dovecot:auth\))?:)?\s+authentication failure; logname=\S* uid=\S* euid=\S* tty=dovecot ruser=\S* rhost=<HOST>(\s+user=\S*)?\s*$
             ^%(__prefix_line)s(pop3|imap)-login: (Info: )?(Aborted login|Disconnected)(: Inactivity)? \(((auth failed, \d+ attempts)( in \d+ secs)?|tried to use (disabled|disallowed) \S+ auth)\):( user=<\S*>,)?( method=\S+,)? rip=<HOST>(, lip=(\d{1,3}\.){3}\d{1,3})?(, TLS( handshaking(: SSL_accept\(\) failed: error:[\dA-F]+:SSL routines:[TLS\d]+_GET_CLIENT_HELLO:unknown protocol)?)?(: Disconnected)?)?(, session=<\S+>)?\s*$
             ^%(__prefix_line)s(Info|dovecot: auth\(default\)|auth-worker\(\d+\)): pam\(\S+,<HOST>\): pam_authenticate\(\) failed: (User not known to the underlying authentication module: \d+ Time\(s\)|Authentication failure \(password mismatch\?\))\s*$
+            ^%(__prefix_line)sauth-worker\(\d+\): pam\(\S+,<HOST>\): unknown user\s*$
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/dovecot
+++ b/fail2ban/tests/files/logs/dovecot
@@ -34,6 +34,9 @@ Jul 02 13:49:32 hostname dovecot[442]: dovecot: auth(default): pam(account@MYSER
 # failJSON: { "time": "2005-01-29T05:32:50", "match": true , "host": "1.2.3.4" }
 Jan 29 05:32:50 mail dovecot: auth-worker(304): pam(username,1.2.3.4): pam_authenticate() failed: Authentication failure (password mismatch?)
 
+# failJSON: { "time": "2005-01-29T05:13:40", "match": true , "host": "1.2.3.4" }
+Jan 29 05:13:40 mail dovecot: auth-worker(31326): pam(username,1.2.3.4): unknown user
+
 # failJSON: { "time": "2005-04-19T05:22:20", "match": true , "host": "80.255.3.104" }
 Apr 19 05:22:20 vm5 auth: pam_unix(dovecot:auth): authentication failure; logname= uid=0 euid=0 tty=dovecot ruser=informix rhost=80.255.3.104
 

--- a/fail2ban/tests/files/logs/dovecot
+++ b/fail2ban/tests/files/logs/dovecot
@@ -31,6 +31,9 @@ Jul 02 13:49:32 hostname dovecot[442]: dovecot: auth(default): pam(account@MYSER
 # failJSON: { "time": "2013-08-11T03:56:40", "match": true , "host": "1.2.3.4" }
 2013-08-11 03:56:40 auth-worker(default): Info: pam(username,1.2.3.4): pam_authenticate() failed: Authentication failure (password mismatch?)
 
+# failJSON: { "time": "2005-01-29T05:32:50", "match": true , "host": "1.2.3.4" }
+Jan 29 05:32:50 mail dovecot: auth-worker(304): pam(username,1.2.3.4): pam_authenticate() failed: Authentication failure (password mismatch?)
+
 # failJSON: { "time": "2005-04-19T05:22:20", "match": true , "host": "80.255.3.104" }
 Apr 19 05:22:20 vm5 auth: pam_unix(dovecot:auth): authentication failure; logname= uid=0 euid=0 tty=dovecot ruser=informix rhost=80.255.3.104
 


### PR DESCRIPTION
Updated the dovecot regex to match:

Jan 29 05:32:50 mail dovecot: auth-worker(304): pam(username,1.2.3.4): pam_authenticate() failed: Authentication failure (password mismatch?)

which I'm seeing on EL7 with dovecot 2.2.10