### PR TITLE
Match hacking attempt IP instead of asterisk server IP (closes #1000)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -40,6 +40,7 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
    * firewallcmd-* actions: split output into separate lines for grepping (gh-908)
    * Guard unicode encode/decode issues while storing records in the database.
      Fixes "binding parameter error (unsupported type)" (gh-973), thanks to kot for reporting
+   * filter.d/asterisk.conf - Match hacking attempt IP instead of asterisk server IP
 
 - New Features:
    - New filters:

--- a/config/filter.d/asterisk.conf
+++ b/config/filter.d/asterisk.conf
@@ -22,7 +22,7 @@ failregex = ^(%(__prefix_line)s|\[\]\s*)%(log_prefix)s Registration from '[^']*'
             ^(%(__prefix_line)s|\[\]\s*)%(log_prefix)s No registration for peer '[^']*' \(from <HOST>\)$
             ^(%(__prefix_line)s|\[\]\s*)%(log_prefix)s Host <HOST> failed MD5 authentication for '[^']*' \([^)]+\)$
             ^(%(__prefix_line)s|\[\]\s*)%(log_prefix)s Failed to authenticate (user|device) [^@]+@<HOST>\S*$
-            ^(%(__prefix_line)s|\[\]\s*)%(log_prefix)s (?:handle_request_subscribe: )?Sending fake auth rejection for (device|user) \d*<sip:[^@]+@<HOST>>;tag=\w+\S*$
+            ^(%(__prefix_line)s|\[\]\s*)%(log_prefix)s hacking attempt detected '<HOST>'$
             ^(%(__prefix_line)s|\[\]\s*)%(log_prefix)s SecurityEvent="(FailedACL|InvalidAccountID|ChallengeResponseFailed|InvalidPassword)",EventTV="[\d-]+",Severity="[\w]+",Service="[\w]+",EventVersion="\d+",AccountID="\d*",SessionID="0x[\da-f]+",LocalAddress="IPV[46]/(UD|TC)P/[\da-fA-F:.]+/\d+",RemoteAddress="IPV[46]/(UD|TC)P/<HOST>/\d+"(,Challenge="\w+",ReceivedChallenge="\w+")?(,ReceivedHash="[\da-f]+")?(,ACLName="\w+")?$
             ^(%(__prefix_line)s|\[\]\s*WARNING%(__pid_re)s:?(?:\[C-[\da-f]*\])? )Ext\. s: "Rejecting unknown SIP connection from <HOST>"$
 

--- a/fail2ban/tests/files/logs/asterisk
+++ b/fail2ban/tests/files/logs/asterisk
@@ -29,15 +29,9 @@
 [2013-05-13 07:10:53] SECURITY[1204] res_security_log.c: SecurityEvent="InvalidAccountID",EventTV="1368439853-500975",Severity="Error",Service="SIP",EventVersion="1",AccountID="00972599580679",SessionID="0x7f8ecc0421f8",LocalAddress="IPV4/UDP/1.2.3.4/5060",RemoteAddress="IPV4/UDP/1.2.3.4/5070"
 # failJSON: { "time": "2013-06-10T18:15:03", "match": true , "host": "1.2.3.4" }
 [2013-06-10 18:15:03] NOTICE[2723] chan_sip.c: Registration from '"100"<sip:100@192.168.0.2:5060>' failed for '1.2.3.4' - Not a local domain
-# http://forum.4psa.com/showthread.php?t=6601
-# failJSON: { "time": "2009-12-22T16:35:24", "match": true , "host": "192.168.2.102" }
-[2009-12-22 16:35:24] NOTICE[6163] chan_sip.c: Sending fake auth rejection for device <sip:0004*001@192.168.2.102>;tag=e3793a95e1acbc69o
-# http://www.freepbx.org/forum/general-help/fake-auth-rejection
-# failJSON: { "time": "2009-12-22T16:35:24", "match": true , "host": "192.168.2.102" }
-[2009-12-22 16:35:24] NOTICE[1570][C-00000086] chan_sip.c: Sending fake auth rejection for device 1022<sip:1022@192.168.2.102>;tag=5d8b6f92
-# http://www.spinics.net/lists/asterisk/msg127381.html
-# failJSON: { "time": "2009-12-22T16:35:24", "match": true , "host": "192.168.2.102" }
-[2009-12-22 16:35:24] NOTICE[14916]: chan_sip.c:15644 handle_request_subscribe: Sending fake auth rejection for user <sip:CS@192.168.2.102>;tag=6pwd6erg54
+# http://sourceforge.net/p/fail2ban/mailman/message/33603322/
+# failJSON: { "time": "2015-03-16T18:46:34", "match": true , "host": "192.168.2.102" }
+[2015-03-16 18:46:34] NOTICE[3453] chan_sip.c: hacking attempt detected '192.168.2.102'
 # failJSON: { "time": "2013-07-06T09:09:25", "match": true , "host": "141.255.164.106" }
 [2013-07-06 09:09:25] SECURITY[3308] res_security_log.c: SecurityEvent="InvalidPassword",EventTV="1373098165-824497",Severity="Error",Service="SIP",EventVersion="2",AccountID="972592891005",SessionID="0x88aab6c",LocalAddress="IPV4/UDP/92.28.73.180/5060",RemoteAddress="IPV4/UDP/141.255.164.106/5084",Challenge="41d26de5",ReceivedChallenge="41d26de5",ReceivedHash="7a6a3a2e95a05260aee612896e1b4a39"
 # failJSON: { "time": "2014-01-10T16:39:06", "match": true , "host": "50.30.42.14" }


### PR DESCRIPTION
Sending fake auth rejection for (device|user) logs use the asterisk server's public IP (per referenced URLs in previous sample logs file. Replaced the regex with one matching (hacking attempt) log mentioned on mailing list.