### PR TITLE
Fix actions in ufw.conf

### DIFF
--- a/config/action.d/ufw.conf
+++ b/config/action.d/ufw.conf
@@ -13,9 +13,11 @@ actionstop =
 
 actioncheck = 
 
-actionban = [ -n "<application>" ] && app="app <application>" ; ufw insert <insertpos> <blocktype> from <ip> to <destination> $app
+actionban = [ -n "<application>" ] && app="app <application>"
+            ufw insert <insertpos> <blocktype> from <ip> to <destination> $app
 
-actionunban = [ -n "<application>" ] && app="app <application>" ; ufw delete <blocktype> from <ip> to <destination> $app
+actionunban = [ -n "<application>" ] && app="app <application>"
+            ufw delete <blocktype> from <ip> to <destination> $app
 
 [Init]
 # Option: insertpos


### PR DESCRIPTION
On Ubuntu 15.04 the ufw action was not working.
- With empty application, receiving errors:

2015-04-24 16:28:35,204 fail2ban.filter         [8527]: INFO    [sshd] Found 43.255.190.157
2015-04-24 16:28:35,695 fail2ban.actions        [8527]: NOTICE  [sshd] Ban 43.255.190.157
2015-04-24 16:28:35,802 fail2ban.action         [8527]: ERROR   [ -n "" ] && app="app " -- stdout: b''
2015-04-24 16:28:35,803 fail2ban.action         [8527]: ERROR   [ -n "" ] && app="app " -- stderr: b''
2015-04-24 16:28:35,803 fail2ban.action         [8527]: ERROR   [ -n "" ] && app="app " -- returned 1

- With action = ufw[application=OpenSSH], it was silently not doing
  anything (no errors after "Ban x.x.x.x", but no IP addresses in ufw
  status).

Re-arranged the bash commands on two lines, and it works with or without
application.