### PR TITLE
Update regex to work with roundcube 1.0.5 and 1.1.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,10 @@ Fail2Ban: Changelog
 ver. 0.9.3 (2015/XX/XXX) - wanna-be-released
 -----------
 
+- IMPORTANT incompatible changes:
+   * filter.d/roundcube-auth.conf
+     - Changed logpath to 'errors' log (was 'userlogins')
+
 - Fixes:
    * reload in interactive mode appends all the jails twice (gh-825)
    * reload server/jail failed if database used (but was not changed) and
@@ -17,6 +21,10 @@ ver. 0.9.3 (2015/XX/XXX) - wanna-be-released
      Thanks Anton Shestakov
    * Fix fail2ban-regex not parsing journalmatch correctly from filter config
    * filter.d/asterisk.conf - fix security log support for Asterisk 12+
+   * filter.d/roundcube-auth.conf
+     - Updated regex to work with 'errors' log (v1.0.5)
+     - Added regex to work with 'userlogins' log
+   * jail.conf: Changed default logpath for roundcube-auth
 
 - New Features:
    - New filters:

--- a/ChangeLog
+++ b/ChangeLog
@@ -22,7 +22,7 @@ ver. 0.9.3 (2015/XX/XXX) - wanna-be-released
    * Fix fail2ban-regex not parsing journalmatch correctly from filter config
    * filter.d/asterisk.conf - fix security log support for Asterisk 12+
    * filter.d/roundcube-auth.conf
-     - Updated regex to work with 'errors' log (v1.0.5)
+     - Updated regex to work with 'errors' log (1.0.5 and 1.1.1)
      - Added regex to work with 'userlogins' log
    * jail.conf: Changed default logpath for roundcube-auth
 

--- a/config/filter.d/roundcube-auth.conf
+++ b/config/filter.d/roundcube-auth.conf
@@ -13,8 +13,8 @@ before = common.conf
 
 [Definition]
 
-failregex = ^\s*(\[\])?(%(__hostname)s\s*(roundcube:)? IMAP Error)?: (FAILED login|Login failed) for .*? from <HOST>(\. .* in .*?/rcube_imap\.php on line \d+ \(\S+ \S+\))?$
-            ^\[\]: Failed login for [\w\-\.\+]+(@[\w\-\.\+]+\.[a-zA-Z]{2,6})? from <HOST> in session \S+( \(error: \d\))?$
+failregex = ^\s*(\[\])?(%(__hostname)s\s*(roundcube:)?\s*(<[\w]+>)? IMAP Error)?: (FAILED login|Login failed) for .*? from <HOST>(\. .* in .*?/rcube_imap\.php on line \d+ \(\S+ \S+\))?$
+            ^\[\]:\s*(<[\w]+>)? Failed login for [\w\-\.\+]+(@[\w\-\.\+]+\.[a-zA-Z]{2,6})? from <HOST> in session \w+( \(error: \d\))?$
 
 ignoreregex = 
 # DEV Notes:

--- a/config/filter.d/roundcube-auth.conf
+++ b/config/filter.d/roundcube-auth.conf
@@ -1,6 +1,10 @@
 # Fail2Ban configuration file for roundcube web server
 #
+# By default failed logins are printed to 'errors'. The first regex matches those
+# The second regex matches those printed to 'userlogins'
+#   The userlogins log file can be enabled by setting $config['log_logins'] = true; in config.inc.php
 #
+# The logpath in your jail can be updated to userlogins if you wish
 #
 
 [INCLUDES]
@@ -9,7 +13,8 @@ before = common.conf
 
 [Definition]
 
-failregex = ^\s*(\[\])?(%(__hostname)s roundcube: IMAP Error)?: (FAILED login|Login failed) for .*? from <HOST>(\. .* in .*?/rcube_imap\.php on line \d+ \(\S+ \S+\))?$
+failregex = ^\s*(\[\])?(%(__hostname)s\s*(roundcube:)? IMAP Error)?: (FAILED login|Login failed) for .*? from <HOST>(\. .* in .*?/rcube_imap\.php on line \d+ \(\S+ \S+\))?$
+            ^\[\]: Failed login for [\w\-\.\+]+(@[\w\-\.\+]+\.[a-zA-Z]{2,6})? from <HOST> in session \S+( \(error: \d\))?$
 
 ignoreregex = 
 # DEV Notes:
@@ -26,4 +31,4 @@ ignoreregex =
 # arbitrary user input and IMAP response doesn't inject the wrong IP for
 # fail2ban
 #
-# Author: Teodor Micu & Yaroslav Halchenko & terence namusonge & Daniel Black
+# Author: Teodor Micu & Yaroslav Halchenko & terence namusonge & Daniel Black & Lee Clemens

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -348,7 +348,7 @@ logpath = %(lighttpd_error_log)s
 [roundcube-auth]
 
 port     = http,https
-logpath  = /var/log/roundcube/userlogins
+logpath  = logpath = %(roundcube_errors_log)s
 
 
 [openwebmail]

--- a/config/paths-common.conf
+++ b/config/paths-common.conf
@@ -62,5 +62,7 @@ solidpop3d_log = %(syslog_local0)s
 
 mysql_log = %(syslog_daemon)s
 
+roundcube_errors_log = /var/log/roundcube/errors
+
 # Directory with ignorecommand scripts
 ignorecommands_dir = /etc/fail2ban/filter.d/ignorecommands

--- a/config/paths-debian.conf
+++ b/config/paths-debian.conf
@@ -35,5 +35,3 @@ exim_main_log = /var/log/exim4/mainlog
 # was in debian squeezy but not in wheezy
 # /etc/proftpd/proftpd.conf (SystemLog)
 proftpd_log = /var/log/proftpd/proftpd.log
-
-roundcube_errors_log = /var/log/roundcube/errors

--- a/config/paths-debian.conf
+++ b/config/paths-debian.conf
@@ -36,5 +36,4 @@ exim_main_log = /var/log/exim4/mainlog
 # /etc/proftpd/proftpd.conf (SystemLog)
 proftpd_log = /var/log/proftpd/proftpd.log
 
-
-
+roundcube_errors_log = /var/log/roundcube/errors

--- a/config/paths-fedora.conf
+++ b/config/paths-fedora.conf
@@ -35,3 +35,5 @@ apache_access_log = /var/log/httpd/*access_log
 exim_main_log = /var/log/exim/main.log
 
 mysql_log = /var/lib/mysql/mysqld.log
+
+roundcube_errors_log = /var/log/roundcubemail/errors

--- a/fail2ban/tests/files/logs/roundcube-auth
+++ b/fail2ban/tests/files/logs/roundcube-auth
@@ -22,3 +22,13 @@ Jul 11 03:06:37 myhostname roundcube: IMAP Error: Login failed for admin from 12
 # user = admin from 127.0.0.1 in 
 # failJSON: { "time": "2005-07-11T03:06:37", "match": true , "host": "1.2.3.4" }
 Jul 11 03:06:37 myhostname roundcube: IMAP Error: Login failed for admin from 127.0.0.1 in from 1.2.3.4. AUTHENTICATE PLAIN: A0002 NO Login failed. user=admin from 127.0.0.1 in in /usr/share/roundcube/program/include/rcube_imap.php on line 205 (POST /wmail/?_task=login&_action=login)
+
+# Roundcube 1.0.5 CentOS 6 (/var/log/roundcubemail/errors)
+# failJSON: { "time": "2014-12-30T19:02:34", "match": true , "host": "1.2.3.4" }
+[30-Dec-2014 13:02:34 -0500]: IMAP Error: Login failed for admin@example.com from 1.2.3.4. AUTHENTICATE PLAIN: Authentication failed. in /docroot/path/program/lib/Roundcube/rcube_imap.php on line 184 (POST /?_task=login?_task=login&_action=login)
+
+# Roundcube 1.0.5 CentOS 6 (/var/log/roundcubemail/userlogins)
+# failJSON: { "time": "2015-05-10T19:02:52", "match": true , "host": "1.2.3.4" }
+[10-May-2015 13:02:52 -0400]: Failed login for sampleuser from 1.2.3.4 in session 1z506z6rvddstv6k7jz08hxo27 (error: 0)
+# failJSON: { "time": "2015-05-10T19:02:52", "match": true , "host": "1.2.3.4" }
+[10-May-2015 13:02:52 -0400]: Failed login for foo.bar-admin@some-thing.example.com from 1.2.3.4 in session 1z506z6rvddstv6k7jz08hxo27 (error: 0)

--- a/fail2ban/tests/files/logs/roundcube-auth
+++ b/fail2ban/tests/files/logs/roundcube-auth
@@ -31,4 +31,12 @@ Jul 11 03:06:37 myhostname roundcube: IMAP Error: Login failed for admin from 12
 # failJSON: { "time": "2015-05-10T19:02:52", "match": true , "host": "1.2.3.4" }
 [10-May-2015 13:02:52 -0400]: Failed login for sampleuser from 1.2.3.4 in session 1z506z6rvddstv6k7jz08hxo27 (error: 0)
 # failJSON: { "time": "2015-05-10T19:02:52", "match": true , "host": "1.2.3.4" }
-[10-May-2015 13:02:52 -0400]: Failed login for foo.bar-admin@some-thing.example.com from 1.2.3.4 in session 1z506z6rvddstv6k7jz08hxo27 (error: 0)
+[10-May-2015 13:02:52 -0400]: Failed login for foo.bar-admin@some-thing.example.com from 1.2.3.4 in session 2z506z6rvddstv6k7jz08hxo27 (error: 0)
+
+# Roundcube 1.1.1 (/var/log/roundcubemail/errors)
+# failJSON: { "time": "2014-12-30T19:02:34", "match": true , "host": "1.2.3.4" }
+[30-Dec-2014 13:02:34 -0500]: <3z506z6r> IMAP Error: Login failed for admin@example.com from 1.2.3.4. AUTHENTICATE PLAIN: Authentication failed. in /docroot/path/program/lib/Roundcube/rcube_imap.php on line 198 (POST /?_task=login?_task=login&_action=login)
+
+# Roundcube 1.1.1 (/var/log/roundcubemail/userlogins)
+# failJSON: { "time": "2015-05-10T19:02:52", "match": true , "host": "1.2.3.4" }
+[10-May-2015 13:02:52 -0400]: <4z506z6r> Failed login for admin@example.com from 1.2.3.4 in session 4z506z6rvddstv6k7jz08hxo27 (error: 0)


### PR DESCRIPTION
Updated regex to work with roundcube 1.0.5 and 1.1.1 'errors' log lines
Added regex for 'userlogins' log (optionally enabled)
Updated jail.conf logpath for roundcube-auth to match default log, 'errors'