### PR TITLE
Add jail nginx-botsearch

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,7 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
    - New filter:
      - postfix-rbl  Thanks Lee Clemens
      - apache-fakegooglebot.conf  Thanks Lee Clemens
+     - nginx-botsearch  Thanks Frantisek Sumsal
    - New recursive embedded substitution feature added:
      - `<<PREF>HOST>` becomes `<IPV4HOST>` for PREF=`IPV4`;
      - `<<PREF>HOST>` becomes `1.2.3.4` for PREF=`IPV4` and IPV4HOST=`1.2.3.4`;

--- a/THANKS
+++ b/THANKS
@@ -39,6 +39,7 @@ Enrico Labedzki
 Eugene Hopkinson (SlowRiot)
 ftoppi
 François Boulogne
+Frantisek Sumsal
 Frédéric
 Georgiy Mernov
 Guilhem Lettron

--- a/config/filter.d/apache-botsearch.conf
+++ b/config/filter.d/apache-botsearch.conf
@@ -17,10 +17,9 @@
 [INCLUDES]
 
 # overwrite with apache-common.local if _apache_error_client is incorrect.
+# Load regexes for filtering from botsearch-common.conf
 before = apache-common.conf
-
-# Load regexes for filtering
-after = botsearch-common.conf
+         botsearch-common.conf
 
 [Definition]
 

--- a/config/filter.d/apache-botsearch.conf
+++ b/config/filter.d/apache-botsearch.conf
@@ -19,6 +19,9 @@
 # overwrite with apache-common.local if _apache_error_client is incorrect.
 before = apache-common.conf
 
+# Load regexes for filtering
+after = botsearch-common.conf
+
 [Definition]
 
 failregex = ^%(_apache_error_client)s ((AH001(28|30): )?File does not exist|(AH01264: )?script not found or unable to stat): <webroot><block>(, referer: \S+)?\s*$
@@ -31,16 +34,6 @@ ignoreregex =
 
 # Webroot represents the webroot on which all other files are based
 webroot = /var/www/
-# Block is the actual non-found directories to block
-block = (<webmail>|<phpmyadmin>|<wordpress>)[^,]*
-
-# These are just convient definitions that assist the blocking of stuff that 
-# isn't installed
-webmail = roundcube|(ext)?mail|horde|(v-?)?webmail
-
-phpmyadmin = (typo3/|xampp/|admin/|)(pma|(php)?[Mm]y[Aa]dmin)
-
-wordpress = wp-(login|signup)\.php
 
 
 # DEV Notes:

--- a/config/filter.d/botsearch-common.conf
+++ b/config/filter.d/botsearch-common.conf
@@ -1,0 +1,19 @@
+# Generic configuration file for -botsearch filters
+
+[Init]
+
+# Block is the actual non-found directories to block
+block = \/?(<webmail>|<phpmyadmin>|<wordpress>|cgi-bin|mysqladmin)[^,]*
+
+# These are just convient definitions that assist the blocking of stuff that 
+# isn't installed
+webmail = roundcube|(ext)?mail|horde|(v-?)?webmail
+
+phpmyadmin = (typo3/|xampp/|admin/|)(pma|(php)?[Mm]y[Aa]dmin)
+
+wordpress = wp-(login|signup)\.php
+
+# DEV Notes:
+# Taken from apache-botsearch filter
+# 
+# Author: Frantisek Sumsal

--- a/config/filter.d/nginx-botsearch.conf
+++ b/config/filter.d/nginx-botsearch.conf
@@ -4,7 +4,7 @@
 [Definition]
 
 failregex = ^<HOST> \- \S+ \[\] \"(GET|POST) \/<block> \S+\" 404 .+$
-			^ \[error\] \d+#\d+: \*\d+ (\S+ )?\"\S+\" (failed|is not found) \(2\: No such file or directory\), client\: <HOST>\, server\: \S*\, request: \"(GET|POST) \/<block> \S+\"\, .*?$
+            ^ \[error\] \d+#\d+: \*\d+ (\S+ )?\"\S+\" (failed|is not found) \(2\: No such file or directory\), client\: <HOST>\, server\: \S*\, request: \"(GET|POST) \/<block> \S+\"\, .*?$
 
 ignoreregex = 
 

--- a/config/filter.d/nginx-botsearch.conf
+++ b/config/filter.d/nginx-botsearch.conf
@@ -1,0 +1,29 @@
+# Fail2Ban filter to match web requests for selected URLs that don't exist
+#
+
+[Definition]
+
+failregex = ^<HOST> \- \S+ \[\] \"(GET|POST) \/<block> \S+\" 404 .+$
+			^ \[error\] \d+#\d+: \*\d+ (\S+ )?\"\S+\" (failed|is not found) \(2\: No such file or directory\), client\: <HOST>\, server\: \S*\, request: \"(GET|POST) \/<block> \S+\"\, .*?$
+
+ignoreregex = 
+
+
+[Init]
+
+# Block is the actual non-found directories to block
+block = \/?(<webmail>|<phpmyadmin>|<wordpress>|cgi-bin|mysqladmin)[^,]*
+
+# These are just convient definitions that assist the blocking of stuff that 
+# isn't installed
+webmail = roundcube|(ext)?mail|horde|(v-?)?webmail
+
+phpmyadmin = (typo3/|xampp/|admin/|)(pma|(php)?[Mm]y[Aa]dmin)
+
+wordpress = wp-(login|signup)\.php
+
+
+# DEV Notes:
+# Based on apache-botsearch filter
+# 
+# Author: Frantisek Sumsal

--- a/config/filter.d/nginx-botsearch.conf
+++ b/config/filter.d/nginx-botsearch.conf
@@ -1,26 +1,17 @@
 # Fail2Ban filter to match web requests for selected URLs that don't exist
 #
 
+[INCLUDES]
+
+# Load regexes for filtering
+before = botsearch-common.conf
+
 [Definition]
 
 failregex = ^<HOST> \- \S+ \[\] \"(GET|POST) \/<block> \S+\" 404 .+$
             ^ \[error\] \d+#\d+: \*\d+ (\S+ )?\"\S+\" (failed|is not found) \(2\: No such file or directory\), client\: <HOST>\, server\: \S*\, request: \"(GET|POST) \/<block> \S+\"\, .*?$
 
 ignoreregex = 
-
-
-[Init]
-
-# Block is the actual non-found directories to block
-block = \/?(<webmail>|<phpmyadmin>|<wordpress>|cgi-bin|mysqladmin)[^,]*
-
-# These are just convient definitions that assist the blocking of stuff that 
-# isn't installed
-webmail = roundcube|(ext)?mail|horde|(v-?)?webmail
-
-phpmyadmin = (typo3/|xampp/|admin/|)(pma|(php)?[Mm]y[Aa]dmin)
-
-wordpress = wp-(login|signup)\.php
 
 
 # DEV Notes:

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -298,8 +298,7 @@ logpath = %(nginx_error_log)s
 
 port     = http,https
 logpath  = %(nginx_error_log)s
-maxretry = 10
-findtime = 300
+maxretry = 2
 
 # Ban attackers that try to use PHP's URL-fopen() functionality
 # through GET/POST variables. - Experimental, with more than a year

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -294,6 +294,12 @@ maxretry = 1
 port    = http,https
 logpath = %(nginx_error_log)s
 
+[nginx-botsearch]
+
+port     = http,https
+logpath  = %(nginx_error_log)s
+maxretry = 10
+findtime = 300
 
 # Ban attackers that try to use PHP's URL-fopen() functionality
 # through GET/POST variables. - Experimental, with more than a year

--- a/fail2ban/tests/files/logs/nginx-botsearch
+++ b/fail2ban/tests/files/logs/nginx-botsearch
@@ -1,0 +1,23 @@
+# failJSON: { "time": "2015-01-20T19:53:28", "match": true , "host": "12.34.56.78" }
+12.34.56.78 - - [20/Jan/2015:19:53:28 +0100] "GET //phpMyAdmin-2.8.2.3/scripts/setup.php HTTP/1.1" 404 47 "-" "-" "-"
+
+# failJSON: { "time": "2015-01-20T19:53:28", "match": true , "host": "12.34.56.78" }
+12.34.56.78 - - [20/Jan/2015:19:53:28 +0100] "GET //pma/scripts/setup.php HTTP/1.1" 404 47 "-" "-" "-"
+
+# failJSON: { "time": "2015-01-20T19:53:28", "match": true , "host": "12.34.56.78" }
+12.34.56.78 - - [20/Jan/2015:19:53:28 +0100] "GET //mysqladmin/scripts/setup.php HTTP/1.1" 404 47 "-" "-" "-"
+
+# failJSON: { "time": "2015-01-20T19:53:28", "match": true , "host": "12.34.56.78" }
+12.34.56.78 - - [20/Jan/2015:19:53:28 +0100] "GET //admin/pma/scripts/setup.php HTTP/1.1" 404 47 "-" "-" "-"
+
+# failJSON: { "time": "2015-01-20T01:17:07", "match": true , "host": "7.8.9.10" }
+7.8.9.10 - root [20/Jan/2015:01:17:07 +0100] "GET /cgi-bin/recent.cgi HTTP/1.1" 404 162 "-" "-" "-"
+
+# failJSON: { "time": "2014-12-12T22:59:02", "match": true , "host": "2.5.2.5" }
+2.5.2.5 - tomcat [12/Dec/2014:22:59:02 +0100] "GET /cgi-bin/tools/tools.pl HTTP/1.1" 404 162 "-" "-" "-"
+
+# failJSON: { "time": "2015-01-21T10:56:10", "match": true , "host": "5.7.9.2" }
+2015/01/21 10:56:10 [error] 2833#0: *16336 open() "/var/www/site/cgi-bin/php4" failed (2: No such file or directory), client: 5.7.9.2, server: localhost, request: "GET /cgi-bin/php4 HTTP/1.1", host: "1.2.3.4"
+
+# failJSON: { "time": "2015-01-21T15:02:27", "match": true , "host": "5.7.9.2" }
+2015/01/21 15:02:27 [error] 2833#0: *16813 "/var/www/site/roundcube/" is not found (2: No such file or directory), client: 5.7.9.2, server: localhost, request: "GET /roundcube/ HTTP/1.1", host: "1.2.3.4"


### PR DESCRIPTION
Jail blocks requests for predefined non-existent folders. Based on
apache-botsearch jail.