### PR TITLE
Non-US locale warning for proftpd

### DIFF
--- a/config/filter.d/proftpd.conf
+++ b/config/filter.d/proftpd.conf
@@ -3,7 +3,7 @@
 # Set "UseReverseDNS off" in proftpd.conf to avoid the need for DNS.
 # See: http://www.proftpd.org/docs/howto/DNS.html
 # When the default locale for your system is not en_US.UTF-8
-# be sure to add this to /etc/default/proftpd
+# on Debian-based systems be sure to add this to /etc/default/proftpd
 # export LC_TIME="en_US.UTF-8"
 
 [INCLUDES]

--- a/config/filter.d/proftpd.conf
+++ b/config/filter.d/proftpd.conf
@@ -2,6 +2,9 @@
 #
 # Set "UseReverseDNS off" in proftpd.conf to avoid the need for DNS.
 # See: http://www.proftpd.org/docs/howto/DNS.html
+# When the default locale for your system is not en_US.UTF-8
+# be sure to add this to /etc/default/proftpd
+# export LC_TIME="en_US.UTF-8"
 
 [INCLUDES]
 


### PR DESCRIPTION
For example with Hungarian default locale proftpd logs:
```
ápr 06 16:56:30 szerver.szepe.net proftpd[31424] szerver.szepe.net (94-*.pool.digikabel.hu[94.*]): FTP session closed.
```