### PR TITLE
Configure Syslog Socket Path (closes #814)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -69,6 +69,7 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
      timezone not UTC time/zone. Closes gh-911
    * Conditionally log Ignore IP with reason (dns, ip, command). Closes gh-916
    * Absorbed DNSUtils.cidr into addr2bin in filter.py, added unittests
+   * Added syslogsocket configuration to fail2ban.conf
 
 
 ver. 0.9.1 (2014/10/29) - better, faster, stronger

--- a/config/fail2ban.conf
+++ b/config/fail2ban.conf
@@ -36,8 +36,9 @@ logtarget = /var/log/fail2ban.log
 
 # Option: syslogsocket
 # Notes: Set the syslog socket file. Only used when logtarget is SYSLOG
-# Values: [ FILE ]  Default: /dev/log
-syslogsocket = /dev/log
+#        auto uses platform.system() to determine predefined paths
+# Values: [ auto | FILE ]  Default: auto
+syslogsocket = auto
 
 # Option: socket
 # Notes.: Set the socket file. This is used to communicate with the daemon. Do

--- a/config/fail2ban.conf
+++ b/config/fail2ban.conf
@@ -34,6 +34,11 @@ loglevel = INFO
 #
 logtarget = /var/log/fail2ban.log
 
+# Option: syslogsocket
+# Notes: Set the syslog socket file. Only used when logtarget is SYSLOG
+# Values: [ FILE ]  Default: /dev/log
+syslogsocket = /dev/log
+
 # Option: socket
 # Notes.: Set the socket file. This is used to communicate with the daemon. Do
 #         not remove this file when Fail2ban runs. It will not be possible to

--- a/fail2ban/client/beautifier.py
+++ b/fail2ban/client/beautifier.py
@@ -85,6 +85,9 @@ class Beautifier:
 						val = " ".join(res1[1]) if isinstance(res1[1], list) else res1[1]
 						msg.append("%s %s:\t%s" % (prefix1, res1[0], val))
 				msg = "\n".join(msg)
+			elif inC[1] == "syslogsocket":
+				msg = "Current syslog socket is:\n"
+				msg = msg + "`- " + response
 			elif inC[1] == "logtarget":
 				msg = "Current logging target is:\n"
 				msg = msg + "`- " + response

--- a/fail2ban/client/fail2banreader.py
+++ b/fail2ban/client/fail2banreader.py
@@ -46,6 +46,7 @@ class Fail2banReader(ConfigReader):
 	def getOptions(self):
 		opts = [["string", "loglevel", "INFO" ],
 				["string", "logtarget", "STDERR"],
+				["string", "syslogsocket", "/dev/log"],
 				["string", "dbfile", "/var/lib/fail2ban/fail2ban.sqlite3"],
 				["int", "dbpurgeage", 86400]]
 		self.__opts = ConfigReader.getOptions(self, "Definition", opts)
@@ -57,6 +58,8 @@ class Fail2banReader(ConfigReader):
 				stream.append(["set", "loglevel", self.__opts[opt]])
 			elif opt == "logtarget":
 				stream.append(["set", "logtarget", self.__opts[opt]])
+			elif opt == "syslogsocket":
+				stream.append(["set", "syslogsocket", self.__opts[opt]])
 			elif opt == "dbfile":
 				stream.append(["set", "dbfile", self.__opts[opt]])
 			elif opt == "dbpurgeage":

--- a/fail2ban/client/fail2banreader.py
+++ b/fail2ban/client/fail2banreader.py
@@ -46,7 +46,7 @@ class Fail2banReader(ConfigReader):
 	def getOptions(self):
 		opts = [["string", "loglevel", "INFO" ],
 				["string", "logtarget", "STDERR"],
-				["string", "syslogsocket", "/dev/log"],
+				["string", "syslogsocket", "auto"],
 				["string", "dbfile", "/var/lib/fail2ban/fail2ban.sqlite3"],
 				["int", "dbpurgeage", 86400]]
 		self.__opts = ConfigReader.getOptions(self, "Definition", opts)

--- a/fail2ban/protocol.py
+++ b/fail2ban/protocol.py
@@ -44,7 +44,7 @@ protocol = [
 ["get loglevel", "gets the logging level"], 
 ["set logtarget <TARGET>", "sets logging target to <TARGET>. Can be STDOUT, STDERR, SYSLOG or a file"], 
 ["get logtarget", "gets logging target"], 
-["set syslogsocket <SOCKET>", "sets the syslog socket path to <SOCKET>. Only used if logtarget is SYSLOG"],
+["set syslogsocket auto|<SOCKET>", "sets the syslog socket path to auto or <SOCKET>. Only used if logtarget is SYSLOG"],
 ["get syslogsocket", "gets syslog socket path"],
 ["flushlogs", "flushes the logtarget if a file and reopens it. For log rotation."], 
 ['', "DATABASE", ""],

--- a/fail2ban/protocol.py
+++ b/fail2ban/protocol.py
@@ -44,6 +44,8 @@ protocol = [
 ["get loglevel", "gets the logging level"], 
 ["set logtarget <TARGET>", "sets logging target to <TARGET>. Can be STDOUT, STDERR, SYSLOG or a file"], 
 ["get logtarget", "gets logging target"], 
+["set syslogsocket <SOCKET>", "sets the syslog socket path to <SOCKET>. Only used if logtarget is SYSLOG"],
+["get syslogsocket", "gets syslog socket path"],
 ["flushlogs", "flushes the logtarget if a file and reopens it. For log rotation."], 
 ['', "DATABASE", ""],
 ["set dbfile <FILE>", "set the location of fail2ban persistent datastore. Set to \"None\" to disable"], 

--- a/fail2ban/server/transmitter.py
+++ b/fail2ban/server/transmitter.py
@@ -121,6 +121,12 @@ class Transmitter:
 				return self.__server.getLogTarget()
 			else:
 				raise Exception("Failed to change log target")
+		elif name == "syslogsocket":
+			value = command[1]
+			if self.__server.setSyslogSocket(value):
+				return self.__server.getSyslogSocket()
+			else:
+				raise Exception("Failed to change syslog socket")
 		#Database
 		elif name == "dbfile":
 			self.__server.setDatabase(command[1])
@@ -264,6 +270,8 @@ class Transmitter:
 			return self.__server.getLogLevel()
 		elif name == "logtarget":
 			return self.__server.getLogTarget()
+		elif name == "syslogsocket":
+			return self.__server.getSyslogSocket()
 		#Database
 		elif name == "dbfile":
 			db = self.__server.getDatabase()

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -624,7 +624,7 @@ class JailsReaderTest(LogCaptureTestCase):
 							  ['set', 'dbpurgeage', 86400],
 							  ['set', 'loglevel', "INFO"],
 							  ['set', 'logtarget', '/var/log/fail2ban.log'],
-							  ['set', 'syslogsocket', '/dev/log']])
+							  ['set', 'syslogsocket', 'auto']])
 
 			# and if we force change configurator's fail2ban's baseDir
 			# there should be an error message (test visually ;) --

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -623,7 +623,8 @@ class JailsReaderTest(LogCaptureTestCase):
 								'/var/lib/fail2ban/fail2ban.sqlite3'],
 							  ['set', 'dbpurgeage', 86400],
 							  ['set', 'loglevel', "INFO"],
-							  ['set', 'logtarget', '/var/log/fail2ban.log']])
+							  ['set', 'logtarget', '/var/log/fail2ban.log'],
+							  ['set', 'syslogsocket', '/dev/log']])
 
 			# and if we force change configurator's fail2ban's baseDir
 			# there should be an error message (test visually ;) --

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -739,6 +739,7 @@ class TransmitterLogging(TransmitterBase):
 		self.server = Server()
 		self.server.setLogTarget("/dev/null")
 		self.server.setLogLevel("CRITICAL")
+		self.server.setSyslogSocket("/dev/log")
 		super(TransmitterLogging, self).setUp()
 
 	def testLogTarget(self):
@@ -766,6 +767,16 @@ class TransmitterLogging(TransmitterBase):
 			raise unittest.SkipTest("'/dev/log' not present")
 		elif not os.path.exists("/dev/log"):
 			return
+		self.setGetTest("logtarget", "SYSLOG")
+
+	def testSyslogSocket(self):
+		self.setGetTest("syslogsocket", "/dev/log/NEW/PATH")
+
+	def testSyslogSocketNOK(self):
+		self.setGetTest("syslogsocket", "/this/path/should/not/exist")
+		self.setGetTestNOK("logtarget", "SYSLOG")
+		# set back for other tests
+		self.setGetTest("syslogsocket", "/dev/log")
 		self.setGetTest("logtarget", "SYSLOG")
 
 	def testLogLevel(self):

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -739,7 +739,7 @@ class TransmitterLogging(TransmitterBase):
 		self.server = Server()
 		self.server.setLogTarget("/dev/null")
 		self.server.setLogLevel("CRITICAL")
-		self.server.setSyslogSocket("/dev/log")
+		self.server.setSyslogSocket("auto")
 		super(TransmitterLogging, self).setUp()
 
 	def testLogTarget(self):
@@ -767,7 +767,9 @@ class TransmitterLogging(TransmitterBase):
 			raise unittest.SkipTest("'/dev/log' not present")
 		elif not os.path.exists("/dev/log"):
 			return
+		self.assertTrue(self.server.getSyslogSocket(), "auto")
 		self.setGetTest("logtarget", "SYSLOG")
+		self.assertTrue(self.server.getSyslogSocket(), "/dev/log")
 
 	def testSyslogSocket(self):
 		self.setGetTest("syslogsocket", "/dev/log/NEW/PATH")


### PR DESCRIPTION
fail2ban.conf now includes syslogsocket value, default = /dev/log
Can be overridden in fail2ban.local