### PR TITLE
BF/TST: expect ['error'] as a value if no dns module available

### DIFF
--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -511,6 +511,14 @@ class Transmitter(TransmitterBase):
 		)
 
 	def testJailStatusCymru(self):
+		try:
+			import dns.exception
+			import dns.resolver
+		except ImportError:
+			value = ['error']
+		else:
+			value = []
+
 		self.assertEqual(self.transm.proceed(["status", self.jailName, "cymru"]),
 			(0,
 				[
@@ -523,9 +531,9 @@ class Transmitter(TransmitterBase):
 						('Currently banned', 0),
 						('Total banned', 0),
 						('Banned IP list', []),
-						('Banned ASN list', []),
-						('Banned Country list', []),
-						('Banned RIR list', [])]
+						('Banned ASN list', value),
+						('Banned Country list', value),
+						('Banned RIR list', value)]
 					)
 				]
 			)


### PR DESCRIPTION
As many buildbots show:
e.g. http://nipy.bic.berkeley.edu/builders/fail2ban-py2.7-osx-10.8_master/builds/163/steps/shell_1/logs/stdio