### PR TITLE
Shorewall shorewall-ipset-proto6.conf

### DIFF
--- a/config/filter.d/shorewall-ipset-proto6.conf
+++ b/config/filter.d/shorewall-ipset-proto6.conf
@@ -1,0 +1,57 @@
+# Fail2Ban configuration file
+#
+# Author: Eduardo Diaz
+#
+# This is for ipset protocol 6 (and hopefully later) (ipset v6.14).
+# for shorewall
+#
+# This requires the program ipset which is normally in package called ipset.
+#
+# IPset was a feature introduced in the linux kernel 2.6.39 and 3.0.0 kernels.
+#
+# If you are running on an older kernel you make need to patch in external
+# modules.
+# Enable to shorewall use a blacklist using iptables creating a file /etc/shorewall/blacklist
+# and adding +f2b-shorewall to this file see details in shorewall documentation blacklist
+# to enable restore you ipset You must set SAVE_IPSETS=Yes in shorewall.conf
+# Is importan to read this documentation from shorewall http://shorewall.net/ipsets.html
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed once at the start of Fail2Ban.
+# Values:  CMD
+#
+actionstart = if ! ipset -quiet -name list f2b-shorewall >/dev/null;
+              then ipset create f2b-shorewall hash:ip timeout <bantime>;
+              fi
+
+# Option:  actionstop
+# Notes.:  command executed once at the end of Fail2Ban
+# Values:  CMD
+#
+actionstop = ipset flush f2b-shorewall
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionban = ipset add f2b-shorewall <ip> timeout <bantime> -exist
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionunban = ipset del f2b-shorewall <ip> -exist
+
+[Init]
+
+# Option: bantime
+# Notes:  specifies the bantime in seconds (handled internally rather than by fail2ban)
+# Values:  [ NUM ]  Default: 600
+#
+bantime = 38000

--- a/config/filter.d/shorewall-ipset-proto6.conf
+++ b/config/filter.d/shorewall-ipset-proto6.conf
@@ -11,9 +11,10 @@
 #
 # If you are running on an older kernel you make need to patch in external
 # modules.
-# Enable to shorewall use a blacklist using iptables creating a file /etc/shorewall/blacklist
-# and adding +f2b-shorewall to this file see details in shorewall documentation blacklist
-# to enable restore you ipset You must set SAVE_IPSETS=Yes in shorewall.conf
+# Enable to shorewall use a blacklist using ipset creating a file /etc/shorewall/blacklist
+# and adding +f2b-shorewall to this file see details in shorewall documentation blacklist ipset
+# to enable restore you ipset You must set SAVE_IPSETS=Yes in shorewall.conf, restart fail2ban
+# and restart shorewall to create the ipset at first. 
 # Is importan to read this documentation from shorewall http://shorewall.net/ipsets.html
 
 [Definition]


### PR DESCRIPTION
Use ipset proto6 in shorewall. You must follow the rules to enable ipset in you blacklist

if you have a lot of spam (my case) is better use ipset rather than shorewall command line (is my firewall)

stop fail2ban with shorewall on one list of 1000 Ips takes 5 min with ipset in shorewall 10 sec.

Any comments are welcome.