### PR TITLE
ENH: check badips.com response on presence of "categories" in it

### DIFF
--- a/config/action.d/badips.py
+++ b/config/action.d/badips.py
@@ -111,6 +111,8 @@ class BadIPsAction(ActionBase):
 		------
 		HTTPError
 			Any issues with badips.com request.
+		ValueError
+			If badips.com response didn't contain necessary information
 		"""
 		try:
 			response = urlopen(
@@ -122,7 +124,13 @@ class BadIPsAction(ActionBase):
 				messages['err'])
 			raise
 		else:
-			categories = json.loads(response.read().decode('utf-8'))['categories']
+			response_json = json.loads(response.read().decode('utf-8'))
+			if not 'categories' in response_json:
+				err = "badips.com response lacked categories specification. Response was: %s" \
+				  % (response_json,)
+				self._logSys.error(err)
+				raise ValueError(err)
+			categories = response_json['categories']
 			categories_names = set(
 				value['Name'] for value in categories)
 			if incParents:


### PR DESCRIPTION
As https://travis-ci.org/fail2ban/fail2ban/jobs/50609529 shows
query might fail in that response would not contain "categories".
With this change we will handle it explicitly and will spit out ValueError,
providing information about the response so it could be
troubleshooted