### PR TITLE
Fix actions in ufw.conf

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ ver. 0.9.2 (2014/XX/XXX) - wanna-be-released
 -----------
 
 - Fixes:
+   * Fix ufw action commands
    * infinite busy loop on _escapedTags match in substituteRecursiveTags gh-907.
      Thanks TonyThompson
    * port[s] typo in jail.conf/nginx-http-auth gh-913. Thanks Frederik Wagner (fnerdwq)

--- a/THANKS
+++ b/THANKS
@@ -6,6 +6,7 @@ the project.  If you have been left off, please let us know
 (preferably send a pull request on github with the "fix") and you will
 be added
 
+Aaron Brice
 Adam Tkac
 Adrien Clerc
 ache

--- a/config/action.d/ufw.conf
+++ b/config/action.d/ufw.conf
@@ -13,9 +13,11 @@ actionstop =
 
 actioncheck = 
 
-actionban = [ -n "<application>" ] && app="app <application>" ; ufw insert <insertpos> <blocktype> from <ip> to <destination> $app
+actionban = [ -n "<application>" ] && app="app <application>"
+            ufw insert <insertpos> <blocktype> from <ip> to <destination> $app
 
-actionunban = [ -n "<application>" ] && app="app <application>" ; ufw delete <blocktype> from <ip> to <destination> $app
+actionunban = [ -n "<application>" ] && app="app <application>"
+              ufw delete <blocktype> from <ip> to <destination> $app
 
 [Init]
 # Option: insertpos


### PR DESCRIPTION
On Ubuntu 15.04 the ufw action was not working.
- With empty application, receiving errors:

2015-04-24 16:28:35,204 fail2ban.filter         [8527]: INFO    [sshd] Found 43.255.190.157
2015-04-24 16:28:35,695 fail2ban.actions        [8527]: NOTICE  [sshd] Ban 43.255.190.157
2015-04-24 16:28:35,802 fail2ban.action         [8527]: ERROR   [ -n "" ] && app="app " -- stdout: b''
2015-04-24 16:28:35,803 fail2ban.action         [8527]: ERROR   [ -n "" ] && app="app " -- stderr: b''
2015-04-24 16:28:35,803 fail2ban.action         [8527]: ERROR   [ -n "" ] && app="app " -- returned 1

- With action = ufw[application=OpenSSH], it was silently not doing
  anything (no errors after "Ban x.x.x.x", but no IP addresses in ufw
  status).

Re-arranged the bash commands on two lines, and it works with or without
application.