### PR TITLE
[postfix-sasl] update regexes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,8 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
      - match unknown user line from EL7
    * Use use_poll=True for Python 2.7 to overcome "Bad file descriptor" msgs
      issue (gh-161)
+   * filter.d/postfix-sasl.conf - tweak failregex and add ignoreregex to ignore
+     system authentication issues
 
 - New Features:
    - New filter:

--- a/config/filter.d/postfix-sasl.conf
+++ b/config/filter.d/postfix-sasl.conf
@@ -9,9 +9,9 @@ before = common.conf
 
 _daemon = postfix/(submission/)?smtp(d|s)
 
-failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL ((?i)LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/]*={0,2})?\s*$
+failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL ((?i)LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/:]*={0,2})?\s*$
 
-ignoreregex = 
+ignoreregex = authentication failed: Connection lost to authentication server$
 
 [Init]
 

--- a/fail2ban/tests/files/logs/postfix-sasl
+++ b/fail2ban/tests/files/logs/postfix-sasl
@@ -12,3 +12,12 @@ Sep  6 00:44:56 trianon postfix/submission/smtpd[11538]: warning: unknown[82.221
 #4 Example from postfix post-debian changes to rename to add "submission" to syslog name + downcase
 # failJSON: { "time": "2004-09-06T00:44:57", "match": true , "host": "82.221.106.233" }
 Sep  6 00:44:57 trianon postfix/submission/smtpd[11538]: warning: unknown[82.221.106.233]: SASL login authentication failed: UGFzc3dvcmQ6
+
+#5 Example to add :
+# failJSON: { "time": "2005-01-29T08:11:45", "match": true , "host": "1.1.1.1" }
+Jan 29 08:11:45 mail postfix/smtpd[10752]: warning: unknown[1.1.1.1]: SASL LOGIN authentication failed: Password:
+
+#6 Example to ignore
+# failJSON: { "time": "2005-02-03T08:29:28", "match": false , "host": "1.1.1.1" }
+Feb  3 08:29:28 mail postfix/smtpd[21022]: warning: unknown[1.1.1.1]: SASL LOGIN authentication failed: Connection lost to authentication server
+


### PR DESCRIPTION
- Add : to match "SASL LOGIN authentication failed: Password:"
- Add ignoreregex to ignore system authentication issues:
  "warning: unknown[1.1.1.1]: SASL LOGIN authentication failed: Connection lost to authentication server"
- Add test log messages for both