### PR TITLE
shorewall-ipset-proto6.conf for shorewall

### DIFF
--- a/config/action.d/shorewall-ipset-proto6.conf
+++ b/config/action.d/shorewall-ipset-proto6.conf
@@ -22,10 +22,9 @@
 #
 # A lot of this depends of the shorewall version at least have the 4.5.5 Version
 #
-# Enable to shorewall use a blacklist using iptables creating a file /etc/shorewall/blrules
-# and adding "DROP     net:+f2b-ssh    all" one for every jail
-# details in shorewall documentation blacklist.
-# to enable restore you ipset You must set SAVE_IPSETS=Yes in shorewall.conf
+# Enable shorewall to use a blacklist using iptables creating a file /etc/shorewall/blrules
+# and adding "DROP     net:+f2b-ssh    all" one for every jail details in shorewall documentation blacklist.
+# To enable restore you ipset You must set SAVE_IPSETS=Yes in shorewall.conf
 # Is importan to read this documentation from shorewall http://shorewall.net/ipsets.html
 #
 # To force create the ipset in the case that somebody delete the ipset create a file

--- a/config/action.d/shorewall-ipset-proto6.conf
+++ b/config/action.d/shorewall-ipset-proto6.conf
@@ -1,0 +1,84 @@
+# Fail2Ban configuration file
+#
+# Author: Eduardo Diaz
+#
+# This is for ipset protocol 6 (and hopefully later) (ipset v6.14).
+# for shorewall
+#
+# Use this setting in jail.conf to modify the name and the max time in every jain
+# action   = shorewall-ipset-proto6[name=SSH, bantime=10000]
+#
+# This requires the program ipset which is normally in package called ipset.
+#
+# IPset was a feature introduced in the linux kernel 2.6.39 and 3.0.0 kernels.
+#
+# The default Shorewall configuration is with "BLACKLISTNEWONLY=Yes" (see
+# file /etc/shorewall/shorewall.conf). This means that when Fail2ban adds a
+# new shorewall rule to ban an IP address, that rule will affect only new
+# connections. So if the attempter goes on trying using the same connection
+# he could even log in. In order to get the same behavior of the iptable
+# action (so that the ban is immediate) the /etc/shorewall/shorewall.conf
+# file should me modified with "BLACKLISTNEWONLY=No".
+#
+# A lot of this depends of the shorewall version at least have the 4.5.5 Version
+#
+# Enable to shorewall use a blacklist using iptables creating a file /etc/shorewall/blrules
+# and adding "DROP     net:+f2b-ssh    all" one for every jail
+# details in shorewall documentation blacklist.
+# to enable restore you ipset You must set SAVE_IPSETS=Yes in shorewall.conf
+# Is importan to read this documentation from shorewall http://shorewall.net/ipsets.html
+#
+# To force create the ipset in the case that somebody delete the ipset create a file
+# /etc/shorewall/initdone and add one line for every ipset (this files are in Perl)
+# take care of add 1; at the end of the file
+# the example is:
+# system("/usr/sbin/ipset -quiet -exist create f2b-ssh hash:ip timeout 600 ");
+# 1;
+#
+# To destroy the ipset in shorewall you must add to the file /etc/shorewall/stopped
+# # One line of every ipset
+# system("/usr/sbin/ipset -quiet destroy f2b-ssh ");
+# 1; # This must go to the end of the file if not shorewall complilation fails
+#
+#
+
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed once at the start of Fail2Ban.
+# Values:  CMD
+#
+actionstart = if ! ipset -quiet -name list f2b-<name> >/dev/null;
+              then ipset -quiet -exist create f2b-<name> hash:ip timeout <bantime>;
+              fi
+
+# Option:  actionstop
+# Notes.:  command executed once at the end of Fail2Ban
+# Values:  CMD
+#
+actionstop = ipset flush f2b-<name>
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionban = ipset add f2b-<name> <ip> timeout <bantime> -exist
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionunban = ipset del f2b-<name> <ip> -exist
+
+[Init]
+
+# Option: bantime
+# Notes:  specifies the bantime in seconds (handled internally rather than by fail2ban)
+# Values:  [ NUM ]  Default: 600
+#
+bantime = 600

--- a/config/action.d/shorewall-ipset-proto6.conf
+++ b/config/action.d/shorewall-ipset-proto6.conf
@@ -20,7 +20,8 @@
 # action (so that the ban is immediate) the /etc/shorewall/shorewall.conf
 # file should me modified with "BLACKLISTNEWONLY=No".
 #
-# A lot of this depends of the shorewall version at least have the 4.5.5 Version
+# The use in IPset in shorewall depends of the version you must have at least 4.5.5< version
+# of shorewall
 #
 # Enable shorewall to use a blacklist using iptables creating a file /etc/shorewall/blrules
 # and adding "DROP     net:+f2b-ssh    all" one for every jail details in shorewall documentation blacklist.
@@ -37,7 +38,7 @@
 # To destroy the ipset in shorewall you must add to the file /etc/shorewall/stopped
 # # One line of every ipset
 # system("/usr/sbin/ipset -quiet destroy f2b-ssh ");
-# 1; # This must go to the end of the file if not shorewall complilation fails
+# 1; # This must go to the end of the file if not shorewall compilation fails
 #
 #
 


### PR DESCRIPTION
Use ipset proto6 in shorewall. You must follow the rules to enable ipset in you blacklist
if you have a lot of spam (my case) is better use ipset rather than shorewall command line (is my firewall)
stop fail2ban with shorewall on one list of 1000 Ips takes 5 min with ipset in shorewall 10 sec.