### PR TITLE
BF: binding parameter error (unsupported type) (closes gh-973) ...

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,8 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
      system authentication issues
    * fail2ban-regex reads filter file(s) completely, incl. '.local' file etc. (gh-954)
    * firewallcmd-* actions: split output into separate lines for grepping (gh-908)
+   * binding parameter error (unsupported type) by writing json with invalid encoded
+     lines into sqlite database (gh-973), thanks to kot for issue reporting;
 
 - New Features:
    - New filters:

--- a/ChangeLog
+++ b/ChangeLog
@@ -38,8 +38,8 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
      system authentication issues
    * fail2ban-regex reads filter file(s) completely, incl. '.local' file etc. (gh-954)
    * firewallcmd-* actions: split output into separate lines for grepping (gh-908)
-   * binding parameter error (unsupported type) by writing json with invalid encoded
-     lines into sqlite database (gh-973), thanks to kot for issue reporting;
+   * Guard unicode encode/decode issues while storing records in the database.
+     Fixes "binding parameter error (unsupported type)" (gh-973), thanks to kot for reporting
 
 - New Features:
    - New filters:

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -802,8 +802,8 @@ class FileContainer:
 				" encoding) for this jail. Continuing"
 				" to process line ignoring invalid characters: %r" %
 				(self.getFileName(), self.getEncoding(), line))
-			if sys.version_info >= (3,): # In python3, must be decoded
-				line = line.decode(self.getEncoding(), 'ignore')
+			# decode with replacing error chars:
+			line = line.decode(self.getEncoding(), 'replace')
 		return line
 
 	def close(self):

--- a/fail2ban/tests/databasetestcase.py
+++ b/fail2ban/tests/databasetestcase.py
@@ -177,6 +177,17 @@ class DatabaseTest(LogCaptureTestCase):
 		self.assertTrue(
 			isinstance(self.db.getBans(jail=self.jail)[0], FailTicket))
 
+	def testAddBanInvalidEncoded(self):
+		if Fail2BanDb is None: # pragma: no cover
+			return
+		self.testAddJail()
+		ticket = FailTicket("127.0.0.1", 0, {'m': ['... user "\xd1\xe2\xe5\xf2\xe0"  ...'], 'a': 1})
+		self.db.addBan(self.jail, ticket)
+
+		self.assertEqual(len(self.db.getBans(jail=self.jail)), 1)
+		self.assertTrue(
+			isinstance(self.db.getBans(jail=self.jail)[0], FailTicket))
+
 	def testDelBan(self):
 		self.testAddBan()
 		ticket = self.db.getBans(jail=self.jail)[0]

--- a/fail2ban/tests/databasetestcase.py
+++ b/fail2ban/tests/databasetestcase.py
@@ -181,12 +181,16 @@ class DatabaseTest(LogCaptureTestCase):
 		if Fail2BanDb is None: # pragma: no cover
 			return
 		self.testAddJail()
-		ticket = FailTicket("127.0.0.1", 0, {'m': ['... user "\xd1\xe2\xe5\xf2\xe0"  ...'], 'a': 1})
+		ticket = FailTicket("127.0.0.1", 0, ['... user "\xd1\xe2\xe5\xf2\xe0"  ...'])
 		self.db.addBan(self.jail, ticket)
 
 		self.assertEqual(len(self.db.getBans(jail=self.jail)), 1)
+		readticket = self.db.getBans(jail=self.jail)[0]
+		## python 2 or 3 :
 		self.assertTrue(
-			isinstance(self.db.getBans(jail=self.jail)[0], FailTicket))
+			   readticket == FailTicket("127.0.0.1", 0, [u'... user "\ufffd\ufffd\ufffd\ufffd\ufffd"  ...'])
+			or readticket == ticket
+		)
 
 	def testDelBan(self):
 		self.testAddBan()


### PR DESCRIPTION
... by writing json with invalid encoded lines into sqlite database;
especially python < 3.0; try to prevent occurring such errors in the future;