### PR TITLE
Allow use of Python virtual environment in Redhat sysv init script

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,8 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
      issue (gh-161)
    * filter.d/postfix-sasl.conf - tweak failregex and add ignoreregex to ignore
      system authentication issues
+   * files/redhat-initrd - activate python virtual environment
+     if available in /etc/default/fail2ban
 
 - New Features:
    - New filter:

--- a/files/redhat-initd
+++ b/files/redhat-initd
@@ -21,10 +21,13 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
+[ -f /etc/default/fail2ban ] && source /etc/default/fail2ban
+[ "$PYTHON_VENV" ] && [ -f ${PYTHON_VENV}/bin/activate ] && source ${PYTHON_VENV}/bin/activate
+
 # Check that the config file exists
 [ -f /etc/fail2ban/fail2ban.conf ] || exit 0
 
-FAIL2BAN="/usr/bin/fail2ban-client"
+FAIL2BAN=$(which fail2ban-client)
 prog=fail2ban-server
 lockfile=${LOCKFILE-/var/lock/subsys/fail2ban}
 socket=${SOCKET-/var/run/fail2ban/fail2ban.sock}


### PR DESCRIPTION
Use /etc/default/fail2ban to determine Python virtual environment and activate it (also dynamically determine path to `fail2ban-client` using `which`.

If /etc/default/fail2ban does not exist, or defined virtual environment does not exist - falls back to existing behavior (but uses `which` to find `fail2ban-client`).