### PR TITLE
BF: guarantee order of dbfile to be before dbpurgeage (Closes #1048)

### DIFF
--- a/fail2ban/client/fail2banreader.py
+++ b/fail2ban/client/fail2banreader.py
@@ -53,17 +53,19 @@ class Fail2banReader(ConfigReader):
 	
 	def convert(self):
 		stream = list()
+		# Ensure logtarget/level set first so any db errors are captured
+		# Also dbfile should be set before dbpurgeage.
+		# So adding order indices into items, to be stripped after sorting, upon return
 		for opt in self.__opts:
 			if opt == "loglevel":
-				stream.append(["set", "loglevel", self.__opts[opt]])
+				stream.append((3, ["set", "loglevel", self.__opts[opt]]))
 			elif opt == "logtarget":
-				stream.append(["set", "logtarget", self.__opts[opt]])
+				stream.append((2, ["set", "logtarget", self.__opts[opt]]))
 			elif opt == "syslogsocket":
-				stream.append(["set", "syslogsocket", self.__opts[opt]])
+				stream.append((1, ["set", "syslogsocket", self.__opts[opt]]))
 			elif opt == "dbfile":
-				stream.append(["set", "dbfile", self.__opts[opt]])
+				stream.append((4, ["set", "dbfile", self.__opts[opt]]))
 			elif opt == "dbpurgeage":
-				stream.append(["set", "dbpurgeage", self.__opts[opt]])
-		# Ensure logtarget/level set first so any db errors are captured
-		return sorted(stream, reverse=True)
-	
+				stream.append((5, ["set", "dbpurgeage", self.__opts[opt]]))
+		return [e[1] for e in sorted(stream)]
+

--- a/fail2ban/server/transmitter.py
+++ b/fail2ban/server/transmitter.py
@@ -138,6 +138,7 @@ class Transmitter:
 		elif name == "dbpurgeage":
 			db = self.__server.getDatabase()
 			if db is None:
+				logSys.warning("dbpurgeage setting was not in effect since no db yet")
 				return None
 			else:
 				db.purgeage = command[1]

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -616,6 +616,21 @@ class JailsReaderTest(LogCaptureTestCase):
 			configurator.getOptions()
 			configurator.convertToProtocol()
 			commands = configurator.getConfigStream()
+
+			# verify that dbfile comes before dbpurgeage
+			def find_set(option):
+				for i, e in enumerate(commands):
+					if e[0] == 'set' and e[1] == option:
+						return i
+				raise ValueError("Did not find command 'set %s' among commands %s"
+								 % (option, commands))
+
+			# Set up of logging should come first
+			self.assertEqual(find_set('logtarget'), 1)
+			self.assertEqual(find_set('loglevel'), 2)
+			# then dbfile should be before dbpurgeage
+			self.assertGreater(find_set('dbpurgeage'), find_set('dbfile'))
+
 			# and there is logging information left to be passed into the
 			# server
 			self.assertEqual(sorted(commands),


### PR DESCRIPTION
I think this should fix #1048 but need to run atm so can't check "live". may be later