### PR TITLE
Add drupal-auth filter and jail

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -50,6 +50,7 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
      - postfix-rbl  Thanks Lee Clemens
      - apache-fakegooglebot.conf  Thanks Lee Clemens
      - nginx-botsearch  Thanks Frantisek Sumsal
+     - drupal-auth  Thanks Lee Clemens
    - New recursive embedded substitution feature added:
      - `<<PREF>HOST>` becomes `<IPV4HOST>` for PREF=`IPV4`;
      - `<<PREF>HOST>` becomes `1.2.3.4` for PREF=`IPV4` and IPV4HOST=`1.2.3.4`;

--- a/config/filter.d/drupal-auth.conf
+++ b/config/filter.d/drupal-auth.conf
@@ -1,0 +1,26 @@
+# Fail2Ban filter to block repeated failed login attempts to Drupal site(s)
+#
+#
+# Drupal must be setup to use Syslog, which defaults to the following format:
+#
+#   !base_url|!timestamp|!type|!ip|!request_uri|!referer|!uid|!link|!message
+#
+#
+
+[INCLUDES]
+
+before = common.conf
+
+
+[Definition]
+
+failregex = ^%(__prefix_line)s(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(\/[\w\.-]+)*\|\d{10}\|user\|<HOST>\|.+\|.+\|\d\|.*\|Login attempt failed for .+\.$
+
+ignoreregex =
+
+
+# DEV Notes:
+#
+# https://www.drupal.org/documentation/modules/syslog
+#
+# Author: Lee Clemens

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -385,6 +385,11 @@ maxretry = 5
 #
 #
 
+[drupal-auth]
+
+port     = http,https
+logpath  = %(syslog_daemon)s
+
 [guacamole]
 
 port     = http,https

--- a/fail2ban/tests/files/logs/drupal-auth
+++ b/fail2ban/tests/files/logs/drupal-auth
@@ -1,0 +1,7 @@
+# failJSON: { "time": "2005-04-26T13:15:25", "match": true , "host": "1.2.3.4" }
+Apr 26 13:15:25 webserver example.com: https://example.com|1430068525|user|1.2.3.4|https://example.com/?q=user|https://example.com/?q=user|0||Login attempt failed for drupaladmin.
+# failJSON: { "time": "2005-04-26T13:15:25", "match": true , "host": "1.2.3.4" }
+Apr 26 13:15:25 webserver example.com: https://example.com/subdir|1430068525|user|1.2.3.4|https://example.com/subdir/user|https://example.com/subdir/user|0||Login attempt failed for drupaladmin.
+
+# failJSON: { "time": "2005-04-26T13:19:08", "match": false , "host": "1.2.3.4" }
+Apr 26 13:19:08 webserver example.com: https://example.com|1430068748|user|1.2.3.4|https://example.com/user|https://example.com/user|1||Session opened for drupaladmin.


### PR DESCRIPTION
Matches syslog entries from Drupal installations to block users after failed login attempts