### PR TITLE
Added sendmail-geoip-lines.conf

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,7 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
    - Monit config for fail2ban in /files/monit
    - New actions:
      - action.d/firewallcmd-multiport and action.d/firewallcmd-allports Thanks Donald Yandt
+     - action.d/sendmail-geoip-lines.conf
    - New status argument, flavor:
      - fail2ban-client status <jail> [flavor]
        - empty or "basic" works as-is

--- a/config/action.d/sendmail-geoip-lines.conf
+++ b/config/action.d/sendmail-geoip-lines.conf
@@ -1,0 +1,48 @@
+# Fail2Ban configuration file
+#
+# Author: Viktor Szépe
+#
+#
+
+[INCLUDES]
+
+before = sendmail-common.conf
+
+[Definition]
+
+# Option:  actionban
+# Notes.:  Command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+#          You need to install geoiplookup and the GeoLite or GeoIP databases.
+#          (geoip-bin and geoip-database-contrib in Debian)
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+            Date: `LC_TIME=C date -u +"%%a, %%d %%h %%Y %%T +0000"`
+            From: <sendername> <<sender>>
+            To: <dest>\n
+            Hi,\n
+            The IP <ip> has just been banned by Fail2Ban after
+            <failures> attempts against <name>.\n\n
+            Here is more information about <ip>:\n
+            http://bgp.he.net/ip/<ip>
+            http://www.projecthoneypot.org/ip_<ip>
+            http://whois.domaintools.com/<ip>\n\n
+            Country:`/usr/bin/geoiplookup -f /usr/share/GeoIP/GeoIP.dat "<ip>" | cut -d':' -f2-`
+            AS:`/usr/bin/geoiplookup -f /usr/share/GeoIP/GeoIPASNum.dat "<ip>" | cut -d':' -f2-`
+            hostname: `/usr/bin/host -t A <ip> 2>&1`\n\n
+            Lines containing IP:<ip> in <logpath>\n
+            `grep -E '(^|[^0-9])<ip>([^0-9]|$)' <logpath>`\n\n
+            Regards,\n
+            Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+
+[Init]
+
+# Default name of the chain
+#
+name = default
+
+# Path to the log files which contain relevant lines for the abuser IP
+#
+logpath = /dev/null

--- a/config/action.d/sendmail-geoip-lines.conf
+++ b/config/action.d/sendmail-geoip-lines.conf
@@ -14,12 +14,13 @@ before = sendmail-common.conf
 # Notes.:  Command executed when banning an IP. Take care that the
 #          command is executed with Fail2Ban user rights.
 #          You need to install geoiplookup and the GeoLite or GeoIP databases.
-#          (geoip-bin and geoip-database-contrib in Debian)
+#          (geoip-bin and geoip-database in Debian)
+#          The host command comes from bind9-host package.
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
 actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
-            Date: `LC_TIME=C date -u +"%%a, %%d %%h %%Y %%T +0000"`
+            Date: `LC_TIME=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n
             Hi,\n
@@ -29,9 +30,9 @@ actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             http://bgp.he.net/ip/<ip>
             http://www.projecthoneypot.org/ip_<ip>
             http://whois.domaintools.com/<ip>\n\n
-            Country:`/usr/bin/geoiplookup -f /usr/share/GeoIP/GeoIP.dat "<ip>" | cut -d':' -f2-`
-            AS:`/usr/bin/geoiplookup -f /usr/share/GeoIP/GeoIPASNum.dat "<ip>" | cut -d':' -f2-`
-            hostname: `/usr/bin/host -t A <ip> 2>&1`\n\n
+            Country:`geoiplookup -f /usr/share/GeoIP/GeoIP.dat "<ip>" | cut -d':' -f2-`
+            AS:`geoiplookup -f /usr/share/GeoIP/GeoIPASNum.dat "<ip>" | cut -d':' -f2-`
+            hostname: `host -t A <ip> 2>&1`\n\n
             Lines containing IP:<ip> in <logpath>\n
             `grep -E '(^|[^0-9])<ip>([^0-9]|$)' <logpath>`\n\n
             Regards,\n


### PR DESCRIPTION
Are these extremely useful links OK?
```
http://bgp.he.net/ip/<ip>
http://www.projecthoneypot.org/ip_<ip>
http://whois.domaintools.com/<ip>
```

My original geoip-config contains ` | /usr/bin/recode -f ..ASCII` to clear things up. Is it fail2ban-compatible?
