### PR TITLE
BF: asyncore.loop poll=True for recent (>=3.4) pythons too

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,8 +32,8 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
    * filter.d/dovecot.conf
      - match pam_authenticate line from EL7
      - match unknown user line from EL7
-   * Use use_poll=True for Python 2.7 to overcome "Bad file descriptor" msgs
-     issue (gh-161)
+   * Use use_poll=True for Python 2.7 and >=3.4 to overcome "Bad file
+     descriptor" msgs issue (gh-161)
    * filter.d/postfix-sasl.conf - tweak failregex and add ignoreregex to ignore
      system authentication issues
    * fail2ban-regex reads filter file(s) completely, incl. '.local' file etc. (gh-954)

--- a/fail2ban/server/asyncserver.py
+++ b/fail2ban/server/asyncserver.py
@@ -149,7 +149,8 @@ class AsyncServer(asyncore.dispatcher):
 		self.__init = True
 		# TODO Add try..catch
 		# There's a bug report for Python 2.6/3.0 that use_poll=True yields some 2.5 incompatibilities:
-		if sys.version_info >= (2, 7) and sys.version_info < (2, 8): # if python 2.7 ...
+		if (sys.version_info >= (2, 7) and sys.version_info < (2, 8)) \
+		   or (sys.version_info >= (3, 4)): # if python 2.7 ...
 			logSys.debug("Detected Python 2.7. asyncore.loop() using poll")
 			asyncore.loop(use_poll=True) # workaround for the "Bad file descriptor" issue on Python 2.7, gh-161
 		else:


### PR DESCRIPTION
should avoid
  File /usr/lib/python3.4/asyncore.py, line 208, in loop
    poll_fun(timeout, map)
  File /usr/lib/python3.4/asyncore.py, line 145, in poll
    r, w, e = select.select(r, w, e, timeout)
OSError: [Errno 9] Bad file descriptor