### PR TITLE
add froxlor-auth filter and jail

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@ ver. 0.9.3 (2015/XX/XXX) - wanna-be-released
    * Fix fail2ban-regex not parsing journalmatch correctly from filter config
 
 - New Features:
+   - New filters:
+     - froxlor-auth  Thanks Joern Muehlencord
 
 - Enhancements:
 

--- a/config/filter.d/froxlor-auth.conf
+++ b/config/filter.d/froxlor-auth.conf
@@ -1,0 +1,37 @@
+# Fail2Ban configuration file to block repeated failed login attempts to Frolor installation(s)
+# 
+# Froxlor needs to log to Syslog User (e.g. /var/log/user.log) with one of the following messages
+# <syslog prefix> Froxlor: [Login Action <HOST>] Unknown user '<USER>' tried to login.
+# <syslog prefix> Froxlor: [Login Action <HOST>] User '<USER>' tried to login with wrong password.
+#
+# Author: Joern Muehlencord
+#
+
+[INCLUDES]
+
+# Read common prefixes. If any customizations available -- read them from
+# common.local
+before = common.conf
+
+
+[Definition]
+
+_daemon = Froxlor
+
+# Option:  failregex
+# Notes.:  regex to match the password failures messages in the logfile. The
+#          host must be matched by a group named "host". The tag "<HOST>" can
+#          be used for standard IP/hostname matching and is only an alias for
+#          (?:::f{4,6}:)?(?P<host>[\w\-.^_]+)
+# Values:  TEXT
+#
+failregex = ^%(__prefix_line)s\[Login Action <HOST>\] Unknown user \S* tried to login.$
+            ^%(__prefix_line)s\[Login Action <HOST>\] User \S* tried to login with wrong password.$
+
+
+# Option:  ignoreregex
+# Notes.:  regex to ignore. If this regex matches, the line is ignored.
+# Values:  TEXT
+#
+ignoreregex =
+

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -408,6 +408,13 @@ port    = 10000
 logpath = %(syslog_authpriv)s
 
 
+[froxlor-auth]
+
+port    = http,https
+logpath  = %(syslog_authpriv)s
+
+
+
 #
 # HTTP Proxy servers
 #

--- a/fail2ban/tests/files/logs/froxlor-auth
+++ b/fail2ban/tests/files/logs/froxlor-auth
@@ -1,0 +1,5 @@
+# failJSON: { "time": "2015-06-21T00:56:27", "match": true , "host": "1.2.3.4" }
+May 21 00:56:27 jomu Froxlor: [Login Action 1.2.3.4] Unknown user 'user' tried to login.
+# failJSON: { "time": "2015-06-21T00:57:38", "match": true , "host": "1.2.3.4" }
+May 21 00:57:38 jomu Froxlor: [Login Action 83.87.126.64] User 'admin' tried to login with wrong password.
+

--- a/fail2ban/tests/files/logs/froxlor-auth
+++ b/fail2ban/tests/files/logs/froxlor-auth
@@ -1,5 +1,5 @@
-# failJSON: { "time": "2015-06-21T00:56:27", "match": true , "host": "1.2.3.4" }
+# failJSON: { "time": "2005-05-21T00:56:27", "match": true , "host": "1.2.3.4" }
 May 21 00:56:27 jomu Froxlor: [Login Action 1.2.3.4] Unknown user 'user' tried to login.
-# failJSON: { "time": "2015-06-21T00:57:38", "match": true , "host": "1.2.3.4" }
-May 21 00:57:38 jomu Froxlor: [Login Action 83.87.126.64] User 'admin' tried to login with wrong password.
+# failJSON: { "time": "2005-05-21T00:57:38", "match": true , "host": "1.2.3.4" }
+May 21 00:57:38 jomu Froxlor: [Login Action 1.2.3.4] User 'admin' tried to login with wrong password.
 


### PR DESCRIPTION
add filter and jail to ban on failed login attempts into froxlor (www.froxlor.org) installations. 