### PR TITLE
Limit the number of log lines in *-lines.conf actions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@ ver. 0.9.3 (2015/XX/XXX) - wanna-be-released
 - IMPORTANT incompatible changes:
    * filter.d/roundcube-auth.conf
      - Changed logpath to 'errors' log (was 'userlogins')
+   * mail-whois-lines, sendmail-geoip-lines and sendmail-whois-lines
+     actions include only the first 1000 log lines in the email
 
 - Fixes:
    * reload in interactive mode appends all the jails twice (gh-825)

--- a/config/action.d/mail-whois-lines.conf
+++ b/config/action.d/mail-whois-lines.conf
@@ -42,7 +42,7 @@ actionban = printf %%b "Hi,\n
             Here is more information about <ip>:\n
             `whois <ip> || echo missing whois program`\n\n
             Lines containing IP:<ip> in <logpath>\n
-            `grep -E '(^|[^0-9])<ip>([^0-9]|$)' <logpath>`\n\n
+            `grep -E <grepopts> '(^|[^0-9])<ip>([^0-9]|$)' <logpath>`\n\n
             Regards,\n
             Fail2Ban"|mail -s "[Fail2Ban] <name>: banned <ip> from  `uname -n`" <dest>
 
@@ -67,3 +67,7 @@ dest = root
 # Path to the log files which contain relevant lines for the abuser IP
 #
 logpath = /dev/null
+
+# Number of log lines to include in the email
+#
+grepopts = -m 1000

--- a/config/action.d/sendmail-geoip-lines.conf
+++ b/config/action.d/sendmail-geoip-lines.conf
@@ -34,7 +34,7 @@ actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             AS:`geoiplookup -f /usr/share/GeoIP/GeoIPASNum.dat "<ip>" | cut -d':' -f2-`
             hostname: `host -t A <ip> 2>&1`\n\n
             Lines containing IP:<ip> in <logpath>\n
-            `grep -E '(^|[^0-9])<ip>([^0-9]|$)' <logpath>`\n\n
+            `grep -E <grepopts> '(^|[^0-9])<ip>([^0-9]|$)' <logpath>`\n\n
             Regards,\n
             Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
 
@@ -47,3 +47,7 @@ name = default
 # Path to the log files which contain relevant lines for the abuser IP
 #
 logpath = /dev/null
+
+# Number of log lines to include in the email
+#
+grepopts = -m 1000

--- a/config/action.d/sendmail-whois-lines.conf
+++ b/config/action.d/sendmail-whois-lines.conf
@@ -26,7 +26,7 @@ actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Here is more information about <ip>:\n
             `/usr/bin/whois <ip> || echo missing whois program`\n\n
             Lines containing IP:<ip> in <logpath>\n
-            `grep -E '(^|[^0-9])<ip>([^0-9]|$)' <logpath>`\n\n
+            `grep -E <grepopts> '(^|[^0-9])<ip>([^0-9]|$)' <logpath>`\n\n
             Regards,\n
             Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
 
@@ -40,3 +40,6 @@ name = default
 #
 logpath = /dev/null
 
+# Number of log lines to include in the email
+#
+grepopts = -m 1000


### PR DESCRIPTION
1000 lines are around 200-300kB at max.
Is someone expecting more than 1000 lines in an email? Thus is it necessary to tell about this in the changelog?
