### PR TITLE
Flush logs at USR1 signal

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -62,6 +62,7 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
      - empty or "basic" works as-is
      - "cymru" additionally prints (ASN, Country RIR) per banned IP
        (requires dnspython or dnspython3)
+   - Flush log at USR1 signal
 
 - Enhancements:
    * Enable multiport for firewallcmd-new action.  Closes gh-834

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -71,12 +71,17 @@ class Server:
 		logSys.debug("Caught signal %d. Exiting" % signum)
 		self.quit()
 	
+	def __sigUSR1Handler(self, signum, fname):
+		logSys.debug("Caught signal %d. Flushing logs" % signum)
+		self.flushLogs()
+
 	def start(self, sock, pidfile, force = False):
 		logSys.info("Starting Fail2ban v" + version.version)
 		
 		# Install signal handlers
 		signal.signal(signal.SIGTERM, self.__sigTERMhandler)
 		signal.signal(signal.SIGINT, self.__sigTERMhandler)
+		signal.signal(signal.SIGUSR1, self.__sigUSR1handler)
 		
 		# Ensure unhandled exceptions are logged
 		sys.excepthook = excepthook


### PR DESCRIPTION
FreeBSD's newsyslog can not run a command at log rotation, so it can not invoke `fail2ban-client flushlogs`, but it can send a configurable signal to a process.