### PR TITLE
PEP8 violations

### DIFF
--- a/bin/fail2ban-client
+++ b/bin/fail2ban-client
@@ -25,12 +25,9 @@ __license__ = "GPL"
 import getopt
 import logging
 import os
-import pickle
-import re
 import shlex
 import signal
 import socket
-import string
 import sys
 import time
 
@@ -47,6 +44,7 @@ logSys = getLogger("fail2ban")
 ##
 #
 # @todo This class needs cleanup.
+
 
 class Fail2banClient:
 
@@ -80,7 +78,7 @@ class Fail2banClient:
 	def dispUsage(self):
 		""" Prints Fail2Ban command line options and exits
 		"""
-		print "Usage: "+self.__argv[0]+" [OPTIONS] <COMMAND>"
+		print "Usage: " + self.__argv[0] + " [OPTIONS] <COMMAND>"
 		print
 		print "Fail2Ban v" + version + " reads log file that contains password failure report"
 		print "and bans the corresponding IP addresses using firewall rules."
@@ -131,9 +129,9 @@ class Fail2banClient:
 			elif opt[0] == "-d":
 				self.__conf["dump"] = True
 			elif opt[0] == "-v":
-				self.__conf["verbose"] = self.__conf["verbose"] + 1
+				self.__conf["verbose"] += 1
 			elif opt[0] == "-q":
-				self.__conf["verbose"] = self.__conf["verbose"] - 1
+				self.__conf["verbose"] -= 1
 			elif opt[0] == "-x":
 				self.__conf["force"] = True
 			elif opt[0] == "-i":
@@ -152,7 +150,7 @@ class Fail2banClient:
 	def __ping(self):
 		return self.__processCmd([["ping"]], False)
 
-	def __processCmd(self, cmd, showRet = True):
+	def __processCmd(self, cmd, showRet=True):
 		client = None
 		try:
 			beautifier = Beautifier()
@@ -164,11 +162,11 @@ class Fail2banClient:
 						client = CSocket(self.__conf["socket"])
 					ret = client.send(c)
 					if ret[0] == 0:
-						logSys.debug("OK : " + `ret[1]`)
+						logSys.debug("OK : " + repr(ret[1]))
 						if showRet:
 							print beautifier.beautify(ret[1])
 					else:
-						logSys.error("NOK: " + `ret[1].args`)
+						logSys.error("NOK: " + repr(ret[1].args))
 						if showRet:
 							print beautifier.beautifyError(ret[1])
 						streamRet = False
@@ -280,13 +278,12 @@ class Fail2banClient:
 		else:
 			return self.__processCmd([cmd])
 
-
 	##
 	# Start Fail2Ban server.
 	#
 	# Start the Fail2ban server in daemon mode.
 
-	def __startServerAsync(self, socket, pidfile, force = False, background = True):
+	def __startServerAsync(self, socket, pidfile, force=False, background=True):
 		# Forks the current process.
 		pid = os.fork()
 		if pid == 0:
@@ -306,7 +303,7 @@ class Fail2banClient:
 				args.append("-b")
 			else:
 				args.append("-f")
-			
+
 			try:
 				# Use the current directory.
 				exe = os.path.abspath(os.path.join(sys.path[0], self.SERVER))
@@ -332,10 +329,10 @@ class Fail2banClient:
 			# Wonderful visual :)
 			if self.__conf["verbose"] > 1:
 				pos += delta
-				sys.stdout.write("\rINFO   " + mask[:pos] + '#' + mask[pos+1:] +
+				sys.stdout.write("\rINFO   " + mask[:pos] + '#' + mask[pos + 1:] +
 								 " Waiting on the server...")
 				sys.stdout.flush()
-				if pos > len(mask)-3:
+				if pos > len(mask) - 3:
 					delta = -1
 				elif pos < 2:
 					delta = 1
@@ -348,7 +345,6 @@ class Fail2banClient:
 			cnt += 1
 		if self.__conf["verbose"] > 1:
 			sys.stdout.write('\n')
-
 
 	def start(self, argv):
 		# Command line options

--- a/bin/fail2ban-regex
+++ b/bin/fail2ban-regex
@@ -29,18 +29,14 @@ __author__ = "Fail2Ban Developers"
 __copyright__ = "Copyright (c) 2004-2008 Cyril Jaquier, 2012-2014 Yaroslav Halchenko"
 __license__ = "GPL"
 
-import getopt
 import locale
 import logging
 import os
-import shlex
 import sys
-import time
 import time
 import urllib
 from optparse import OptionParser, Option
 
-from ConfigParser import NoOptionError, NoSectionError, MissingSectionHeaderError
 
 try:
 	from systemd import journal
@@ -57,18 +53,21 @@ from fail2ban.helpers import FormatterWithTraceBack, getLogger
 # Gets the instance of the logger.
 logSys = getLogger("fail2ban")
 
+
 def debuggexURL(sample, regex):
-	q = urllib.urlencode({ 're': regex.replace('<HOST>', '(?&.ipv4)'),
+	q = urllib.urlencode({'re': regex.replace('<HOST>', '(?&.ipv4)'),
 							'str': sample,
-							'flavor': 'python' })
+							'flavor': 'python'})
 	return 'http://www.debuggex.com/?' + q
+
 
 def shortstr(s, l=53):
 	"""Return shortened string
 	"""
 	if len(s) > l:
-		return s[:l-3] + '...'
+		return s[:l - 3] + '...'
 	return s
+
 
 def pprint_list(l, header=None):
 	if not len(l):
@@ -79,6 +78,7 @@ def pprint_list(l, header=None):
 		s = ''
 	print s + "|  " + "\n|  ".join(l) + '\n`-'
 
+
 def file_lines_gen(hdlr):
 	for line in hdlr:
 		try:
@@ -87,6 +87,7 @@ def file_lines_gen(hdlr):
 			if sys.version_info >= (3,): # Python 3 must be decoded
 				line = line.decode(fail2banRegex.encoding, 'ignore')
 		yield line
+
 
 def journal_lines_gen(myjournal):
 	while True:
@@ -97,6 +98,7 @@ def journal_lines_gen(myjournal):
 		if not entry:
 			break
 		yield FilterSystemd.formatJournalEntry(entry)
+
 
 def get_opt_parser():
 	# use module docstring for help output
@@ -228,7 +230,7 @@ class Fail2banRegex(object):
 		self._datepattern_set = False
 		self._journalmatch = None
 
-		self.share_config=dict()
+		self.share_config = dict()
 		self._filter = Filter(None)
 		self._ignoreregex = list()
 		self._failregex = list()
@@ -245,8 +247,6 @@ class Fail2banRegex(object):
 			self.encoding = opts.encoding
 		else:
 			self.encoding = locale.getpreferredencoding()
-
-
 
 	def setDatePattern(self, pattern):
 		if not self._datepattern_set:
@@ -341,7 +341,7 @@ class Fail2banRegex(object):
 			for match in ret:
 				# Append True/False flag depending if line was matched by
 				# more than one regex
-				match.append(len(ret)>1)
+				match.append(len(ret) > 1)
 				regex = self._failregex[match[0]]
 				regex.inc()
 				regex.appendIP(match)
@@ -404,8 +404,6 @@ class Fail2banRegex(object):
 				self._filter.dateDetector.sortTemplate()
 		self._time_elapsed = time.time() - t0
 
-
-
 	def printLines(self, ltype):
 		lstats = self._line_stats
 		assert(self._line_stats.missed == lstats.tested - (lstats.matched + lstats.ignored))
@@ -422,8 +420,8 @@ class Fail2banRegex(object):
 				if lines < self._maxlines or getattr(self, '_print_all_' + ltype):
 					ans = [[]]
 					for arg in [l, regexlist]:
-						ans = [ x + [y] for x in ans for y in arg ]
-					b = map(lambda a: a[0] +  ' | ' + a[1].getFailRegex() + ' |  ' + debuggexURL(a[0], a[1].getFailRegex()), ans)
+						ans = [x + [y] for x in ans for y in arg]
+					b = map(lambda a: a[0] + ' | ' + a[1].getFailRegex() + ' |  ' + debuggexURL(a[0], a[1].getFailRegex()), ans)
 					pprint_list([x.rstrip() for x in b], header)
 				else:
 					print "%s too many to print.  Use --print-all-%s " \
@@ -445,8 +443,8 @@ class Fail2banRegex(object):
 			for cnt, failregex in enumerate(failregexes):
 				match = failregex.getStats()
 				total += match
-				if (match or self._verbose):
-					out.append("%2d) [%d] %s" % (cnt+1, match, failregex.getFailRegex()))
+				if match or self._verbose:
+					out.append("%2d) [%d] %s" % (cnt + 1, match, failregex.getFailRegex()))
 
 				if self._verbose and len(failregex.getIPList()):
 					for ip in failregex.getIPList():
@@ -465,7 +463,6 @@ class Fail2banRegex(object):
 		# Print title
 		total = print_failregexes("Failregex", self._failregex)
 		_ = print_failregexes("Ignoreregex", self._ignoreregex)
-
 
 		if self._filter.dateDetector is not None:
 			print "\nDate template hits:"
@@ -583,7 +580,7 @@ if __name__ == "__main__":
 		test_lines = journal_lines_gen(myjournal)
 	else:
 		print "Use      single line : %s" % shortstr(cmd_log)
-		test_lines = [ cmd_log ]
+		test_lines = [cmd_log]
 	print
 
 	fail2banRegex.process(test_lines)

--- a/bin/fail2ban-server
+++ b/bin/fail2ban-server
@@ -23,7 +23,6 @@ __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
 __license__ = "GPL"
 
 import getopt
-import os
 import sys
 
 from fail2ban.version import version
@@ -40,6 +39,7 @@ logSys = getLogger("fail2ban")
 #
 # Fail2ban is designed to protect your server against brute force attacks.
 # Its first goal was to protect a SSH server.
+
 
 class Fail2banServer:
 
@@ -65,7 +65,7 @@ class Fail2banServer:
 	def dispUsage(self):
 		""" Prints Fail2Ban command line options and exits
 		"""
-		print "Usage: "+self.__argv[0]+" [OPTIONS]"
+		print "Usage: " + self.__argv[0] + " [OPTIONS]"
 		print
 		print "Fail2Ban v" + version + " reads log file that contains password failure report"
 		print "and bans the corresponding IP addresses using firewall rules."

--- a/bin/fail2ban-testcases
+++ b/bin/fail2ban-testcases
@@ -27,10 +27,9 @@ __license__ = "GPL"
 import logging
 import os
 import sys
-import time
 import unittest
 
-# Check if local fail2ban module exists, and use if it exists by 
+# Check if local fail2ban module exists, and use if it exists by
 # modifying the path. This is such that tests can be used in dev
 # environment.
 if os.path.exists("fail2ban/__init__.py"):
@@ -39,9 +38,9 @@ from fail2ban.version import version
 
 from fail2ban.tests.utils import gatherTests
 from fail2ban.helpers import FormatterWithTraceBack, getLogger
-from fail2ban.server.mytime import MyTime
 
 from optparse import OptionParser, Option
+
 
 def get_opt_parser():
 	# use module docstring for help output

--- a/config/action.d/badips.py
+++ b/config/action.d/badips.py
@@ -126,7 +126,7 @@ class BadIPsAction(ActionBase):
 			raise
 		else:
 			response_json = json.loads(response.read().decode('utf-8'))
-			if not 'categories' in response_json:
+			if 'categories' not in response_json:
 				err = "badips.com response lacked categories specification. Response was: %s" \
 				  % (response_json,)
 				self._logSys.error(err)
@@ -267,7 +267,7 @@ class BadIPsAction(ActionBase):
 				self._logSys.error(
 					"Error banning IP %s for jail '%s' with action '%s': %s",
 					ip, self._jail.name, self.banaction, e,
-					exc_info=self._logSys.getEffectiveLevel()<=logging.DEBUG)
+					exc_info=self._logSys.getEffectiveLevel() <= logging.DEBUG)
 			else:
 				self._bannedips.add(ip)
 				self._logSys.info(
@@ -288,7 +288,7 @@ class BadIPsAction(ActionBase):
 				self._logSys.info(
 					"Error unbanning IP %s for jail '%s' with action '%s': %s",
 					ip, self._jail.name, self.banaction, e,
-					exc_info=self._logSys.getEffectiveLevel()<=logging.DEBUG)
+					exc_info=self._logSys.getEffectiveLevel() <= logging.DEBUG)
 			else:
 				self._logSys.info(
 					"Unbanned IP %s for jail '%s' with action '%s'",

--- a/config/action.d/smtp.py
+++ b/config/action.d/smtp.py
@@ -112,7 +112,7 @@ class SMTPAction(ActionBase):
 		#TODO: self.ssl = ssl
 
 		self.user = user
-		self.password =password
+		self.password = password
 
 		self.fromname = sendername
 		self.fromaddr = sender
@@ -121,9 +121,9 @@ class SMTPAction(ActionBase):
 		self.matches = matches
 
 		self.message_values = CallingMap(
-			jailname = self._jail.name,
-			hostname = socket.gethostname,
-			bantime = self._jail.actions.getBanTime,
+			jailname=self._jail.name,
+			hostname=socket.gethostname,
+			bantime=self._jail.actions.getBanTime,
 			)
 
 	def _sendMessage(self, subject, text):

--- a/config/filter.d/ignorecommands/apache-fakegooglebot
+++ b/config/filter.d/ignorecommands/apache-fakegooglebot
@@ -6,20 +6,22 @@
 #
 import sys
 
+
 def process_args(argv):
     if len(argv) != 2:
-       sys.stderr.write("Please provide a single IP as an argument. Got: %s\n"
+        sys.stderr.write("Please provide a single IP as an argument. Got: %s\n"
                         % (argv[1:]))
-       sys.exit(2)
+        sys.exit(2)
 
     ip = argv[1]
 
     from fail2ban.server.filter import DNSUtils
     if not DNSUtils.isValidIP(ip):
-       sys.stderr.write("Argument must be a single valid IP. Got: %s\n"
+        sys.stderr.write("Argument must be a single valid IP. Got: %s\n"
                         % ip)
-       sys.exit(3)
+        sys.exit(3)
     return ip
+
 
 def is_googlebot(ip):
     import re

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import sys
-import os
 
 sys.path.insert(0, ".")
 sys.path.insert(0, "..")

--- a/fail2ban/__init__.py
+++ b/fail2ban/__init__.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"

--- a/fail2ban/client/__init__.py
+++ b/fail2ban/client/__init__.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"

--- a/fail2ban/client/actionreader.py
+++ b/fail2ban/client/actionreader.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -51,7 +51,7 @@ class ActionReader(DefinitionInitConfigReader):
 	def setFile(self, fileName):
 		self.__file = fileName
 		DefinitionInitConfigReader.setFile(self, os.path.join("action.d", fileName))
-	
+
 	def getFile(self):
 		return self.__file
 

--- a/fail2ban/client/beautifier.py
+++ b/fail2ban/client/beautifier.py
@@ -36,7 +36,7 @@ logSys = getLogger(__name__)
 
 class Beautifier:
 
-	def __init__(self, cmd = None):
+	def __init__(self, cmd=None):
 		self.__inputCmd = cmd
 
 	def setInputCmd(self, cmd):
@@ -96,15 +96,15 @@ class Beautifier:
 			elif inC[1:2] == ['loglevel']:
 				msg = "Current logging level is "
 				if response == 1:
-					msg = msg + "ERROR"
+					msg += "ERROR"
 				elif response == 2:
-					msg = msg + "WARN"
+					msg += "WARN"
 				elif response == 3:
-					msg = msg + "INFO"
+					msg += "INFO"
 				elif response == 4:
-					msg = msg + "DEBUG"
+					msg += "DEBUG"
 				else:
-					msg = msg + repr(response)
+					msg += repr(response)
 			elif inC[1] == "dbfile":
 				if response is None:
 					msg = "Database currently disabled"
@@ -116,7 +116,7 @@ class Beautifier:
 					msg = "Database currently disabled"
 				else:
 					msg = "Current database purge age is:\n"
-					msg = msg + "`- %iseconds" % response
+					msg += "`- %iseconds" % response
 			elif inC[2] in ("logpath", "addlogpath", "dellogpath"):
 				if len(response) == 0:
 					msg = "No file is currently monitored"
@@ -124,7 +124,7 @@ class Beautifier:
 					msg = "Current monitored log file(s):\n"
 					for path in response[:-1]:
 						msg = msg + "|- " + path + "\n"
-					msg = msg + "`- " + response[len(response)-1]
+					msg = msg + "`- " + response[len(response) - 1]
 			elif inC[2] == "logencoding":
 				msg = "Current log encoding is set to:\n"
 				msg = msg + response
@@ -137,11 +137,11 @@ class Beautifier:
 			elif inC[2] == "datepattern":
 				msg = "Current date pattern set to: "
 				if response is None:
-					msg = msg + "Not set/required"
+					msg += "Not set/required"
 				elif response[0] is None:
-					msg = msg + "%s" % response[1]
+					msg += "%s" % response[1]
 				else:
-					msg = msg + "%s (%s)" % response
+					msg += "%s (%s)" % response
 			elif inC[2] in ("ignoreip", "addignoreip", "delignoreip"):
 				if len(response) == 0:
 					msg = "No IP address/network is ignored"
@@ -149,7 +149,7 @@ class Beautifier:
 					msg = "These IP addresses/networks are ignored:\n"
 					for ip in response[:-1]:
 						msg = msg + "|- " + ip + "\n"
-					msg = msg + "`- " + response[len(response)-1]
+					msg = msg + "`- " + response[len(response) - 1]
 			elif inC[2] in ("failregex", "addfailregex", "delfailregex",
 							"ignoreregex", "addignoreregex", "delignoreregex"):
 				if len(response) == 0:
@@ -160,7 +160,7 @@ class Beautifier:
 					for ip in response[:-1]:
 						msg = msg + "|- [" + str(c) + "]: " + ip + "\n"
 						c += 1
-					msg = msg + "`- [" + str(c) + "]: " + response[len(response)-1]
+					msg = msg + "`- [" + str(c) + "]: " + response[len(response) - 1]
 			elif inC[2] == "actions":
 				if len(response) == 0:
 					msg = "No actions for jail %s" % inC[1]
@@ -187,7 +187,7 @@ class Beautifier:
 			logSys.warning("Beautifier error. Please report the error")
 			logSys.error("Beautify " + repr(response) + " with "
 				+ repr(self.__inputCmd) + " failed")
-			msg = msg + repr(response)
+			msg += repr(response)
 		return msg
 
 	def beautifyError(self, response):

--- a/fail2ban/client/configparserinc.py
+++ b/fail2ban/client/configparserinc.py
@@ -28,7 +28,7 @@ import os
 import sys
 from ..helpers import getLogger
 
-if sys.version_info >= (3,2): # pragma: no cover
+if sys.version_info >= (3, 2): # pragma: no cover
 
 	# SafeConfigParser deprecated from Python 3.2 (renamed to ConfigParser)
 	from configparser import ConfigParser as SafeConfigParser, \
@@ -99,7 +99,7 @@ after = 1.conf
 
 	SECTION_NAME = "INCLUDES"
 
-	if sys.version_info >= (3,2):
+	if sys.version_info >= (3, 2):
 		# overload constructor only for fancy new Python3's
 		def __init__(self, share_config=None, *args, **kwargs):
 			kwargs = kwargs.copy()
@@ -123,7 +123,7 @@ after = 1.conf
 		# read single one, add to return list, use sharing if possible:
 		if self._cfg_share:
 			# cache/share each file as include (ex: filter.d/common could be included in each filter config):
-			hashv = 'inc:'+(filename if not isinstance(filename, list) else '\x01'.join(filename))
+			hashv = 'inc:' + (filename if not isinstance(filename, list) else '\x01'.join(filename))
 			cfg, i = self._cfg_share.get(hashv, (None, None))
 			if cfg is None:
 				cfg = SCPWI(share_config=self._cfg_share)
@@ -135,15 +135,15 @@ after = 1.conf
 			# don't have sharing:
 			cfg = SCPWI()
 			i = cfg.read(filename, get_includes=False)
-		return (cfg, i)
+		return cfg, i
 
 	def _getIncludes(self, filenames, seen=[]):
 		if not isinstance(filenames, list):
-			filenames = [ filenames ]
+			filenames = [filenames]
 		# retrieve or cache include paths:
 		if self._cfg_share:
 			# cache/share include list:
-			hashv = 'inc-path:'+('\x01'.join(filenames))
+			hashv = 'inc-path:' + ('\x01'.join(filenames))
 			fileNamesFull = self._cfg_share.get(hashv)
 			if fileNamesFull is None:
 				fileNamesFull = []
@@ -171,10 +171,10 @@ after = 1.conf
 		except UnicodeDecodeError, e:
 			logSys.error("Error decoding config file '%s': %s" % (resource, e))
 			return []
-		
+
 		resourceDir = os.path.dirname(resource)
 
-		newFiles = [ ('before', []), ('after', []) ]
+		newFiles = [('before', []), ('after', [])]
 		if SCPWI.SECTION_NAME in parser.sections():
 			for option_name, option_list in newFiles:
 				if option_name in parser.options(SCPWI.SECTION_NAME):
@@ -199,7 +199,7 @@ after = 1.conf
 
 	def read(self, filenames, get_includes=True):
 		if not isinstance(filenames, list):
-			filenames = [ filenames ]
+			filenames = [filenames]
 		# retrieve (and cache) includes:
 		fileNamesFull = []
 		if get_includes:
@@ -232,7 +232,7 @@ after = 1.conf
 								sk = {}
 								for k, v in s2.iteritems():
 									if not k.startswith('known/'):
-										sk['known/'+k] = v
+										sk['known/' + k] = v
 								s2.update(sk)
 								# merge section
 								s2.update(s)
@@ -247,7 +247,7 @@ after = 1.conf
 		if logSys.getEffectiveLevel() <= logLevel:
 			logSys.log(logLevel, "    Reading file: %s", fileNamesFull[0])
 		# read file(s) :
-		if sys.version_info >= (3,2): # pragma: no cover
+		if sys.version_info >= (3, 2): # pragma: no cover
 			return SafeConfigParser.read(self, fileNamesFull, encoding='utf-8')
 		else:
 			return SafeConfigParser.read(self, fileNamesFull)
@@ -257,6 +257,5 @@ after = 1.conf
 		sk = {}
 		for k, v in options.iteritems():
 			if pref == '' or not k.startswith(pref):
-				sk[pref+k] = v
+				sk[pref + k] = v
 		alls[section].update(sk)
-

--- a/fail2ban/client/configreader.py
+++ b/fail2ban/client/configreader.py
@@ -35,7 +35,7 @@ from ..helpers import getLogger
 logSys = getLogger(__name__)
 
 
-class ConfigReader():
+class ConfigReader:
 	"""Generic config reader class.
 
 	A caching adapter which automatically reuses already shared configuration.
@@ -74,7 +74,7 @@ class ConfigReader():
 	def read(self, name, once=True):
 		""" Overloads a default (not shared) read of config reader.
 
-	  To prevent mutiple reads of config files with it includes, reads into 
+	  To prevent mutiple reads of config files with it includes, reads into
 	  the config reader, if it was not yet cached/shared by 'name'.
 	  """
 		# already shared ?
@@ -95,7 +95,7 @@ class ConfigReader():
 	def _create_unshared(self, name=''):
 		""" Allocates and share a config file by it name.
 
-	  Automatically allocates unshared or reuses shared handle by given 'name' and 
+	  Automatically allocates unshared or reuses shared handle by given 'name' and
 	  init arguments inside a given shared storage.
 	  """
 		if not self._cfg and self._cfg_share is not None:
@@ -146,34 +146,34 @@ class ConfigReaderUnshared(SafeConfigParserWithIncludes):
 	"""
 
 	DEFAULT_BASEDIR = '/etc/fail2ban'
-	
+
 	def __init__(self, basedir=None, *args, **kwargs):
 		SafeConfigParserWithIncludes.__init__(self, *args, **kwargs)
 		self.read_cfg_files = None
 		self.setBaseDir(basedir)
-	
+
 	def setBaseDir(self, basedir):
 		if basedir is None:
 			basedir = ConfigReaderUnshared.DEFAULT_BASEDIR	# stock system location
 		self._basedir = basedir.rstrip('/')
-	
+
 	def getBaseDir(self):
 		return self._basedir
-	
+
 	def read(self, filename):
 		if not os.path.exists(self._basedir):
 			raise ValueError("Base configuration directory %s does not exist "
 							  % self._basedir)
 		basename = os.path.join(self._basedir, filename)
-		logSys.debug("Reading configs for %s under %s " , filename, self._basedir)
-		config_files = [ basename + ".conf" ]
+		logSys.debug("Reading configs for %s under %s ", filename, self._basedir)
+		config_files = [basename + ".conf"]
 
 		# possible further customizations under a .conf.d directory
 		config_dir = basename + '.d'
 		config_files += sorted(glob.glob('%s/*.conf' % config_dir))
 
 		config_files.append(basename + ".local")
-	
+
 		config_files += sorted(glob.glob('%s/*.local' % config_dir))
 
 		# choose only existing ones
@@ -183,7 +183,7 @@ class ConfigReaderUnshared(SafeConfigParserWithIncludes):
 			# at least one config exists and accessible
 			logSys.debug("Reading config files: %s", ', '.join(config_files))
 			config_files_read = SafeConfigParserWithIncludes.read(self, config_files)
-			missed = [ cf for cf in config_files if cf not in config_files_read ]
+			missed = [cf for cf in config_files if cf not in config_files_read]
 			if missed:
 				logSys.error("Could not read config files: %s", ', '.join(missed))
 			if config_files_read:
@@ -207,7 +207,7 @@ class ConfigReaderUnshared(SafeConfigParserWithIncludes):
 	# 0 -> the type of the option
 	# 1 -> the name of the option
 	# 2 -> the default value for the option
-	
+
 	def getOptions(self, sec, options, pOptions=None):
 		values = dict()
 		for option in options:
@@ -218,7 +218,7 @@ class ConfigReaderUnshared(SafeConfigParserWithIncludes):
 					v = self.getint(sec, option[1])
 				else:
 					v = self.get(sec, option[1])
-				if not pOptions is None and option[1] in pOptions:
+				if pOptions is not None and option[1] in pOptions:
 					continue
 				values[option[1]] = v
 			except NoSectionError, e:
@@ -250,26 +250,26 @@ class DefinitionInitConfigReader(ConfigReader):
 	"""
 
 	_configOpts = []
-	
+
 	def __init__(self, file_, jailName, initOpts, **kwargs):
 		ConfigReader.__init__(self, **kwargs)
 		self.setFile(file_)
 		self.setJailName(jailName)
 		self._initOpts = initOpts
-	
+
 	def setFile(self, fileName):
 		self._file = fileName
 		self._initOpts = {}
-	
+
 	def getFile(self):
 		return self._file
-	
+
 	def setJailName(self, jailName):
 		self._jailName = jailName
-	
+
 	def getJailName(self):
 		return self._jailName
-	
+
 	def read(self):
 		return ConfigReader.read(self, self._file)
 
@@ -278,15 +278,15 @@ class DefinitionInitConfigReader(ConfigReader):
 		if not self._cfg:
 			self._create_unshared(self._file)
 		return SafeConfigParserWithIncludes.read(self._cfg, self._file)
-	
+
 	def getOptions(self, pOpts):
 		self._opts = ConfigReader.getOptions(
 			self, "Definition", self._configOpts, pOpts)
-		
+
 		if self.has_section("Init"):
 			for opt in self.options("Init"):
-				if not opt in self._initOpts:
+				if opt not in self._initOpts:
 					self._initOpts[opt] = self.get("Init", opt)
-	
+
 	def convert(self):
 		raise NotImplementedError

--- a/fail2ban/client/configurator.py
+++ b/fail2ban/client/configurator.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -33,7 +33,7 @@ logSys = getLogger(__name__)
 
 
 class Configurator:
-	
+
 	def __init__(self, force_enable=False, share_config=None):
 		self.__settings = dict()
 		self.__streams = dict()
@@ -51,7 +51,7 @@ class Configurator:
 	def setBaseDir(self, folderName):
 		self.__fail2ban.setBaseDir(folderName)
 		self.__jails.setBaseDir(folderName)
-	
+
 	def getBaseDir(self):
 		fail2ban_basedir = self.__fail2ban.getBaseDir()
 		jails_basedir = self.__jails.getBaseDir()
@@ -61,25 +61,25 @@ class Configurator:
 						 "Returning the one for fail2ban.conf"
 						 % (fail2ban_basedir, jails_basedir))
 		return fail2ban_basedir
-	
+
 	def readEarly(self):
 		self.__fail2ban.read()
-	
+
 	def readAll(self):
 		self.readEarly()
 		self.__jails.read()
-	
+
 	def getEarlyOptions(self):
 		return self.__fail2ban.getEarlyOptions()
 
-	def getOptions(self, jail = None):
+	def getOptions(self, jail=None):
 		self.__fail2ban.getOptions()
 		return self.__jails.getOptions(jail)
-		
+
 	def convertToProtocol(self):
 		self.__streams["general"] = self.__fail2ban.convert()
 		self.__streams["jails"] = self.__jails.convert()
-	
+
 	def getConfigStream(self):
 		cmds = list()
 		for opt in self.__streams["general"]:
@@ -87,4 +87,3 @@ class Configurator:
 		for opt in self.__streams["jails"]:
 			cmds.append(opt)
 		return cmds
-	

--- a/fail2ban/client/csocket.py
+++ b/fail2ban/client/csocket.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -28,20 +28,20 @@ __license__ = "GPL"
 from pickle import dumps, loads, HIGHEST_PROTOCOL
 from ..protocol import CSPROTO
 import socket
-import sys
+
 
 class CSocket:
-	
+
 	def __init__(self, sock="/var/run/fail2ban/fail2ban.sock"):
 		# Create an INET, STREAMing socket
 		#self.csock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		self.__csock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-		#self.csock.connect(("localhost", 2222))
+		#self.csock.connect(("localho", 2222))
 		self.__csock.connect(sock)
 
 	def __del__(self):
 		self.close(False)
-	
+
 	def send(self, msg):
 		# Convert every list member to string
 		obj = dumps([str(m) for m in msg], HIGHEST_PROTOCOL)
@@ -55,7 +55,7 @@ class CSocket:
 			self.__csock.sendall(CSPROTO.CLOSE + CSPROTO.END)
 		self.__csock.close()
 		self.__csock = None
-	
+
 	@staticmethod
 	def receive(sock):
 		msg = CSPROTO.EMPTY

--- a/fail2ban/client/fail2banreader.py
+++ b/fail2ban/client/fail2banreader.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -32,35 +32,34 @@ logSys = getLogger(__name__)
 
 
 class Fail2banReader(ConfigReader):
-	
+
 	def __init__(self, **kwargs):
 		ConfigReader.__init__(self, **kwargs)
-	
+
 	def read(self):
 		ConfigReader.read(self, "fail2ban")
-	
+
 	def getEarlyOptions(self):
 		opts = [["string", "socket", "/var/run/fail2ban/fail2ban.sock"],
 				["string", "pidfile", "/var/run/fail2ban/fail2ban.pid"]]
 		return ConfigReader.getOptions(self, "Definition", opts)
-	
+
 	def getOptions(self):
-		opts = [["string", "loglevel", "INFO" ],
+		opts = [["string", "loglevel", "INFO"],
 				["string", "logtarget", "STDERR"],
 				["string", "syslogsocket", "auto"],
 				["string", "dbfile", "/var/lib/fail2ban/fail2ban.sqlite3"],
 				["int", "dbpurgeage", 86400]]
 		self.__opts = ConfigReader.getOptions(self, "Definition", opts)
-	
+
 	def convert(self):
 		# Ensure logtarget/level set first so any db errors are captured
 		# Also dbfile should be set before all other database options.
 		# So adding order indices into items, to be stripped after sorting, upon return
-		order = {"syslogsocket":0, "loglevel":1, "logtarget":2,
-			"dbfile":50, "dbpurgeage":51}
+		order = {"syslogsocket": 0, "loglevel": 1, "logtarget": 2,
+			"dbfile": 50, "dbpurgeage": 51}
 		stream = list()
 		for opt in self.__opts:
 			if opt in order:
 				stream.append((order[opt], ["set", opt, self.__opts[opt]]))
 		return [opt[1] for opt in sorted(stream)]
-	

--- a/fail2ban/client/filterreader.py
+++ b/fail2ban/client/filterreader.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -45,7 +45,7 @@ class FilterReader(DefinitionInitConfigReader):
 	def setFile(self, fileName):
 		self.__file = fileName
 		DefinitionInitConfigReader.setFile(self, os.path.join("filter.d", fileName))
-	
+
 	def getFile(self):
 		return self.__file
 
@@ -57,7 +57,7 @@ class FilterReader(DefinitionInitConfigReader):
 		if not opts:
 			raise ValueError('recursive tag definitions unable to be resolved')
 		return opts
-	
+
 	def convert(self):
 		stream = list()
 		opts = self.getCombined()
@@ -88,4 +88,3 @@ class FilterReader(DefinitionInitConfigReader):
 						["set", self._jailName, "addjournalmatch"] +
                         shlex.split(match))
 		return stream
-		

--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -39,11 +39,11 @@ logSys = getLogger(__name__)
 
 
 class JailReader(ConfigReader):
-	
+
 	optionCRE = re.compile("^((?:\w|-|_|\.)+)(?:\[(.*)\])?$")
 	optionExtractRE = re.compile(
 		r'([\w\-_\.]+)=(?:"([^"]*)"|\'([^\']*)\'|([^,]*))(?:,|$)')
-	
+
 	def __init__(self, name, force_enable=False, **kwargs):
 		ConfigReader.__init__(self, **kwargs)
 		self.__name = name
@@ -51,17 +51,17 @@ class JailReader(ConfigReader):
 		self.__force_enable = force_enable
 		self.__actions = list()
 		self.__opts = None
-	
+
 	@property
 	def options(self):
 		return self.__opts
 
 	def setName(self, value):
 		self.__name = value
-	
+
 	def getName(self):
 		return self.__name
-	
+
 	def read(self):
 		out = ConfigReader.read(self, "jail")
 		# Before returning -- verify that requested section
@@ -70,7 +70,7 @@ class JailReader(ConfigReader):
 			raise ValueError("Jail %r was not found among available"
 							 % self.__name)
 		return out
-	
+
 	def isEnabled(self):
 		return self.__force_enable or (
 			self.__opts and self.__opts.get("enabled", False))
@@ -111,7 +111,7 @@ class JailReader(ConfigReader):
 		self.__opts = ConfigReader.getOptions(self, self.__name, opts1st)
 		if not self.__opts:
 			return False
-		
+
 		if self.isEnabled():
 			# Read filter
 			if self.__opts["filter"]:
@@ -134,11 +134,11 @@ class JailReader(ConfigReader):
 			self.__opts = ConfigReader.getOptions(self, self.__name, opts)
 			if not self.__opts:
 				return False
-		
+
 			# cumulate filter options again (ignore given in jail):
 			if self.__filter:
 				self.__filter.getOptions(self.__opts)
-		
+
 			# Read action
 			for act in self.__opts["action"].split('\n'):
 				try:
@@ -172,7 +172,7 @@ class JailReader(ConfigReader):
 			if not len(self.__actions):
 				logSys.warning("No actions were defined for %s" % self.__name)
 		return True
-	
+
 	def convert(self, allow_no_files=False):
 		"""Convert read before __opts to the commands stream
 
@@ -239,7 +239,7 @@ class JailReader(ConfigReader):
 				stream.append(action)
 		stream.insert(0, ["add", self.__name, backend])
 		return stream
-	
+
 	@staticmethod
 	def extractOptions(option):
 		match = JailReader.optionCRE.match(option)
@@ -252,6 +252,6 @@ class JailReader(ConfigReader):
 			for optmatch in JailReader.optionExtractRE.finditer(optstr):
 				opt = optmatch.group(1)
 				value = [
-					val for val in optmatch.group(2,3,4) if val is not None][0]
+					val for val in optmatch.group(2, 3, 4) if val is not None][0]
 				option_opts[opt.strip()] = value.strip()
 		return option_name, option_opts

--- a/fail2ban/client/jailsreader.py
+++ b/fail2ban/client/jailsreader.py
@@ -63,16 +63,16 @@ class JailsReader(ConfigReader):
 		if section is None:
 			sections = self.sections()
 		else:
-			sections = [ section ]
+			sections = [section]
 
 		# Get the options of all jails.
 		parse_status = True
 		for sec in sections:
 			if sec == 'INCLUDES':
 				continue
-			# use the cfg_share for filter/action caching and the same config for all 
+			# use the cfg_share for filter/action caching and the same config for all
 			# jails (use_config=...), therefore don't read it here:
-			jail = JailReader(sec, force_enable=self.__force_enable, 
+			jail = JailReader(sec, force_enable=self.__force_enable,
 				share_config=self.share_config, use_config=self._cfg)
 			ret = jail.getOptions()
 			if ret:
@@ -106,4 +106,3 @@ class JailsReader(ConfigReader):
 			stream.append(["start", jail.getName()])
 
 		return stream
-

--- a/fail2ban/exceptions.py
+++ b/fail2ban/exceptions.py
@@ -33,6 +33,3 @@ class DuplicateJailException(Exception):
 
 class UnknownJailException(KeyError):
 	pass
-
-
-

--- a/fail2ban/helpers.py
+++ b/fail2ban/helpers.py
@@ -30,7 +30,7 @@ import logging
 def formatExceptionInfo():
 	""" Consistently format exception information """
 	cla, exc = sys.exc_info()[:2]
-	return (cla.__name__, str(exc))
+	return cla.__name__, str(exc)
 
 
 #
@@ -72,7 +72,7 @@ class TraceBack(object):
 		ftb = traceback.extract_stack(limit=100)[:-2]
 		entries = [
 			[mbasename(x[0]), os.path.dirname(x[0]), str(x[1])] for x in ftb]
-		entries = [ [e[0], e[2]] for e in entries
+		entries = [[e[0], e[2]] for e in entries
 					if not (e[0] in ['unittest', 'logging.__init__']
 							or e[1].endswith('/unittest'))]
 

--- a/fail2ban/protocol.py
+++ b/fail2ban/protocol.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -29,74 +29,76 @@ import textwrap
 ##
 # Describes the protocol used to communicate with the server.
 
+
 class dotdict(dict):
 	def __getattr__(self, name):
 		return self[name]
 
 CSPROTO = dotdict({
-	"EMPTY":  b"",
-	"END":    b"<F2B_END_COMMAND>",
-	"CLOSE":  b"<F2B_CLOSE_COMMAND>"
+	"EMPTY": b"",
+	"END": b"<F2B_END_COMMAND>",
+	"CLOSE": b"<F2B_CLOSE_COMMAND>"
 })
 
+# noinspection PyPep8
 protocol = [
 ['', "BASIC", ""],
-["start", "starts the server and the jails"], 
-["reload", "reloads the configuration"], 
-["reload <JAIL>", "reloads the jail <JAIL>"], 
-["stop", "stops all jails and terminate the server"], 
-["status", "gets the current status of the server"], 
-["ping", "tests if the server is alive"], 
-["help", "return this output"], 
+["start", "starts the server and the jails"],
+["reload", "reloads the configuration"],
+["reload <JAIL>", "reloads the jail <JAIL>"],
+["stop", "stops all jails and terminate the server"],
+["status", "gets the current status of the server"],
+["ping", "tests if the server is alive"],
+["help", "return this output"],
 ["version", "return the server version"],
 ['', "LOGGING", ""],
-["set loglevel <LEVEL>", "sets logging level to <LEVEL>. Levels: CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG"], 
-["get loglevel", "gets the logging level"], 
-["set logtarget <TARGET>", "sets logging target to <TARGET>. Can be STDOUT, STDERR, SYSLOG or a file"], 
-["get logtarget", "gets logging target"], 
+["set loglevel <LEVEL>", "sets logging level to <LEVEL>. Levels: CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG"],
+["get loglevel", "gets the logging level"],
+["set logtarget <TARGET>", "sets logging target to <TARGET>. Can be STDOUT, STDERR, SYSLOG or a file"],
+["get logtarget", "gets logging target"],
 ["set syslogsocket auto|<SOCKET>", "sets the syslog socket path to auto or <SOCKET>. Only used if logtarget is SYSLOG"],
 ["get syslogsocket", "gets syslog socket path"],
-["flushlogs", "flushes the logtarget if a file and reopens it. For log rotation."], 
+["flushlogs", "flushes the logtarget if a file and reopens it. For log rotation."],
 ['', "DATABASE", ""],
-["set dbfile <FILE>", "set the location of fail2ban persistent datastore. Set to \"None\" to disable"], 
-["get dbfile", "get the location of fail2ban persistent datastore"], 
-["set dbpurgeage <SECONDS>", "sets the max age in <SECONDS> that history of bans will be kept"], 
-["get dbpurgeage", "gets the max age in seconds that history of bans will be kept"], 
+["set dbfile <FILE>", "set the location of fail2ban persistent datastore. Set to \"None\" to disable"],
+["get dbfile", "get the location of fail2ban persistent datastore"],
+["set dbpurgeage <SECONDS>", "sets the max age in <SECONDS> that history of bans will be kept"],
+["get dbpurgeage", "gets the max age in seconds that history of bans will be kept"],
 ['', "JAIL CONTROL", ""],
-["add <JAIL> <BACKEND>", "creates <JAIL> using <BACKEND>"], 
-["start <JAIL>", "starts the jail <JAIL>"], 
-["stop <JAIL>", "stops the jail <JAIL>. The jail is removed"], 
+["add <JAIL> <BACKEND>", "creates <JAIL> using <BACKEND>"],
+["start <JAIL>", "starts the jail <JAIL>"],
+["stop <JAIL>", "stops the jail <JAIL>. The jail is removed"],
 ["status <JAIL> [FLAVOR]", "gets the current status of <JAIL>, with optional flavor or extended info"],
 ['', "JAIL CONFIGURATION", ""],
-["set <JAIL> idle on|off", "sets the idle state of <JAIL>"], 
-["set <JAIL> addignoreip <IP>", "adds <IP> to the ignore list of <JAIL>"], 
-["set <JAIL> delignoreip <IP>", "removes <IP> from the ignore list of <JAIL>"], 
-["set <JAIL> addlogpath <FILE> ['tail']", "adds <FILE> to the monitoring list of <JAIL>, optionally starting at the 'tail' of the file (default 'head')."], 
+["set <JAIL> idle on|off", "sets the idle state of <JAIL>"],
+["set <JAIL> addignoreip <IP>", "adds <IP> to the ignore list of <JAIL>"],
+["set <JAIL> delignoreip <IP>", "removes <IP> from the ignore list of <JAIL>"],
+["set <JAIL> addlogpath <FILE> ['tail']", "adds <FILE> to the monitoring list of <JAIL>, optionally starting at the 'tail' of the file (default 'head')."],
 ["set <JAIL> dellogpath <FILE>", "removes <FILE> from the monitoring list of <JAIL>"],
 ["set <JAIL> logencoding <ENCODING>", "sets the <ENCODING> of the log files for <JAIL>"],
 ["set <JAIL> addjournalmatch <MATCH>", "adds <MATCH> to the journal filter of <JAIL>"],
 ["set <JAIL> deljournalmatch <MATCH>", "removes <MATCH> from the journal filter of <JAIL>"],
-["set <JAIL> addfailregex <REGEX>", "adds the regular expression <REGEX> which must match failures for <JAIL>"], 
-["set <JAIL> delfailregex <INDEX>", "removes the regular expression at <INDEX> for failregex"], 
+["set <JAIL> addfailregex <REGEX>", "adds the regular expression <REGEX> which must match failures for <JAIL>"],
+["set <JAIL> delfailregex <INDEX>", "removes the regular expression at <INDEX> for failregex"],
 ["set <JAIL> ignorecommand <VALUE>", "sets ignorecommand of <JAIL>"],
 ["set <JAIL> addignoreregex <REGEX>", "adds the regular expression <REGEX> which should match pattern to exclude for <JAIL>"],
-["set <JAIL> delignoreregex <INDEX>", "removes the regular expression at <INDEX> for ignoreregex"], 
-["set <JAIL> findtime <TIME>", "sets the number of seconds <TIME> for which the filter will look back for <JAIL>"], 
-["set <JAIL> bantime <TIME>", "sets the number of seconds <TIME> a host will be banned for <JAIL>"], 
+["set <JAIL> delignoreregex <INDEX>", "removes the regular expression at <INDEX> for ignoreregex"],
+["set <JAIL> findtime <TIME>", "sets the number of seconds <TIME> for which the filter will look back for <JAIL>"],
+["set <JAIL> bantime <TIME>", "sets the number of seconds <TIME> a host will be banned for <JAIL>"],
 ["set <JAIL> datepattern <PATTERN>", "sets the <PATTERN> used to match date/times for <JAIL>"],
 ["set <JAIL> usedns <VALUE>", "sets the usedns mode for <JAIL>"],
-["set <JAIL> banip <IP>", "manually Ban <IP> for <JAIL>"], 
-["set <JAIL> unbanip <IP>", "manually Unban <IP> in <JAIL>"], 
-["set <JAIL> maxretry <RETRY>", "sets the number of failures <RETRY> before banning the host for <JAIL>"], 
-["set <JAIL> maxlines <LINES>", "sets the number of <LINES> to buffer for regex search for <JAIL>"], 
-["set <JAIL> addaction <ACT>[ <PYTHONFILE> <JSONKWARGS>]", "adds a new action named <NAME> for <JAIL>. Optionally for a Python based action, a <PYTHONFILE> and <JSONKWARGS> can be specified, else will be a Command Action"], 
-["set <JAIL> delaction <ACT>", "removes the action <ACT> from <JAIL>"], 
+["set <JAIL> banip <IP>", "manually Ban <IP> for <JAIL>"],
+["set <JAIL> unbanip <IP>", "manually Unban <IP> in <JAIL>"],
+["set <JAIL> maxretry <RETRY>", "sets the number of failures <RETRY> before banning the host for <JAIL>"],
+["set <JAIL> maxlines <LINES>", "sets the number of <LINES> to buffer for regex search for <JAIL>"],
+["set <JAIL> addaction <ACT>[ <PYTHONFILE> <JSONKWARGS>]", "adds a new action named <NAME> for <JAIL>. Optionally for a Python based action, a <PYTHONFILE> and <JSONKWARGS> can be specified, else will be a Command Action"],
+["set <JAIL> delaction <ACT>", "removes the action <ACT> from <JAIL>"],
 ["", "COMMAND ACTION CONFIGURATION", ""],
-["set <JAIL> action <ACT> actionstart <CMD>", "sets the start command <CMD> of the action <ACT> for <JAIL>"], 
-["set <JAIL> action <ACT> actionstop <CMD>", "sets the stop command <CMD> of the action <ACT> for <JAIL>"], 
-["set <JAIL> action <ACT> actioncheck <CMD>", "sets the check command <CMD> of the action <ACT> for <JAIL>"], 
+["set <JAIL> action <ACT> actionstart <CMD>", "sets the start command <CMD> of the action <ACT> for <JAIL>"],
+["set <JAIL> action <ACT> actionstop <CMD>", "sets the stop command <CMD> of the action <ACT> for <JAIL>"],
+["set <JAIL> action <ACT> actioncheck <CMD>", "sets the check command <CMD> of the action <ACT> for <JAIL>"],
 ["set <JAIL> action <ACT> actionban <CMD>", "sets the ban command <CMD> of the action <ACT> for <JAIL>"],
-["set <JAIL> action <ACT> actionunban <CMD>", "sets the unban command <CMD> of the action <ACT> for <JAIL>"], 
+["set <JAIL> action <ACT> actionunban <CMD>", "sets the unban command <CMD> of the action <ACT> for <JAIL>"],
 ["set <JAIL> action <ACT> timeout <TIMEOUT>", "sets <TIMEOUT> as the command timeout in seconds for the action <ACT> for <JAIL>"],
 ["", "GENERAL ACTION CONFIGURATION", ""],
 ["set <JAIL> action <ACT> <PROPERTY> <VALUE>", "sets the <VALUE> of <PROPERTY> for the action <ACT> for <JAIL>"],
@@ -135,9 +137,9 @@ protocol = [
 # "-h" output of fail2ban-client.
 
 def printFormatted():
-	INDENT=4
-	MARGIN=41
-	WIDTH=34
+	INDENT = 4
+	MARGIN = 41
+	WIDTH = 34
 	firstHeading = False
 	for m in protocol:
 		if m[0] == '' and firstHeading:

--- a/fail2ban/server/__init__.py
+++ b/fail2ban/server/__init__.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"

--- a/fail2ban/server/action.py
+++ b/fail2ban/server/action.py
@@ -409,13 +409,13 @@ class CommandAction(ActionBase):
 						# recursive definitions are bad
 						#logSys.log(5, 'recursion fail tag: %s value: %s' % (tag, value) )
 						return False
-					if found_tag in cls._escapedTags or not found_tag in tags:
+					if found_tag in cls._escapedTags or found_tag not in tags:
 						# Escaped or missing tags - just continue on searching after end of match
 						# Missing tags are ok - cInfo can contain aInfo elements like <HOST> and valid shell
 						# constructs like <STDIN>.
 						m = t.search(value, m.end())
 						continue
-					value = value.replace('<%s>' % found_tag , tags[found_tag])
+					value = value.replace('<%s>' % found_tag, tags[found_tag])
 					#logSys.log(5, 'value now: %s' % value)
 					done.append(found_tag)
 					m = t.search(value, m.start())
@@ -486,7 +486,7 @@ class CommandAction(ActionBase):
 		string = string.replace("<br>", '\n')
 		return string
 
-	def _processCmd(self, cmd, aInfo = None):
+	def _processCmd(self, cmd, aInfo=None):
 		"""Executes a command with preliminary checks and substitutions.
 
 		Before executing any commands, executes the "check" command first
@@ -521,7 +521,7 @@ class CommandAction(ActionBase):
 				return False
 
 		# Replace tags
-		if not aInfo is None:
+		if aInfo is not None:
 			realCmd = self.replaceTag(cmd, aInfo)
 		else:
 			realCmd = cmd
@@ -614,4 +614,3 @@ class CommandAction(ActionBase):
 							% (retcode, msg % locals()))
 			return False
 		raise RuntimeError("Command execution failed: %s" % realCmd)
-

--- a/fail2ban/server/actions.py
+++ b/fail2ban/server/actions.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -165,16 +165,16 @@ class Actions(JailThread, Mapping):
 	# Set the ban time.
 	#
 	# @param value the time
-	
+
 	def setBanTime(self, value):
 		self.__banManager.setBanTime(value)
 		logSys.info("Set banTime = %s" % value)
-	
+
 	##
 	# Get the ban time.
 	#
 	# @return the time
-	
+
 	def getBanTime(self):
 		return self.__banManager.getBanTime()
 
@@ -222,7 +222,7 @@ class Actions(JailThread, Mapping):
 			except Exception as e:
 				logSys.error("Failed to start jail '%s' action '%s': %s",
 					self._jail.name, name, e,
-					exc_info=logSys.getEffectiveLevel()<=logging.DEBUG)
+					exc_info=logSys.getEffectiveLevel() <= logging.DEBUG)
 		while self.active:
 			if not self.idle:
 				#logSys.debug(self._jail.name + ": action")
@@ -242,7 +242,7 @@ class Actions(JailThread, Mapping):
 			except Exception as e:
 				logSys.error("Failed to stop jail '%s' action '%s': %s",
 					self._jail.name, name, e,
-					exc_info=logSys.getEffectiveLevel()<=logging.DEBUG)
+					exc_info=logSys.getEffectiveLevel() <= logging.DEBUG)
 		logSys.debug(self._jail.name + ": action terminated")
 		return True
 
@@ -264,15 +264,15 @@ class Actions(JailThread, Mapping):
 
 		Returns
 		-------
-		BanTicket 
+		BanTicket
 			merged or self ticket only
 		"""
 		idx = 'all' if overalljails else 'jail'
 		if idx in mi:
 			return mi[idx] if mi[idx] is not None else mi['ticket']
 		try:
-			jail=self._jail
-			ip=mi['ip']
+			jail = self._jail
+			ip = mi['ip']
 			mi[idx] = None
 			if overalljails:
 				mi[idx] = jail.database.getBansMerged(ip=ip)
@@ -282,7 +282,7 @@ class Actions(JailThread, Mapping):
 			logSys.error(
 				"Failed to get %s bans merged, jail '%s': %s",
 				idx, jail.name, e,
-				exc_info=logSys.getEffectiveLevel()<=logging.DEBUG)
+				exc_info=logSys.getEffectiveLevel() <= logging.DEBUG)
 		return mi[idx] if mi[idx] is not None else mi['ticket']
 
 	def __checkBan(self):
@@ -307,10 +307,10 @@ class Actions(JailThread, Mapping):
 			aInfo["matches"] = "\n".join(bTicket.getMatches())
 			if self._jail.database is not None:
 				mi4ip = lambda overalljails=False, self=self, \
-					mi={'ip':ip, 'ticket':bTicket}: self.__getBansMerged(mi, overalljails)
-				aInfo["ipmatches"]      = lambda: "\n".join(mi4ip(True).getMatches())
-				aInfo["ipjailmatches"]  = lambda: "\n".join(mi4ip().getMatches())
-				aInfo["ipfailures"]     = lambda: mi4ip(True).getAttempt()
+					mi={'ip': ip, 'ticket': bTicket}: self.__getBansMerged(mi, overalljails)
+				aInfo["ipmatches"] = lambda: "\n".join(mi4ip(True).getMatches())
+				aInfo["ipjailmatches"] = lambda: "\n".join(mi4ip().getMatches())
+				aInfo["ipfailures"] = lambda: mi4ip(True).getAttempt()
 				aInfo["ipjailfailures"] = lambda: mi4ip().getAttempt()
 			if self.__banManager.addBanTicket(bTicket):
 				logSys.notice("[%s] Ban %s" % (self._jail.name, aInfo["ip"]))
@@ -322,7 +322,7 @@ class Actions(JailThread, Mapping):
 							"Failed to execute ban jail '%s' action '%s' "
 							"info '%r': %s",
 							self._jail.name, name, aInfo, e,
-							exc_info=logSys.getEffectiveLevel()<=logging.DEBUG)
+							exc_info=logSys.getEffectiveLevel() <= logging.DEBUG)
 				return True
 			else:
 				logSys.notice("[%s] %s already banned" % (self._jail.name,
@@ -371,7 +371,7 @@ class Actions(JailThread, Mapping):
 					"Failed to execute unban jail '%s' action '%s' "
 					"info '%r': %s",
 					self._jail.name, name, aInfo, e,
-					exc_info=logSys.getEffectiveLevel()<=logging.DEBUG)
+					exc_info=logSys.getEffectiveLevel() <= logging.DEBUG)
 
 	def status(self, flavor="basic"):
 		"""Status of current and total ban counts and current banned IP list.

--- a/fail2ban/server/asyncserver.py
+++ b/fail2ban/server/asyncserver.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -34,7 +34,7 @@ import sys
 import traceback
 
 from ..protocol import CSPROTO
-from ..helpers import getLogger,formatExceptionInfo
+from ..helpers import getLogger, formatExceptionInfo
 
 # Gets the instance of the logger.
 logSys = getLogger(__name__)
@@ -45,8 +45,9 @@ logSys = getLogger(__name__)
 # This class extends asynchat in order to provide a request handler for
 # incoming query.
 
+
 class RequestHandler(asynchat.async_chat):
-	
+
 	def __init__(self, conn, transmitter):
 		asynchat.async_chat.__init__(self, conn)
 		self.__transmitter = transmitter
@@ -66,7 +67,7 @@ class RequestHandler(asynchat.async_chat):
 	def found_terminator(self):
 		# Pop whole buffer
 		message = self.__buffer
-		self.__buffer = []		
+		self.__buffer = []
 		# Joins the buffer items.
 		message = CSPROTO.EMPTY.join(message)
 		# Closes the channel if close was received
@@ -81,13 +82,13 @@ class RequestHandler(asynchat.async_chat):
 		message = dumps(message, HIGHEST_PROTOCOL)
 		# Sends the response to the client.
 		self.push(message + CSPROTO.END)
-		
+
 	def handle_error(self):
 		e1, e2 = formatExceptionInfo()
 		logSys.error("Unexpected communication error: %s" % str(e2))
 		logSys.error(traceback.format_exc().splitlines())
 		self.close()
-		
+
 
 ##
 # Asynchronous server class.
@@ -122,13 +123,13 @@ class AsyncServer(asyncore.dispatcher):
 		# Creates an instance of the handler class to handle the
 		# request/response on the incoming connection.
 		RequestHandler(conn, self.__transmitter)
-	
+
 	##
 	# Starts the communication server.
 	#
 	# @param sock: socket file.
 	# @param force: remove the socket file if exists.
-	
+
 	def start(self, sock, force):
 		self.__sock = sock
 		# Remove socket
@@ -152,16 +153,16 @@ class AsyncServer(asyncore.dispatcher):
 		self.__init = True
 		# TODO Add try..catch
 		# There's a bug report for Python 2.6/3.0 that use_poll=True yields some 2.5 incompatibilities:
-		if (sys.version_info >= (2, 7) and sys.version_info < (2, 8)) \
+		if ((2, 7) <= sys.version_info < (2, 8)) \
 		   or (sys.version_info >= (3, 4)): # if python 2.7 ...
 			logSys.debug("Detected Python 2.7. asyncore.loop() using poll")
 			asyncore.loop(use_poll=True) # workaround for the "Bad file descriptor" issue on Python 2.7, gh-161
 		else:
 			asyncore.loop(use_poll=False) # fixes the "Unexpected communication problem" issue on Python 2.6 and 3.0
-	
+
 	##
 	# Stops the communication server.
-	
+
 	def stop(self):
 		if self.__init:
 			# Only closes the socket if it was initialized first.
@@ -177,12 +178,12 @@ class AsyncServer(asyncore.dispatcher):
 	# running actions involving command execution.
 
 	# @param sock: socket file.
-	
+
 	@staticmethod
 	def __markCloseOnExec(sock):
 		fd = sock.fileno()
 		flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-		fcntl.fcntl(fd, fcntl.F_SETFD, flags|fcntl.FD_CLOEXEC)
+		fcntl.fcntl(fd, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
 
 
 ##

--- a/fail2ban/server/banmanager.py
+++ b/fail2ban/server/banmanager.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -41,12 +41,12 @@ logSys = getLogger(__name__)
 # This class is mainly used by the Action class.
 
 class BanManager:
-	
+
 	##
 	# Constructor.
 	#
 	# Initialize members with default values.
-	
+
 	def __init__(self):
 		## Mutex used to protect the ban list.
 		self.__lock = Lock()
@@ -56,50 +56,50 @@ class BanManager:
 		self.__banTime = 600
 		## Total number of banned IP address
 		self.__banTotal = 0
-	
+
 	##
 	# Set the ban time.
 	#
 	# Set the amount of time an IP address get banned.
 	# @param value the time
-	
+
 	def setBanTime(self, value):
 		try:
 			self.__lock.acquire()
 			self.__banTime = int(value)
 		finally:
 			self.__lock.release()
-	
+
 	##
 	# Get the ban time.
 	#
 	# Get the amount of time an IP address get banned.
 	# @return the time
-	
+
 	def getBanTime(self):
 		try:
 			self.__lock.acquire()
 			return self.__banTime
 		finally:
 			self.__lock.release()
-	
+
 	##
 	# Set the total number of banned address.
 	#
 	# @param value total number
-	
+
 	def setBanTotal(self, value):
 		try:
 			self.__lock.acquire()
 			self.__banTotal = value
 		finally:
 			self.__lock.release()
-	
+
 	##
 	# Get the total number of banned address.
 	#
 	# @return the total number
-	
+
 	def getBanTotal(self):
 		try:
 			self.__lock.acquire()
@@ -111,7 +111,7 @@ class BanManager:
 	# Returns a copy of the IP list.
 	#
 	# @return IP list
-	
+
 	def getBanList(self):
 		try:
 			self.__lock.acquire()
@@ -244,7 +244,7 @@ class BanManager:
 	# is the current time. This is a static method.
 	# @param ticket the FailTicket
 	# @return a BanTicket
-	
+
 	@staticmethod
 	def createBanTicket(ticket):
 		ip = ticket.getIP()
@@ -253,14 +253,14 @@ class BanManager:
 		banTicket = BanTicket(ip, lastTime, ticket.getMatches())
 		banTicket.setAttempt(ticket.getAttempt())
 		return banTicket
-	
+
 	##
 	# Add a ban ticket.
 	#
 	# Add a BanTicket instance into the ban list.
 	# @param ticket the ticket
 	# @return True if the IP address is not in the ban list
-	
+
 	def addBanTicket(self, ticket):
 		try:
 			self.__lock.acquire()
@@ -291,20 +291,20 @@ class BanManager:
 	# ban list.
 	# @param ticket the ticket
 	# @return True if a ticket already exists
-	
+
 	def _inBanList(self, ticket):
 		for i in self.__banList:
 			if ticket.getIP() == i.getIP():
 				return True
 		return False
-	
+
 	##
 	# Get the list of IP address to unban.
 	#
 	# Return a list of BanTicket which need to be unbanned.
 	# @param time the time
 	# @return the list of ticket to unban
-	
+
 	def unBanList(self, time):
 		try:
 			self.__lock.acquire()
@@ -315,11 +315,11 @@ class BanManager:
 			# Gets the list of ticket to remove.
 			unBanList = [ticket for ticket in self.__banList
 						 if ticket.getTime() < time - self.__banTime]
-			
+
 			# Removes tickets.
 			self.__banList = [ticket for ticket in self.__banList
 							  if ticket not in unBanList]
-						
+
 			return unBanList
 		finally:
 			self.__lock.release()
@@ -329,7 +329,7 @@ class BanManager:
 	#
 	# Get the ban list and initialize it with an empty one.
 	# @return the complete ban list
-	
+
 	def flushBanList(self):
 		try:
 			self.__lock.acquire()

--- a/fail2ban/server/database.py
+++ b/fail2ban/server/database.py
@@ -162,7 +162,7 @@ class Fail2BanDb(object):
 			"CREATE INDEX bans_ip ON bans(ip);" \
 
 
-	def __init__(self, filename, purgeAge=24*60*60):
+	def __init__(self, filename, purgeAge=24 * 60 * 60):
 		try:
 			self._lock = RLock()
 			self._db = sqlite3.connect(
@@ -194,10 +194,10 @@ class Fail2BanDb(object):
 			if version < Fail2BanDb.__version__:
 				newversion = self.updateDb(version)
 				if newversion == Fail2BanDb.__version__:
-					logSys.warning( "Database updated from '%i' to '%i'",
+					logSys.warning("Database updated from '%i' to '%i'",
 						version, newversion)
 				else:
-					logSys.error( "Database update failed to achieve version '%i'"
+					logSys.error("Database update failed to achieve version '%i'"
 						": updated from '%i' to '%i'",
 						Fail2BanDb.__version__, version, newversion)
 					raise RuntimeError('Failed to fully update')
@@ -428,10 +428,10 @@ class Fail2BanDb(object):
 		ip : str
 			IP to be removed.
 		"""
-		queryArgs = (jail.name, ip);
+		queryArgs = (jail.name, ip)
 		cur.execute(
-			"DELETE FROM bans WHERE jail = ? AND ip = ?", 
-			queryArgs);
+			"DELETE FROM bans WHERE jail = ? AND ip = ?",
+			queryArgs)
 
 	@commitandrollback
 	def _getBans(self, cur, jail=None, bantime=None, ip=None):
@@ -548,4 +548,3 @@ class Fail2BanDb(object):
 		cur.execute(
 			"DELETE FROM jails WHERE enabled = 0 "
 				"AND NOT EXISTS(SELECT * FROM bans WHERE jail = jails.name)")
-

--- a/fail2ban/server/datedetector.py
+++ b/fail2ban/server/datedetector.py
@@ -76,15 +76,15 @@ class DateDetector(object):
 		self.__lock.acquire()
 		try:
 			# asctime with optional day, subsecond and/or year:
-			# Sun Jan 23 21:59:59.011 2005 
+			# Sun Jan 23 21:59:59.011 2005
 			self.appendTemplate("(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %Y)?")
 			# simple date, optional subsecond (proftpd):
-			# 2005-01-23 21:59:59 
-			# simple date: 2005/01/23 21:59:59 
+			# 2005-01-23 21:59:59
+			# simple date: 2005/01/23 21:59:59
 			# custom for syslog-ng 2006.12.21 06:43:20
 			self.appendTemplate("%Y(?P<_sep>[-/.])%m(?P=_sep)%d %H:%M:%S(?:,%f)?")
-			# simple date too (from x11vnc): 23/01/2005 21:59:59 
-			# and with optional year given by 2 digits: 23/01/05 21:59:59 
+			# simple date too (from x11vnc): 23/01/2005 21:59:59
+			# and with optional year given by 2 digits: 23/01/05 21:59:59
 			# (See http://bugs.debian.org/537610)
 			# 17-07-2008 17:23:25
 			self.appendTemplate("%d(?P<_sep>[-/])%m(?P=_sep)(?:%Y|%y) %H:%M:%S")
@@ -94,7 +94,7 @@ class DateDetector(object):
 			self.appendTemplate("%d(?P<_sep>[-/])%b(?P=_sep)%Y[ :]?%H:%M:%S(?:\.%f)?(?: %z)?")
 			# CPanel 05/20/2008:01:57:39
 			self.appendTemplate("%m/%d/%Y:%H:%M:%S")
-			# named 26-Jul-2007 15:20:52.252 
+			# named 26-Jul-2007 15:20:52.252
 			# roundcube 26-Jul-2007 15:20:52 +0200
 			# 01-27-2012 16:22:44.252
 			# subseconds explicit to avoid possible %m<->%d confusion
@@ -151,7 +151,7 @@ class DateDetector(object):
 		try:
 			for template in self.__templates:
 				match = template.matchDate(line)
-				if not match is None:
+				if match not is None:
 					logSys.debug("Matched time template %s" % template.name)
 					template.hits += 1
 					return match

--- a/fail2ban/server/datetemplate.py
+++ b/fail2ban/server/datetemplate.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -82,14 +82,12 @@ class DateTemplate(object):
 			If regular expression fails to compile
 		"""
 		regex = regex.strip()
-		if (wordBegin and not re.search(r'^\^', regex)):
+		if wordBegin and not re.search(r'^\^', regex):
 			regex = r'\b' + regex
 		self._regex = regex
 		self._cRegex = re.compile(regex, re.UNICODE | re.IGNORECASE)
 
-	regex = property(getRegex, setRegex, doc=
-		"""Regex used to search for date.
-		""")
+	regex = property(getRegex, setRegex, doc="""Regex used to search for date.""")
 
 	def matchDate(self, line):
 		"""Check if regex for date matches on a log line.
@@ -151,7 +149,7 @@ class DateEpoch(DateTemplate):
 		dateMatch = self.matchDate(line)
 		if dateMatch:
 			# extract part of format which represents seconds since epoch
-			return (float(dateMatch.group()), dateMatch)
+			return float(dateMatch.group()), dateMatch
 		return None
 
 
@@ -273,5 +271,5 @@ class DateTai64n(DateTemplate):
 			value = dateMatch.group()
 			seconds_since_epoch = value[2:17]
 			# convert seconds from HEX into local time stamp
-			return (int(seconds_since_epoch, 16), dateMatch)
+			return int(seconds_since_epoch, 16), dateMatch
 		return None

--- a/fail2ban/server/faildata.py
+++ b/fail2ban/server/faildata.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -31,7 +31,7 @@ logSys = getLogger(__name__)
 
 
 class FailData:
-	
+
 	def __init__(self):
 		self.__retry = 0
 		self.__lastTime = 0
@@ -60,7 +60,7 @@ class FailData:
 	def setLastTime(self, value):
 		if value > self.__lastTime:
 			self.__lastTime = value
-	
+
 	def getLastTime(self):
 		return self.__lastTime
 

--- a/fail2ban/server/failmanager.py
+++ b/fail2ban/server/failmanager.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -36,49 +36,49 @@ logSys = getLogger(__name__)
 
 
 class FailManager:
-	
+
 	def __init__(self):
 		self.__lock = Lock()
 		self.__failList = dict()
 		self.__maxRetry = 3
 		self.__maxTime = 600
 		self.__failTotal = 0
-	
+
 	def setFailTotal(self, value):
 		try:
 			self.__lock.acquire()
 			self.__failTotal = value
 		finally:
 			self.__lock.release()
-		
+
 	def getFailTotal(self):
 		try:
 			self.__lock.acquire()
 			return self.__failTotal
 		finally:
 			self.__lock.release()
-	
+
 	def setMaxRetry(self, value):
 		try:
 			self.__lock.acquire()
 			self.__maxRetry = value
 		finally:
 			self.__lock.release()
-	
+
 	def getMaxRetry(self):
 		try:
 			self.__lock.acquire()
 			return self.__maxRetry
 		finally:
 			self.__lock.release()
-	
+
 	def setMaxTime(self, value):
 		try:
 			self.__lock.acquire()
 			self.__maxTime = value
 		finally:
 			self.__lock.release()
-	
+
 	def getMaxTime(self):
 		try:
 			self.__lock.acquire()
@@ -113,19 +113,19 @@ class FailManager:
 				# in case of having many active failures, it should be ran only
 				# if debug level is "low" enough
 				failures_summary = ', '.join(['%s:%d' % (k, v.getRetry())
-											  for k,v in  self.__failList.iteritems()])
+											  for k, v in self.__failList.iteritems()])
 				logSys.debug("Total # of detected failures: %d. Current failures from %d IPs (IP:count): %s"
 							 % (self.__failTotal, len(self.__failList), failures_summary))
 		finally:
 			self.__lock.release()
-	
+
 	def size(self):
 		try:
 			self.__lock.acquire()
 			return len(self.__failList)
 		finally:
 			self.__lock.release()
-	
+
 	def cleanup(self, time):
 		try:
 			self.__lock.acquire()
@@ -135,11 +135,11 @@ class FailManager:
 					self.__delFailure(item)
 		finally:
 			self.__lock.release()
-	
+
 	def __delFailure(self, ip):
 		if ip in self.__failList:
 			del self.__failList[ip]
-	
+
 	def toBan(self):
 		try:
 			self.__lock.acquire()

--- a/fail2ban/server/failregex.py
+++ b/fail2ban/server/failregex.py
@@ -39,7 +39,7 @@ class Regex:
 	# Creates a new object. This method can throw RegexException in order to
 	# avoid construction of invalid object.
 	# @param value the regular expression
-	
+
 	def __init__(self, regex):
 		self._matchCache = None
 		# Perform shortcuts expansions.
@@ -66,10 +66,10 @@ class Regex:
 	#
 	# The effective regular expression used is returned.
 	# @return the regular expression
-	
+
 	def getRegex(self):
 		return self._regex
-	
+
 	##
 	# Searches the regular expression.
 	#
@@ -77,7 +77,7 @@ class Regex:
 	# the pattern again. This method must be called before calling any other
 	# method of this object.
 	# @param a list of tupples. The tupples are ( prematch, datematch, postdatematch )
-	
+
 	def search(self, tupleLines):
 		self._matchCache = self._regexObj.search(
 			"\n".join("".join(value[::2]) for value in tupleLines) + "\n")
@@ -85,7 +85,7 @@ class Regex:
 			# Find start of the first line where the match was found
 			try:
 				self._matchLineStart = self._matchCache.string.rindex(
-					"\n", 0, self._matchCache.start() +1 ) + 1
+					"\n", 0, self._matchCache.start() + 1) + 1
 			except ValueError:
 				self._matchLineStart = 0
 			# Find end of the last line where the match was found
@@ -108,7 +108,7 @@ class Regex:
 					self._matchedTupleLines[n:]):
 					if "".join(matchedTupleLine[::2]) == skippedLine:
 						self._unmatchedTupleLines.append(
-							self._matchedTupleLines.pop(n+m))
+							self._matchedTupleLines.pop(n + m))
 						n += m
 						break
 			self._unmatchedTupleLines.extend(tupleLines[lineCount2:])
@@ -116,7 +116,7 @@ class Regex:
 	# Checks if the previous call to search() matched.
 	#
 	# @return True if a match was found, False otherwise
-	
+
 	def hasMatched(self):
 		if self._matchCache:
 			return True
@@ -128,7 +128,7 @@ class Regex:
 	#
 	# This returns skipped lines captured by the <SKIPLINES> tag.
 	# @return list of skipped lines
-	
+
 	def getSkippedLines(self):
 		if not self._matchCache:
 			return []
@@ -141,7 +141,7 @@ class Regex:
 				n += 1
 			except IndexError:
 				break
-			# KeyError is because of PyPy issue1665 affecting pypy <= 2.2.1 
+			# KeyError is because of PyPy issue1665 affecting pypy <= 2.2.1
 			except KeyError:
 				if 'PyPy' not in sys.version: # pragma: no cover - not sure this is even reachable
 					raise
@@ -206,20 +206,20 @@ class FailRegex(Regex):
 	# Creates a new object. This method can throw RegexException in order to
 	# avoid construction of invalid object.
 	# @param value the regular expression
-	
+
 	def __init__(self, regex):
 		# Initializes the parent.
 		Regex.__init__(self, regex)
 		# Check for group "host"
 		if "host" not in self._regexObj.groupindex:
 			raise RegexException("No 'host' group in '%s'" % self._regex)
-	
+
 	##
 	# Returns the matched host.
 	#
 	# This corresponds to the pattern matched by the named group "host".
 	# @return the matched host
-	
+
 	def getHost(self):
 		host = self._matchCache.group("host")
 		if host is None:

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -26,7 +26,6 @@ import fcntl
 import locale
 import os
 import re
-import sys
 
 from .failmanager import FailManagerEmpty, FailManager
 from .ticket import FailTicket
@@ -140,7 +139,7 @@ class Filter(JailThread):
 			self.__ignoreRegex.append(regex)
 		except RegexException, e:
 			logSys.error(e)
-			raise e 
+			raise e
 
 	def delIgnoreRegex(self, index):
 		try:
@@ -238,7 +237,7 @@ class Filter(JailThread):
 				return None, "Default Detectors"
 			elif len(templates) == 1:
 				if hasattr(templates[0], "pattern"):
-					pattern =  templates[0].pattern
+					pattern = templates[0].pattern
 				else:
 					pattern = None
 				return pattern, templates[0].name
@@ -386,7 +385,7 @@ class Filter(JailThread):
 				return True
 
 		if self.__ignoreCommand:
-			command = CommandAction.replaceTag(self.__ignoreCommand, { 'ip': ip } )
+			command = CommandAction.replaceTag(self.__ignoreCommand, {'ip': ip})
 			logSys.debug('ignore command: ' + command)
 			ret_ignore = CommandAction.executeCmd(command)
 			self.logIgnoreIp(ip, log_ignore and ret_ignore, ignore_source="command")
@@ -406,7 +405,7 @@ class Filter(JailThread):
 
 			timeMatch = self.dateDetector.matchTime(l)
 			if timeMatch:
-				tupleLine  = (
+				tupleLine = (
 					l[:timeMatch.start()],
 					l[timeMatch.start():timeMatch.end()],
 					l[timeMatch.end():])
@@ -560,7 +559,7 @@ class FileFilter(Filter):
 	#
 	# @param path log file path
 
-	def addLogPath(self, path, tail = False):
+	def addLogPath(self, path, tail=False):
 		if self.containsLogPath(path):
 			logSys.error(path + " already exists")
 		else:
@@ -721,7 +720,7 @@ except ImportError: # pragma: no cover
 
 class FileContainer:
 
-	def __init__(self, filename, encoding, tail = False):
+	def __init__(self, filename, encoding, tail=False):
 		self.__filename = filename
 		self.setEncoding(encoding)
 		self.__tail = tail
@@ -810,7 +809,7 @@ class FileContainer:
 		return line
 
 	def close(self):
-		if not self.__handler is None:
+		if self.__handler is not None:
 			# Saves the last position.
 			self.__pos = self.__handler.tell()
 			# Closes the file.
@@ -903,7 +902,7 @@ class DNSUtils:
 		ipList = list()
 		# Search for plain IP
 		plainIP = DNSUtils.searchIP(text)
-		if not plainIP is None:
+		if plainIP is not None:
 			plainIPStr = plainIP.group(0)
 			if DNSUtils.isValidIP(plainIPStr):
 				ipList.append(plainIPStr)

--- a/fail2ban/server/filtergamin.py
+++ b/fail2ban/server/filtergamin.py
@@ -59,7 +59,7 @@ class FilterGamin(FileFilter):
 		self.monitor = gamin.WatchMonitor()
 		fd = self.monitor.get_fd()
 		flags = fcntl.fcntl(fd, fcntl.F_GETFD)
-		fcntl.fcntl(fd, fcntl.F_SETFD, flags|fcntl.FD_CLOEXEC)
+		fcntl.fcntl(fd, fcntl.F_SETFD, flags | fcntl.FD_CLOEXEC)
 		logSys.debug("Created FilterGamin")
 
 	def callback(self, path, event):

--- a/fail2ban/server/filterpyinotify.py
+++ b/fail2ban/server/filterpyinotify.py
@@ -77,13 +77,13 @@ class FilterPyinotify(FileFilter):
 	def callback(self, event, origin=''):
 		logSys.debug("%sCallback for Event: %s", origin, event)
 		path = event.pathname
-		if event.mask & ( pyinotify.IN_CREATE | pyinotify.IN_MOVED_TO ):
+		if event.mask & (pyinotify.IN_CREATE | pyinotify.IN_MOVED_TO):
 			# skip directories altogether
 			if event.mask & pyinotify.IN_ISDIR:
 				logSys.debug("Ignoring creation of directory %s", path)
 				return
 			# check if that is a file we care about
-			if not path in self.__watches:
+			if path not in self.__watches:
 				logSys.debug("Ignoring creation of %s we do not monitor", path)
 				return
 			else:
@@ -142,7 +142,7 @@ class FilterPyinotify(FileFilter):
 		self._addFileWatcher(path)
 		self._process_file(path)
 
-    ##
+	##
 	# Delete a log path
 	#
 	# @param path the log file to delete

--- a/fail2ban/server/filtersystemd.py
+++ b/fail2ban/server/filtersystemd.py
@@ -103,7 +103,7 @@ class FilterSystemd(JournalFilter): # pragma: systemd no cover
 	##
 	# Reset a journal match filter called on removal or failure
 	#
-	# @return None 
+	# @return None
 
 	def resetJournalMatches(self):
 		self.__journal.flush_matches()
@@ -139,11 +139,11 @@ class FilterSystemd(JournalFilter): # pragma: systemd no cover
 	def getJournalMatch(self):
 		return self.__matches
 
-    ##
-    # Join group of log elements which may be a mix of bytes and strings
-    #
-    # @param elements list of strings and bytes
-    # @return elements joined as string
+	##
+	# Join group of log elements which may be a mix of bytes and strings
+	#
+	# @param elements list of strings and bytes
+	# @return elements joined as string
 
 	@staticmethod
 	def _joinStrAndBytes(elements):
@@ -184,7 +184,7 @@ class FilterSystemd(JournalFilter): # pragma: systemd no cover
 			else:
 				monotonic = logentry.get('__MONOTONIC_TIMESTAMP')[0]
 			logelements.append("[%12.6f]" % monotonic.total_seconds())
-		if isinstance(logentry.get('MESSAGE',''), list):
+		if isinstance(logentry.get('MESSAGE', ''), list):
 			logelements.append(" ".join(logentry['MESSAGE']))
 		else:
 			logelements.append(logentry.get('MESSAGE', ''))
@@ -198,14 +198,14 @@ class FilterSystemd(JournalFilter): # pragma: systemd no cover
 			# Python 3, one or more elements bytes
 			logSys.warning("Error decoding log elements from journal: %s" %
 				repr(logelements))
-			logline =  cls._joinStrAndBytes(logelements)
+			logline = cls._joinStrAndBytes(logelements)
 
 		date = logentry.get('_SOURCE_REALTIME_TIMESTAMP',
 				logentry.get('__REALTIME_TIMESTAMP'))
 		logSys.debug("Read systemd journal entry: %r" %
 			"".join([date.isoformat(), logline]))
 		return (('', date.isoformat(), logline),
-			time.mktime(date.timetuple()) + date.microsecond/1.0E6)
+			time.mktime(date.timetuple()) + date.microsecond / 1.0E6)
 
 	##
 	# Main loop.
@@ -257,7 +257,7 @@ class FilterSystemd(JournalFilter): # pragma: systemd no cover
 					self.__modified = False
 			self.__journal.wait(self.sleeptime)
 		logSys.debug((self.jail is not None and self.jail.name
-                      or "jailless") +" filter terminated")
+                      or "jailless") + " filter terminated")
 		return True
 
 	def status(self, flavor="basic"):

--- a/fail2ban/server/jail.py
+++ b/fail2ban/server/jail.py
@@ -65,7 +65,7 @@ class Jail:
 	#      list had .index until 2.6
 	_BACKENDS = ['pyinotify', 'gamin', 'polling', 'systemd']
 
-	def __init__(self, name, backend = "auto", db=None):
+	def __init__(self, name, backend="auto", db=None):
 		self.__db = db
 		# 26 based on iptable chain name limit of 30 less len('f2b-')
 		if len(name) >= 26:

--- a/fail2ban/server/jailthread.py
+++ b/fail2ban/server/jailthread.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -50,8 +50,8 @@ except ImportError:
 
 
 class Server:
-	
-	def __init__(self, daemon = False):
+
+	def __init__(self, daemon=False):
 		self.__loggingLock = Lock()
 		self.__lock = RLock()
 		self.__jails = Jails()
@@ -63,7 +63,7 @@ class Server:
 		self.__logTarget = None
 		self.__syslogSocket = None
 		self.__autoSyslogSocketPaths = {
-			'Darwin':  '/var/run/syslog',
+			'Darwin': '/var/run/syslog',
 			'FreeBSD': '/var/run/log',
 			'Linux': '/dev/log',
 		}
@@ -75,19 +75,19 @@ class Server:
 	def __sigTERMhandler(self, signum, frame):
 		logSys.debug("Caught signal %d. Exiting" % signum)
 		self.quit()
-	
+
 	def __sigUSR1handler(self, signum, fname):
 		logSys.debug("Caught signal %d. Flushing logs" % signum)
 		self.flushLogs()
 
-	def start(self, sock, pidfile, force = False):
+	def start(self, sock, pidfile, force=False):
 		logSys.info("Starting Fail2ban v" + version.version)
-		
+
 		# Install signal handlers
 		signal.signal(signal.SIGTERM, self.__sigTERMhandler)
 		signal.signal(signal.SIGINT, self.__sigTERMhandler)
 		signal.signal(signal.SIGUSR1, self.__sigUSR1handler)
-		
+
 		# Ensure unhandled exceptions are logged
 		sys.excepthook = excepthook
 
@@ -101,7 +101,7 @@ class Server:
 			else:
 				logSys.error("Could not create daemon")
 				raise ServerInitializationError("Could not create daemon")
-		
+
 		# Creates a PID file.
 		try:
 			logSys.debug("Creating PID file %s" % pidfile)
@@ -110,7 +110,7 @@ class Server:
 			pidFile.close()
 		except IOError, e:
 			logSys.error("Unable to create PID file: %s" % e)
-		
+
 		# Start the communication
 		logSys.debug("Starting communication")
 		try:
@@ -124,7 +124,7 @@ class Server:
 		except OSError, e:
 			logSys.error("Unable to remove PID file: %s" % e)
 		logSys.info("Exiting Fail2ban")
-	
+
 	def quit(self):
 		# Stop communication first because if jail's unban action
 		# tries to communicate via fail2ban-client we get a lockup
@@ -148,7 +148,7 @@ class Server:
 		self.__jails.add(name, backend, self.__db)
 		if self.__db is not None:
 			self.__db.addJail(self.__jails[name])
-		
+
 	def delJail(self, name):
 		if self.__db is not None:
 			self.__db.delJail(self.__jails[name])
@@ -161,7 +161,7 @@ class Server:
 				self.__jails[name].start()
 		finally:
 			self.__lock.release()
-	
+
 	def stopJail(self, name):
 		logSys.debug("Stopping jail %s" % name)
 		try:
@@ -171,7 +171,7 @@ class Server:
 				self.delJail(name)
 		finally:
 			self.__lock.release()
-	
+
 	def stopAllJail(self):
 		logSys.info("Stopping all jails")
 		try:
@@ -187,27 +187,27 @@ class Server:
 
 	def getIdleJail(self, name):
 		return self.__jails[name].idle
-	
+
 	# Filter
 	def addIgnoreIP(self, name, ip):
 		self.__jails[name].filter.addIgnoreIP(ip)
-	
+
 	def delIgnoreIP(self, name, ip):
 		self.__jails[name].filter.delIgnoreIP(ip)
-	
+
 	def getIgnoreIP(self, name):
 		return self.__jails[name].filter.getIgnoreIP()
-	
+
 	def addLogPath(self, name, fileName, tail=False):
 		filter_ = self.__jails[name].filter
 		if isinstance(filter_, FileFilter):
 			filter_.addLogPath(fileName, tail)
-	
+
 	def delLogPath(self, name, fileName):
 		filter_ = self.__jails[name].filter
 		if isinstance(filter_, FileFilter):
 			filter_.delLogPath(fileName)
-	
+
 	def getLogPath(self, name):
 		filter_ = self.__jails[name].filter
 		if isinstance(filter_, FileFilter):
@@ -216,17 +216,17 @@ class Server:
 		else: # pragma: systemd no cover
 			logSys.info("Jail %s is not a FileFilter instance" % name)
 			return []
-	
+
 	def addJournalMatch(self, name, match): # pragma: systemd no cover
 		filter_ = self.__jails[name].filter
 		if isinstance(filter_, JournalFilter):
 			filter_.addJournalMatch(match)
-	
+
 	def delJournalMatch(self, name, match): # pragma: systemd no cover
 		filter_ = self.__jails[name].filter
 		if isinstance(filter_, JournalFilter):
 			filter_.delJournalMatch(match)
-	
+
 	def getJournalMatch(self, name): # pragma: systemd no cover
 		filter_ = self.__jails[name].filter
 		if isinstance(filter_, JournalFilter):
@@ -234,20 +234,20 @@ class Server:
 		else:
 			logSys.info("Jail %s is not a JournalFilter instance" % name)
 			return []
-	
+
 	def setLogEncoding(self, name, encoding):
 		filter_ = self.__jails[name].filter
 		if isinstance(filter_, FileFilter):
 			filter_.setLogEncoding(encoding)
-	
+
 	def getLogEncoding(self, name):
 		filter_ = self.__jails[name].filter
 		if isinstance(filter_, FileFilter):
 			return filter_.getLogEncoding()
-	
+
 	def setFindTime(self, name, value):
 		self.__jails[name].filter.setFindTime(value)
-	
+
 	def getFindTime(self, name):
 		return self.__jails[name].filter.getFindTime()
 
@@ -265,65 +265,65 @@ class Server:
 
 	def addFailRegex(self, name, value):
 		self.__jails[name].filter.addFailRegex(value)
-	
+
 	def delFailRegex(self, name, index):
 		self.__jails[name].filter.delFailRegex(index)
-	
+
 	def getFailRegex(self, name):
 		return self.__jails[name].filter.getFailRegex()
-	
+
 	def addIgnoreRegex(self, name, value):
 		self.__jails[name].filter.addIgnoreRegex(value)
-	
+
 	def delIgnoreRegex(self, name, index):
 		self.__jails[name].filter.delIgnoreRegex(index)
-	
+
 	def getIgnoreRegex(self, name):
 		return self.__jails[name].filter.getIgnoreRegex()
-	
+
 	def setUseDns(self, name, value):
 		self.__jails[name].filter.setUseDns(value)
-	
+
 	def getUseDns(self, name):
 		return self.__jails[name].filter.getUseDns()
-	
+
 	def setMaxRetry(self, name, value):
 		self.__jails[name].filter.setMaxRetry(value)
-	
+
 	def getMaxRetry(self, name):
 		return self.__jails[name].filter.getMaxRetry()
-	
+
 	def setMaxLines(self, name, value):
 		self.__jails[name].filter.setMaxLines(value)
-	
+
 	def getMaxLines(self, name):
 		return self.__jails[name].filter.getMaxLines()
-	
+
 	# Action
 	def addAction(self, name, value, *args):
 		self.__jails[name].actions.add(value, *args)
-	
+
 	def getActions(self, name):
 		return self.__jails[name].actions
-	
+
 	def delAction(self, name, value):
 		del self.__jails[name].actions[value]
-	
+
 	def getAction(self, name, value):
 		return self.__jails[name].actions[value]
-	
+
 	def setBanTime(self, name, value):
 		self.__jails[name].actions.setBanTime(value)
-	
+
 	def setBanIP(self, name, value):
 		return self.__jails[name].filter.addBannedIP(value)
-		
+
 	def setUnbanIP(self, name, value):
 		self.__jails[name].actions.removeBannedIP(value)
-		
+
 	def getBanTime(self, name):
 		return self.__jails[name].actions.getBanTime()
-	
+
 	# Status
 	def status(self):
 		try:
@@ -336,12 +336,12 @@ class Server:
 			return ret
 		finally:
 			self.__lock.release()
-	
+
 	def statusJail(self, name, flavor="basic"):
 		return self.__jails[name].status(flavor=flavor)
 
 	# Logging
-	
+
 	##
 	# Set the logging level.
 	#
@@ -352,7 +352,7 @@ class Server:
 	# INFO
 	# DEBUG
 	# @param value the level
-	
+
 	def setLogLevel(self, value):
 		try:
 			self.__loggingLock.acquire()
@@ -364,13 +364,13 @@ class Server:
 			self.__logLevel = value.upper()
 		finally:
 			self.__loggingLock.release()
-	
+
 	##
 	# Get the logging level.
 	#
 	# @see setLogLevel
 	# @return the log level
-	
+
 	def getLogLevel(self):
 		try:
 			self.__loggingLock.acquire()
@@ -383,7 +383,7 @@ class Server:
 	#
 	# target can be a file, SYSLOG, STDOUT or STDERR.
 	# @param target the logging target
-	
+
 	def setLogTarget(self, target):
 		try:
 			self.__loggingLock.acquire()
@@ -435,14 +435,14 @@ class Server:
 					# Is known to be thrown after logging was shutdown once
 					# with older Pythons -- seems to be safe to ignore there
 					# At least it was still failing on 2.6.2-0ubuntu1 (jaunty)
-					if (2,6,3) <= sys.version_info < (3,) or \
-							(3,2) <= sys.version_info:
+					if (2, 6, 3) <= sys.version_info < (3,) or \
+							(3, 2) <= sys.version_info:
 						raise
 			# tell the handler to use this format
 			hdlr.setFormatter(formatter)
 			logger.addHandler(hdlr)
 			# Does not display this message at startup.
-			if not self.__logTarget is None:
+			if self.__logTarget is not None:
 				logSys.info(
 					"Changed logging target to %s for Fail2ban v%s"
 					% ((target
@@ -496,7 +496,7 @@ class Server:
 				handler.flush()
 				logSys.info("flush performed on %s" % self.__logTarget)
 			return "flushed"
-			
+
 	def setDatabase(self, filename):
 		# if not changed - nothing to do
 		if self.__db and self.__db.filename == filename:
@@ -516,17 +516,17 @@ class Server:
 				logSys.error(
 					"Unable to import fail2ban database module as sqlite "
 					"is not available.")
-	
+
 	def getDatabase(self):
 		return self.__db
 
 	def __createDaemon(self): # pragma: no cover
 		""" Detach a process from the controlling terminal and run it in the
 			background as a daemon.
-		
+
 			http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/278731
 		"""
-	
+
 		# When the first child terminates, all processes in the second child
 		# are sent a SIGHUP, so it's ignored.
 
@@ -534,7 +534,7 @@ class Server:
 		# child process, and this makes sure that it is effect even if the parent
 		# terminates quickly.
 		signal.signal(signal.SIGHUP, signal.SIG_IGN)
-		
+
 		try:
 			# Fork a child process so the parent can exit.  This will return control
 			# to the command line or shell.  This is required so that the new process
@@ -544,10 +544,10 @@ class Server:
 			# PGID.
 			pid = os.fork()
 		except OSError, e:
-			return((e.errno, e.strerror))	 # ERROR (return a tuple)
-		
+			return e.errno, e.strerror  # ERROR (return a tuple)
+
 		if pid == 0:	   # The first child.
-	
+
 			# Next we call os.setsid() to become the session leader of this new
 			# session.  The process also becomes the process group leader of the
 			# new process group.  Since a controlling terminal is associated with a
@@ -556,7 +556,7 @@ class Server:
 			# fail, since we're guaranteed that the child is not a process group
 			# leader.
 			os.setsid()
-		
+
 			try:
 				# Fork a second child to prevent zombies.  Since the first child is
 				# a session leader without a controlling terminal, it's possible for
@@ -565,9 +565,9 @@ class Server:
 				# preventing the daemon from ever acquiring a controlling terminal.
 				pid = os.fork()		# Fork a second child.
 			except OSError, e:
-				return((e.errno, e.strerror))  # ERROR (return a tuple)
-		
-			if (pid == 0):	  # The second child.
+				return e.errno, e.strerror  # ERROR (return a tuple)
+
+			if pid == 0:	  # The second child.
 				# Ensure that the daemon doesn't keep any directory in use.  Failure
 				# to do this could make a filesystem unmountable.
 				os.chdir("/")
@@ -575,7 +575,7 @@ class Server:
 				os._exit(0)	  # Exit parent (the first child) of the second child.
 		else:
 			os._exit(0)		 # Exit parent of the first child.
-		
+
 		# Close all open files.  Try the system configuration variable, SC_OPEN_MAX,
 		# for the maximum number of open files to close.  If it doesn't exist, use
 		# the default value (configurable).
@@ -583,7 +583,7 @@ class Server:
 			maxfd = os.sysconf("SC_OPEN_MAX")
 		except (AttributeError, ValueError):
 			maxfd = 256	   # default maximum
-	
+
 		# urandom should not be closed in Python 3.4.0. Fixed in 3.4.1
 		# http://bugs.python.org/issue21207
 		if sys.version_info[0:3] == (3, 4, 0): # pragma: no cover
@@ -597,7 +597,7 @@ class Server:
 			os.close(urandom_fd)
 		else:
 			os.closerange(0, maxfd)
-	
+
 		# Redirect the standard file descriptors to /dev/null.
 		os.open("/dev/null", os.O_RDONLY)	# standard input (0)
 		os.open("/dev/null", os.O_RDWR)		# standard output (1)

--- a/fail2ban/server/strptime.py
+++ b/fail2ban/server/strptime.py
@@ -136,7 +136,7 @@ def reGroupDictStrptime(found_dict):
 				tzoffset = 0
 			else:
 				tzoffset = int(z[1:3]) * 60 # Hours...
-				if len(z)>3:
+				if len(z) > 3:
 					tzoffset += int(z[-2:]) # ...and minutes
 				if z.startswith("-"):
 					tzoffset = -tzoffset
@@ -174,7 +174,7 @@ def reGroupDictStrptime(found_dict):
 		assume_today = True
 
 	# Actully create date
-	date_result =  datetime.datetime(
+	date_result = datetime.datetime(
 		year, month, day, hour, minute, second, fraction)
 	if gmtoff:
 		date_result = date_result - datetime.timedelta(seconds=gmtoff)
@@ -186,10 +186,9 @@ def reGroupDictStrptime(found_dict):
 		# Could be last year?
 		# also reset month and day as it's not yesterday...
 		date_result = date_result.replace(
-			year=year-1, month=month, day=day)
+			year=year - 1, month=month, day=day)
 
 	if gmtoff is not None:
 		return calendar.timegm(date_result.utctimetuple())
 	else:
 		return time.mktime(date_result.timetuple())
-

--- a/fail2ban/server/ticket.py
+++ b/fail2ban/server/ticket.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -31,7 +31,7 @@ logSys = getLogger(__name__)
 
 
 class Ticket:
-	
+
 	def __init__(self, ip, time, matches=None):
 		"""Ticket constructor
 
@@ -67,19 +67,19 @@ class Ticket:
 			# guarantee using regular str instead of unicode for the IP
 			value = str(value)
 		self.__ip = value
-	
+
 	def getIP(self):
 		return self.__ip
-	
+
 	def setTime(self, value):
 		self.__time = value
-	
+
 	def getTime(self):
 		return self.__time
-	
+
 	def setAttempt(self, value):
 		self.__attempt = value
-	
+
 	def getAttempt(self):
 		return self.__attempt
 

--- a/fail2ban/server/transmitter.py
+++ b/fail2ban/server/transmitter.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -35,21 +35,21 @@ logSys = getLogger(__name__)
 
 
 class Transmitter:
-	
+
 	##
 	# Constructor.
 	#
 	# @param The server reference
-	
+
 	def __init__(self, server):
 		self.__server = server
-		
+
 	##
 	# Proceeds a command.
 	#
 	# Proceeds an incoming command.
 	# @param command The incoming command
-	
+
 	def proceed(self, command):
 		# Deserialize object
 		logSys.debug("Command: " + repr(command))
@@ -61,12 +61,12 @@ class Transmitter:
 						% (command, e))
 			ack = 1, e
 		return ack
-	
+
 	##
 	# Handle an command.
 	#
-	# 
-	
+	#
+
 	def __commandHandler(self, command):
 		if command[0] == "ping":
 			return "pong"
@@ -108,7 +108,7 @@ class Transmitter:
 		elif command[0] == "version":
 			return version.version
 		raise Exception("Invalid command")
-	
+
 	def __commandSet(self, command):
 		name = command[0]
 		# Logging
@@ -170,7 +170,7 @@ class Transmitter:
 			value = command[2]
 			tail = False
 			if len(command) == 4:
-				if command[3].lower()  == "tail":
+				if command[3].lower() == "tail":
 					tail = True
 				elif command[3].lower() != "head":
 					raise ValueError("File option must be 'head' or 'tail'")
@@ -237,7 +237,7 @@ class Transmitter:
 			return self.__server.getBanTime(name)
 		elif command[1] == "banip":
 			value = command[2]
-			return self.__server.setBanIP(name,value)
+			return self.__server.setBanIP(name, value)
 		elif command[1] == "unbanip":
 			value = command[2]
 			self.__server.setUnbanIP(name, value)
@@ -257,14 +257,14 @@ class Transmitter:
 			actionkey = command[3]
 			action = self.__server.getAction(name, actionname)
 			if callable(getattr(action, actionkey, None)):
-				actionvalue = json.loads(command[4]) if len(command)>4 else {}
+				actionvalue = json.loads(command[4]) if len(command) > 4 else {}
 				return getattr(action, actionkey)(**actionvalue)
 			else:
 				actionvalue = command[4]
 				setattr(action, actionkey, actionvalue)
 				return getattr(action, actionkey)
 		raise Exception("Invalid command (no set action or not yet implemented)")
-	
+
 	def __commandGet(self, command):
 		name = command[0]
 		# Logging
@@ -336,7 +336,7 @@ class Transmitter:
 				key for key in dir(action)
 				if not key.startswith("_") and callable(getattr(action, key))]
 		raise Exception("Invalid command (no get action or not yet implemented)")
-	
+
 	def status(self, command):
 		if len(command) == 0:
 			return self.__server.status()

--- a/fail2ban/tests/__init__.py
+++ b/fail2ban/tests/__init__.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"

--- a/fail2ban/tests/action_d/test_badips.py
+++ b/fail2ban/tests/action_d/test_badips.py
@@ -24,7 +24,7 @@ import sys
 from ..dummyjail import DummyJail
 from ..utils import CONFIG_DIR
 
-if sys.version_info >= (2,7):
+if sys.version_info >= (2, 7):
 	class BadIPsActionTest(unittest.TestCase):
 
 		def setUp(self):

--- a/fail2ban/tests/actionstestcase.py
+++ b/fail2ban/tests/actionstestcase.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Daniel Black
-# 
+#
 
 __author__ = "Daniel Black"
 __copyright__ = "Copyright (c) 2013 Daniel Black"
@@ -43,7 +43,7 @@ class ExecuteActions(LogCaptureTestCase):
 		super(ExecuteActions, self).setUp()
 		self.__jail = DummyJail()
 		self.__actions = Actions(self.__jail)
-		self.__tmpfile, self.__tmpfilename  = tempfile.mkstemp()
+		self.__tmpfile, self.__tmpfilename = tempfile.mkstemp()
 
 	def tearDown(self):
 		super(ExecuteActions, self).tearDown()
@@ -74,7 +74,7 @@ class ExecuteActions(LogCaptureTestCase):
 		self.assertEqual(len(self.__actions), 0)
 
 		self.__actions.setBanTime(127)
-		self.assertEqual(self.__actions.getBanTime(),127)
+		self.assertEqual(self.__actions.getBanTime(), 127)
 		self.assertRaises(ValueError, self.__actions.removeBannedIP, '127.0.0.1')
 
 	def testActionsOutput(self):
@@ -82,12 +82,12 @@ class ExecuteActions(LogCaptureTestCase):
 		self.__actions.start()
 		with open(self.__tmpfilename) as f:
 			time.sleep(3)
-			self.assertEqual(f.read(),"ip start 64\n")
+			self.assertEqual(f.read(), "ip start 64\n")
 
 		self.__actions.stop()
 		self.__actions.join()
-		self.assertEqual(self.__actions.status(),[("Currently banned", 0 ),
-               ("Total banned", 0 ), ("Banned IP list", [] )])
+		self.assertEqual(self.__actions.status(), [("Currently banned", 0),
+               ("Total banned", 0), ("Banned IP list", [])])
 
 	def testAddActionPython(self):
 		self.__actions.add(

--- a/fail2ban/tests/actiontestcase.py
+++ b/fail2ban/tests/actiontestcase.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -32,6 +32,7 @@ from ..server.action import CommandAction, CallingMap
 
 from .utils import LogCaptureTestCase
 from .utils import pid_exists
+
 
 class CommandActionTest(LogCaptureTestCase):
 
@@ -60,19 +61,19 @@ class CommandActionTest(LogCaptureTestCase):
 		self.assertFalse(CommandAction.substituteRecursiveTags({'failregex': 'to=<honeypot> fromip=<IP>', 'sweet': '<honeypot>', 'honeypot': '<sweet>', 'ignoreregex': ''}))
 		# missing tags are ok
 		self.assertEqual(CommandAction.substituteRecursiveTags({'A': '<C>'}), {'A': '<C>'})
-		self.assertEqual(CommandAction.substituteRecursiveTags({'A': '<C> <D> <X>','X':'fun'}), {'A': '<C> <D> fun', 'X':'fun'})
+		self.assertEqual(CommandAction.substituteRecursiveTags({'A': '<C> <D> <X>', 'X': 'fun'}), {'A': '<C> <D> fun', 'X': 'fun'})
 		self.assertEqual(CommandAction.substituteRecursiveTags({'A': '<C> <B>', 'B': 'cool'}), {'A': '<C> cool', 'B': 'cool'})
 		# Escaped tags should be ignored
 		self.assertEqual(CommandAction.substituteRecursiveTags({'A': '<matches> <B>', 'B': 'cool'}), {'A': '<matches> cool', 'B': 'cool'})
 		# Multiple stuff on same line is ok
 		self.assertEqual(CommandAction.substituteRecursiveTags({'failregex': 'to=<honeypot> fromip=<IP> evilperson=<honeypot>', 'honeypot': 'pokie', 'ignoreregex': ''}),
-								{ 'failregex': "to=pokie fromip=<IP> evilperson=pokie",
+								{'failregex': "to=pokie fromip=<IP> evilperson=pokie",
 									'honeypot': 'pokie',
 									'ignoreregex': '',
 								})
 		# rest is just cool
 		self.assertEqual(CommandAction.substituteRecursiveTags(aInfo),
-								{ 'HOST': "192.0.2.0",
+								{'HOST': "192.0.2.0",
 									'ABC': '123 192.0.2.0',
 									'xyz': '890 123 192.0.2.0',
 								})
@@ -173,7 +174,7 @@ class CommandActionTest(LogCaptureTestCase):
 	def testExecuteActionChangeCtags(self):
 		self.assertRaises(AttributeError, getattr, self.__action, "ROST")
 		self.__action.ROST = "192.0.2.0"
-		self.assertEqual(self.__action.ROST,"192.0.2.0")
+		self.assertEqual(self.__action.ROST, "192.0.2.0")
 
 	def testExecuteActionUnbanAinfo(self):
 		aInfo = {
@@ -199,8 +200,8 @@ class CommandActionTest(LogCaptureTestCase):
 		self.assertRaises(
 			RuntimeError, CommandAction.executeCmd, 'sleep 60', timeout=2)
 		# give a test still 1 second, because system could be too busy
-		self.assertTrue(time.time() >= stime + 2 and time.time() <= stime + 3)
-		self.assertTrue(self._is_logged('sleep 60 -- timed out after 2 seconds') 
+		self.assertTrue(stime + 2 <= time.time() <= stime + 3)
+		self.assertTrue(self._is_logged('sleep 60 -- timed out after 2 seconds')
 			or self._is_logged('sleep 60 -- timed out after 3 seconds'))
 		self.assertTrue(self._is_logged('sleep 60 -- killed with SIGTERM'))
 
@@ -241,7 +242,6 @@ class CommandActionTest(LogCaptureTestCase):
 		os.unlink(tmpFilename)
 		os.unlink(tmpFilename + '.pid')
 
-
 	def testCaptureStdOutErr(self):
 		CommandAction.executeCmd('echo "How now brown cow"')
 		self.assertTrue(self._is_logged("'How now brown cow\\n'"))
@@ -252,7 +252,7 @@ class CommandActionTest(LogCaptureTestCase):
 
 	def testCallingMap(self):
 		mymap = CallingMap(callme=lambda: str(10), error=lambda: int('a'),
-			dontcallme= "string", number=17)
+			dontcallme="string", number=17)
 
 		# Should work fine
 		self.assertEqual(

--- a/fail2ban/tests/banmanagertestcase.py
+++ b/fail2ban/tests/banmanagertestcase.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -41,7 +41,7 @@ TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "files")
 
 from .utils import CONFIG_DIR
 
-STOCK = os.path.exists(os.path.join('config','fail2ban.conf'))
+STOCK = os.path.exists(os.path.join('config', 'fail2ban.conf'))
 
 IMPERFECT_CONFIG = os.path.join(os.path.dirname(__file__), 'config')
 
@@ -165,11 +165,11 @@ class JailReaderTest(LogCaptureTestCase):
 		self.__share_cfg = {}
 
 	def testIncorrectJail(self):
-		jail = JailReader('XXXABSENTXXX', basedir=CONFIG_DIR, share_config = self.__share_cfg)
+		jail = JailReader('XXXABSENTXXX', basedir=CONFIG_DIR, share_config=self.__share_cfg)
 		self.assertRaises(ValueError, jail.read)
-		
+
 	def testJailActionEmpty(self):
-		jail = JailReader('emptyaction', basedir=IMPERFECT_CONFIG, share_config = self.__share_cfg)
+		jail = JailReader('emptyaction', basedir=IMPERFECT_CONFIG, share_config=self.__share_cfg)
 		self.assertTrue(jail.read())
 		self.assertTrue(jail.getOptions())
 		self.assertTrue(jail.isEnabled())
@@ -177,7 +177,7 @@ class JailReaderTest(LogCaptureTestCase):
 		self.assertTrue(self._is_logged('No actions were defined for emptyaction'))
 
 	def testJailActionFilterMissing(self):
-		jail = JailReader('missingbitsjail', basedir=IMPERFECT_CONFIG, share_config = self.__share_cfg)
+		jail = JailReader('missingbitsjail', basedir=IMPERFECT_CONFIG, share_config=self.__share_cfg)
 		self.assertTrue(jail.read())
 		self.assertFalse(jail.getOptions())
 		self.assertTrue(jail.isEnabled())
@@ -200,14 +200,14 @@ class JailReaderTest(LogCaptureTestCase):
 
 	if STOCK:
 		def testStockSSHJail(self):
-			jail = JailReader('sshd', basedir=CONFIG_DIR, share_config = self.__share_cfg) # we are running tests from root project dir atm
+			jail = JailReader('sshd', basedir=CONFIG_DIR, share_config=self.__share_cfg) # we are running tests from root project dir atm
 			self.assertTrue(jail.read())
 			self.assertTrue(jail.getOptions())
 			self.assertFalse(jail.isEnabled())
 			self.assertEqual(jail.getName(), 'sshd')
 			jail.setName('ssh-funky-blocker')
 			self.assertEqual(jail.getName(), 'ssh-funky-blocker')
-		
+
 	def testSplitOption(self):
 		# Simple example
 		option = "mail-whois[name=SSH]"
@@ -216,7 +216,7 @@ class JailReaderTest(LogCaptureTestCase):
 		self.assertEqual(expected, result)
 
 		self.assertEqual(('mail.who_is', {}), JailReader.extractOptions("mail.who_is"))
-		self.assertEqual(('mail.who_is', {'a':'cat', 'b':'dog'}), JailReader.extractOptions("mail.who_is[a=cat,b=dog]"))
+		self.assertEqual(('mail.who_is', {'a': 'cat', 'b': 'dog'}), JailReader.extractOptions("mail.who_is[a=cat,b=dog]"))
 		self.assertEqual(('mail--ho_is', {}), JailReader.extractOptions("mail--ho_is"))
 
 		self.assertEqual(('mail--ho_is', {}), JailReader.extractOptions("mail--ho_is['s']"))
@@ -259,7 +259,7 @@ class JailReaderTest(LogCaptureTestCase):
 		open(f1, 'w').close()
 		# dangling link
 		f2 = os.path.join(d, 'f2')
-		os.symlink('nonexisting',f2)
+		os.symlink('nonexisting', f2)
 
 		# must be only f1
 		self.assertEqual(JailReader._glob(os.path.join(d, '*')), [f1])
@@ -271,7 +271,7 @@ class JailReaderTest(LogCaptureTestCase):
 		os.remove(f2)
 		os.rmdir(d)
 
-		
+
 class FilterReaderTest(unittest.TestCase):
 
 	def testConvert(self):
@@ -292,7 +292,7 @@ class FilterReaderTest(unittest.TestCase):
 			"[\\[\\(]?sshd(?:\\(\\S+\\))?[\\]\\)]?:?(?:\\[\\d+\\])?:)?\\s*(?:"
 			"error: PAM: )?User not known to the\\nunderlying authentication."
 			"+$<SKIPLINES>^.+ module for .* from <HOST>\\s*$"],
-			['set', 'testcase01', 'addignoreregex', 
+			['set', 'testcase01', 'addignoreregex',
 			"^.+ john from host 192.168.1.1\\s*$"],
 			['set', 'testcase01', 'addjournalmatch',
 				"_COMM=sshd", "+", "_SYSTEMD_UNIT=sshd.service", "_UID=0"],
@@ -349,7 +349,7 @@ class FilterReaderTest(unittest.TestCase):
 		# read explicit uses absolute path:
 		path_ = os.path.abspath(os.path.join(TEST_FILES_DIR, "filter.d"))
 		filterReader = FilterReader(os.path.join(path_, "testcase01.conf"), "testcase01", {})
-		self.assertEqual(filterReader.readexplicit(), 
+		self.assertEqual(filterReader.readexplicit(),
 			[os.path.join(path_, "testcase-common.conf"), os.path.join(path_, "testcase01.conf")]
 		)
 		try:
@@ -360,7 +360,7 @@ class FilterReaderTest(unittest.TestCase):
 			filterReader.get('Definition', 'failregex')
 			filterReader.get('Definition', 'ignoreregex')
 		except Exception, e: # pragma: no cover - failed if reachable
-			self.fail('unexpected options after readexplicit: %s' % (e))
+			self.fail('unexpected options after readexplicit: %s' % e)
 
 
 class JailsReaderTestCache(LogCaptureTestCase):
@@ -378,7 +378,7 @@ class JailsReaderTestCache(LogCaptureTestCase):
 	def _getLoggedReadCount(self, filematch):
 		cnt = 0
 		for s in self.getLog().rsplit('\n'):
-			if re.match(r"^\s*Reading files?: .*/"+filematch, s):
+			if re.match(r"^\s*Reading files?: .*/" + filematch, s):
 				cnt += 1
 		return cnt
 
@@ -462,7 +462,7 @@ class JailsReaderTest(LogCaptureTestCase):
 			 ['start', 'emptyaction'],
 			 ['start', 'missinglogfiles'],
 			 ['start', 'brokenaction'],
-			 ['start', 'parse_to_end_of_jail.conf'],]))
+			 ['start', 'parse_to_end_of_jail.conf'], ]))
 		self.assertTrue(self._is_logged("Errors in jail 'missingbitsjail'. Skipping..."))
 		self.assertTrue(self._is_logged("No file(s) found for glob /weapons/of/mass/destruction"))
 
@@ -514,7 +514,7 @@ class JailsReaderTest(LogCaptureTestCase):
 				# and it must be readable as a Filter
 				filterReader = FilterReader(filterName, jail, {})
 				filterReader.setBaseDir(CONFIG_DIR)
-				self.assertTrue(filterReader.read(),"Failed to read filter:" + filterName)		  # opens fine
+				self.assertTrue(filterReader.read(), "Failed to read filter:" + filterName)		  # opens fine
 				filterReader.getOptions({})	  # reads fine
 
 				#  test if filter has failregex set
@@ -580,7 +580,7 @@ class JailsReaderTest(LogCaptureTestCase):
 			# last commands should be the 'start' commands
 			self.assertEqual(comm_commands[-1][0], 'start')
 
-			for j in  jails._JailsReader__jails:
+			for j in jails._JailsReader__jails:
 				actions = j._JailReader__actions
 				jail_name = j.getName()
 				# make sure that all of the jails have actions assigned,
@@ -606,7 +606,7 @@ class JailsReaderTest(LogCaptureTestCase):
 						self.assertTrue(
 							blocktype_present,
 							msg="Found no %s command among %s"
-								% (target_command, str(commands)) )
+								% (target_command, str(commands)))
 
 		def testStockConfigurator(self):
 			configurator = Configurator()

--- a/fail2ban/tests/databasetestcase.py
+++ b/fail2ban/tests/databasetestcase.py
@@ -48,7 +48,7 @@ class DatabaseTest(LogCaptureTestCase):
 	def setUp(self):
 		"""Call before every test case."""
 		super(DatabaseTest, self).setUp()
-		if Fail2BanDb is None and sys.version_info >= (2,7): # pragma: no cover
+		if Fail2BanDb is None and sys.version_info >= (2, 7): # pragma: no cover
 			raise unittest.SkipTest(
 				"Unable to import fail2ban database module as sqlite is not "
 				"available.")
@@ -223,11 +223,11 @@ class DatabaseTest(LogCaptureTestCase):
 			self.jail, FailTicket("127.0.0.1", MyTime.time() - 60, ["abc\n"]))
 		self.db.addBan(
 			self.jail, FailTicket("127.0.0.1", MyTime.time() - 40, ["abc\n"]))
-		self.assertEqual(len(self.db.getBans(jail=self.jail,bantime=50)), 1)
-		self.assertEqual(len(self.db.getBans(jail=self.jail,bantime=20)), 0)
+		self.assertEqual(len(self.db.getBans(jail=self.jail, bantime=50)), 1)
+		self.assertEqual(len(self.db.getBans(jail=self.jail, bantime=20)), 0)
 		# Negative values are for persistent bans, and such all bans should
 		# be returned
-		self.assertEqual(len(self.db.getBans(jail=self.jail,bantime=-1)), 2)
+		self.assertEqual(len(self.db.getBans(jail=self.jail, bantime=-1)), 2)
 
 	def testGetBansMerged(self):
 		if Fail2BanDb is None: # pragma: no cover

--- a/fail2ban/tests/datedetectortestcase.py
+++ b/fail2ban/tests/datedetectortestcase.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -44,16 +44,16 @@ class DateDetectorTest(unittest.TestCase):
 	def tearDown(self):
 		"""Call after every test case."""
 		tearDownMyTime()
-	
+
 	def testGetEpochTime(self):
 		log = "1138049999 [sshd] error: PAM: Authentication failure"
 		#date = [2006, 1, 23, 21, 59, 59, 0, 23, 0]
 		dateUnix = 1138049999.0
 
-		( datelog, matchlog ) = self.__datedetector.getTime(log)
+		(datelog, matchlog) = self.__datedetector.getTime(log)
 		self.assertEqual(datelog, dateUnix)
 		self.assertEqual(matchlog.group(), '1138049999')
-	
+
 	def testGetTime(self):
 		log = "Jan 23 21:59:59 [sshd] error: PAM: Authentication failure"
 		dateUnix = 1106513999.0
@@ -61,7 +61,7 @@ class DateDetectorTest(unittest.TestCase):
 		#      is not correctly determined atm, since year is not present
 		#      in the log entry.  Since this doesn't effect the operation
 		#      of fail2ban -- we just ignore incorrect day of the week
-		( datelog, matchlog ) = self.__datedetector.getTime(log)
+		(datelog, matchlog) = self.__datedetector.getTime(log)
 		self.assertEqual(datelog, dateUnix)
 		self.assertEqual(matchlog.group(), 'Jan 23 21:59:59')
 
@@ -70,6 +70,7 @@ class DateDetectorTest(unittest.TestCase):
 		"""
 		dateUnix = 1106513999.0
 
+		# noinspection PyPep8
 		for anchored, sdate in (
 			(False, "Jan 23 21:59:59"),
 			(False, "Sun Jan 23 21:59:59 2005"),
@@ -93,22 +94,22 @@ class DateDetectorTest(unittest.TestCase):
 			(False, "2005-01-23T20:59:59.252Z"), #ISO 8601 (UTC)
 			(False, "2005-01-23T15:59:59-05:00"), #ISO 8601 with TZ
 			(False, "2005-01-23T21:59:59"), #ISO 8601 no TZ, assume local
-			(True,  "<01/23/05@21:59:59>"),
-			(True,  "050123 21:59:59"), # MySQL
-			(True,  "Jan-23-05 21:59:59"), # ASSP like
+			(True, "<01/23/05@21:59:59>"),
+			(True, "050123 21:59:59"), # MySQL
+			(True, "Jan-23-05 21:59:59"), # ASSP like
 			(False, "Jan 23, 2005 9:59:59 PM"), # Apache Tomcat
-			(True,  "1106513999"), # Regular epoch
-			(True,  "1106513999.000"), # Regular epoch with millisec
+			(True, "1106513999"), # Regular epoch
+			(True, "1106513999.000"), # Regular epoch with millisec
 			(False, "audit(1106513999.000:987)"), # SELinux
 			):
-			for should_match, prefix in ((True,     ""),
+			for should_match, prefix in ((True, ""),
 										 (not anchored, "bogus-prefix ")):
 				log = prefix + sdate + "[sshd] error: PAM: Authentication failure"
 
 				logtime = self.__datedetector.getTime(log)
 				if should_match:
-					self.assertNotEqual(logtime, None, "getTime retrieved nothing: failure for %s, anchored: %r, log: %s" % ( sdate, anchored, log))
-					( logUnix, logMatch ) = logtime
+					self.assertNotEqual(logtime, None, "getTime retrieved nothing: failure for %s, anchored: %r, log: %s" % (sdate, anchored, log))
+					(logUnix, logMatch) = logtime
 					self.assertEqual(logUnix, dateUnix, "getTime comparison failure for %s: \"%s\" is not \"%s\"" % (sdate, logUnix, dateUnix))
 					if sdate.startswith('audit('):
 						# yes, special case, the group only matches the number
@@ -136,18 +137,18 @@ class DateDetectorTest(unittest.TestCase):
 		mu = time.mktime(datetime.datetime(2012, 10, 11, 2, 37, 17).timetuple())
 		logdate = self.__datedetector.getTime('2012/10/11 02:37:17 [error] 18434#0')
 		self.assertNotEqual(logdate, None)
-		( logTime, logMatch ) = logdate
+		(logTime, logMatch) = logdate
 		self.assertEqual(logTime, mu)
 		self.assertEqual(logMatch.group(), '2012/10/11 02:37:17')
 		self.__datedetector.sortTemplate()
 		# confuse it with year being at the end
 		for i in xrange(10):
-			( logTime, logMatch ) =	self.__datedetector.getTime('11/10/2012 02:37:17 [error] 18434#0')
+			(logTime, logMatch) = self.__datedetector.getTime('11/10/2012 02:37:17 [error] 18434#0')
 			self.assertEqual(logTime, mu)
 			self.assertEqual(logMatch.group(), '11/10/2012 02:37:17')
 		self.__datedetector.sortTemplate()
 		# and now back to the original
-		( logTime, logMatch ) = self.__datedetector.getTime('2012/10/11 02:37:17 [error] 18434#0')
+		(logTime, logMatch) = self.__datedetector.getTime('2012/10/11 02:37:17 [error] 18434#0')
 		self.assertEqual(logTime, mu)
 		self.assertEqual(logMatch.group(), '2012/10/11 02:37:17')
 
@@ -162,11 +163,10 @@ class DateDetectorTest(unittest.TestCase):
 #	def testDefaultTempate(self):
 #		self.__datedetector.setDefaultRegex("^\S{3}\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2}")
 #		self.__datedetector.setDefaultPattern("%b %d %H:%M:%S")
-#		
+#
 #		log = "Jan 23 21:59:59 [sshd] error: PAM: Authentication failure"
 #		date = [2005, 1, 23, 21, 59, 59, 1, 23, -1]
 #		dateUnix = 1106513999.0
-#		
+#
 #		self.assertEqual(self.__datedetector.getTime(log), date)
 #		self.assertEqual(self.__datedetector.getUnixTime(log), dateUnix)
-	

--- a/fail2ban/tests/failmanagertestcase.py
+++ b/fail2ban/tests/failmanagertestcase.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -47,21 +47,21 @@ class AddFailure(unittest.TestCase):
 					    ['100.100.10.10', 1000001000.0],
 					    ['100.100.10.10', 1000001500.0],
 					    ['100.100.10.10', 1000002000.0]]
-		
+
 		self.__failManager = FailManager()
 		for i in self.__items:
 			self.__failManager.addFailure(FailTicket(i[0], i[1]))
 
 	def tearDown(self):
 		"""Call after every test case."""
-	
+
 	def testFailManagerAdd(self):
 		self.assertEqual(self.__failManager.size(), 3)
 		self.assertEqual(self.__failManager.getFailTotal(), 13)
 		self.__failManager.setFailTotal(0)
 		self.assertEqual(self.__failManager.getFailTotal(), 0)
 		self.__failManager.setFailTotal(13)
-	
+
 	def testFailManagerMaxTime(self):
 		self.assertEqual(self.__failManager.getMaxTime(), 600)
 		self.__failManager.setMaxTime(13)
@@ -71,19 +71,19 @@ class AddFailure(unittest.TestCase):
 	def _testDel(self):
 		self.__failManager.delFailure('193.168.0.128')
 		self.__failManager.delFailure('111.111.1.111')
-		
+
 		self.assertEqual(self.__failManager.size(), 1)
-		
+
 	def testCleanupOK(self):
 		timestamp = 1167606999.0
 		self.__failManager.cleanup(timestamp)
 		self.assertEqual(self.__failManager.size(), 0)
-		
+
 	def testCleanupNOK(self):
 		timestamp = 1167605990.0
 		self.__failManager.cleanup(timestamp)
 		self.assertEqual(self.__failManager.size(), 2)
-	
+
 	def testbanOK(self):
 		self.__failManager.setMaxRetry(5)
 		#ticket = FailTicket('193.168.0.128', None)
@@ -109,7 +109,7 @@ class AddFailure(unittest.TestCase):
 		self.assertEqual(
 			str(ticket),
 			'FailTicket: ip=193.168.0.128 time=1000002000.0 #attempts=5 matches=[]')
-	
+
 	def testbanNOK(self):
 		self.__failManager.setMaxRetry(10)
 		self.assertRaises(FailManagerEmpty, self.__failManager.toBan)

--- a/fail2ban/tests/files/action.d/action_nomethod.py
+++ b/fail2ban/tests/files/action.d/action_nomethod.py
@@ -1,5 +1,5 @@
 
-class TestAction():
+class TestAction:
 
     def __init__(self, jail, name):
         pass

--- a/fail2ban/tests/files/config/apache-auth/digest.py
+++ b/fail2ban/tests/files/config/apache-auth/digest.py
@@ -15,20 +15,20 @@ def auth(v):
 
     ha1 = md5sum(username + ':' + realm + ':' + password).hexdigest()
     ha2 = md5sum("GET:" + url).hexdigest()
-    
+
     #response = md5sum(ha1 + ':' + v['nonce'][1:-1] + ':' + v['nc'] + ':' + v['cnonce'][1:-1]
     #                  + ':' + v['qop'][1:-1] + ':' + ha2).hexdigest()
-    
+
     nonce = v['nonce'][1:-1]
-    nc=v.get('nc') or ''
+    nc = v.get('nc') or ''
     cnonce = v.get('cnonce') or ''
     #opaque = v.get('opaque') or ''
     qop = v['qop'][1:-1]
     algorithm = v['algorithm']
     response = md5sum(ha1 + ':' + nonce + ':' + nc + ':' + cnonce + ':' + qop + ':' + ha2).hexdigest()
-    
+
     p = requests.Request('GET', host + url).prepare()
-    #p.headers['Authentication-Info'] = response 
+    #p.headers['Authentication-Info'] = response
     p.headers['Authorization'] = """
         Digest username="%s",
         algorithm="%s",
@@ -39,10 +39,10 @@ def auth(v):
         nc="",
         qop=%s,
         response="%s"
-    """ % ( username, algorithm, realm, url, nonce, qop, response )
+    """ % (username, algorithm, realm, url, nonce, qop, response)
 #        opaque="%s",
     print(p.method, p.url, p.headers)
-    s =  requests.Session()
+    s = requests.Session()
     return s.send(p)
 
 
@@ -50,15 +50,15 @@ def preauth():
     r = requests.get(host + url)
     print(r)
     r.headers['www-authenticate'].split(', ')
-    return dict([ a.split('=',1) for a in r.headers['www-authenticate'].split(', ') ])
+    return dict([a.split('=', 1) for a in r.headers['www-authenticate'].split(', ')])
 
 
-url='/digest/'
+url = '/digest/'
 host = 'http://localhost:801'
 
 v = preauth()
 
-username="username"
+username = "username"
 password = "password"
 print(v)
 
@@ -76,38 +76,38 @@ r = auth(v)
 
 # [Sun Jul 28 21:41:20 2013] [error] [client 127.0.0.1] Digest: unknown algorithm `super funky chicken' received: /digest/
 
-print(r.status_code,r.headers, r.text)
+print(r.status_code, r.headers, r.text)
 v['algorithm'] = algorithm
 
 
 r = auth(v)
-print(r.status_code,r.headers, r.text)
+print(r.status_code, r.headers, r.text)
 
 nonce = v['nonce']
-v['nonce']=v['nonce'][5:-5]
+v['nonce'] = v['nonce'][5:-5]
 
 r = auth(v)
-print(r.status_code,r.headers, r.text)
+print(r.status_code, r.headers, r.text)
 
 # [Sun Jul 28 21:05:31.178340 2013] [auth_digest:error] [pid 24224:tid 139895539455744] [client 127.0.0.1:56906] AH01793: invalid qop `auth' received: /digest/qop_none/
 
 
-v['nonce']=nonce[0:11] + 'ZZZ' + nonce[14:]
+v['nonce'] = nonce[0:11] + 'ZZZ' + nonce[14:]
 
 r = auth(v)
-print(r.status_code,r.headers, r.text)
+print(r.status_code, r.headers, r.text)
 
 #[Sun Jul 28 21:18:11.769228 2013] [auth_digest:error] [pid 24752:tid 139895505884928] [client 127.0.0.1:56964] AH01776: invalid nonce b9YAiJDiBAZZZ1b1abe02d20063ea3b16b544ea1b0d981c1bafe received - hash is not d42d824dee7aaf50c3ba0a7c6290bd453e3dd35b
 
 
-url='/digest_time/'
-v=preauth()
+url = '/digest_time/'
+v = preauth()
 
 import time
 time.sleep(1)
 
 r = auth(v)
-print(r.status_code,r.headers, r.text)
+print(r.status_code, r.headers, r.text)
 
 # Obtained by putting the following code in modules/aaa/mod_auth_digest.c
 # in the function initialize_secret
@@ -135,34 +135,34 @@ import struct
 apachesecret = binascii.unhexlify('497d8894adafa5ec7c8c981ddf9c8457da7a90ac')
 s = sha.sha(apachesecret)
 
-v=preauth()
+v = preauth()
 
 print(v['nonce'])
 realm = v['Digest realm'][1:-1]
 
-(t,) = struct.unpack('l',base64.b64decode(v['nonce'][1:13]))
+(t,) = struct.unpack('l', base64.b64decode(v['nonce'][1:13]))
 
 # whee, time travel
-t = t + 5540
+t += 5540
 
-timepac = base64.b64encode(struct.pack('l',t))
+timepac = base64.b64encode(struct.pack('l', t))
 
 s.update(realm)
 s.update(timepac)
 
-v['nonce'] =  v['nonce'][0] + timepac + s.hexdigest() + v['nonce'][-1]
+v['nonce'] = v['nonce'][0] + timepac + s.hexdigest() + v['nonce'][-1]
 
 print(v)
 
 r = auth(v)
 #[Mon Jul 29 02:12:55.539813 2013] [auth_digest:error] [pid 9647:tid 139895522670336] [client 127.0.0.1:58474] AH01777: invalid nonce 59QJppTiBAA=b08983fd166ade9840407df1b0f75b9e6e07d88d received - user attempted time travel
-print(r.status_code,r.headers, r.text)
+print(r.status_code, r.headers, r.text)
 
-url='/digest_onetime/'
-v=preauth()
+url = '/digest_onetime/'
+v = preauth()
 
 # Need opaque header handling in auth
 r = auth(v)
-print(r.status_code,r.headers, r.text)
+print(r.status_code, r.headers, r.text)
 r = auth(v)
-print(r.status_code,r.headers, r.text)
+print(r.status_code, r.headers, r.text)

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -108,7 +108,7 @@ def _ticket_tuple(ticket):
 	date = ticket.getTime()
 	ip = ticket.getIP()
 	matches = ticket.getMatches()
-	return (ip, attempts, date, matches)
+	return ip, attempts, date, matches
 
 
 def _assert_correct_last_attempt(utest, filter_, output, count=None):
@@ -162,7 +162,7 @@ def _copy_lines_between_files(in_, fout, n=None, skip=0, mode='a', terminal_line
 	return fout
 
 
-def _copy_lines_to_journal(in_, fields={},n=None, skip=0, terminal_line=""): # pragma: systemd no cover
+def _copy_lines_to_journal(in_, fields={}, n=None, skip=0, terminal_line=""): # pragma: systemd no cover
 	"""Copy lines from one file to systemd journal
 
 	Returns None
@@ -592,7 +592,7 @@ def get_monitor_failures_testcase(Filter_):
 			self.file = _copy_lines_between_files(GetFailures.FILENAME_01, self.name,
 												  n=14, mode='w')
 			# Poll might need more time
-			self.assertTrue(self.isEmpty(4 + int(isinstance(self.filter, FilterPoll))*2),
+			self.assertTrue(self.isEmpty(4 + int(isinstance(self.filter, FilterPoll)) * 2),
 							"Queue must be empty but it is not: %s."
 							% (', '.join([str(x) for x in self.jail.queue])))
 			self.assertRaises(FailManagerEmpty, self.filter.failManager.toBan)
@@ -822,7 +822,7 @@ class GetFailures(unittest.TestCase):
 
 	# so that they could be reused by other tests
 	FAILURES_01 = ('193.168.0.128', 3, 1124013599.0,
-				  [u'Aug 14 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 193.168.0.128']*3)
+				  [u'Aug 14 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 193.168.0.128'] * 3)
 
 	def setUp(self):
 		"""Call before every test case."""
@@ -844,7 +844,7 @@ class GetFailures(unittest.TestCase):
 		self.filter.getLogPath()[-1].close()
 		self.assertEqual(self.filter.getLogPath()[-1].readline(), "")
 		self.filter.delLogPath(GetFailures.FILENAME_01)
-		self.assertEqual(self.filter.getLogPath(),[])
+		self.assertEqual(self.filter.getLogPath(), [])
 
 	def testGetFailures01(self, filename=None, failures=None):
 		filename = filename or GetFailures.FILENAME_01
@@ -853,7 +853,7 @@ class GetFailures(unittest.TestCase):
 		self.filter.addLogPath(filename)
 		self.filter.addFailRegex("(?:(?:Authentication failure|Failed [-/\w+]+) for(?: [iI](?:llegal|nvalid) user)?|[Ii](?:llegal|nvalid) user|ROOT LOGIN REFUSED) .*(?: from|FROM) <HOST>$")
 		self.filter.getFailures(filename)
-		_assert_correct_last_attempt(self, self.filter,  failures)
+		_assert_correct_last_attempt(self, self.filter, failures)
 
 	def testCRLFFailures01(self):
 		# We first adjust logfile/failures to end with CR+LF
@@ -914,8 +914,8 @@ class GetFailures(unittest.TestCase):
 		#self.assertRaises(ValueError,
 		#				  FileFilter, None, useDns='wrong_value_for_useDns')
 
-		for useDns, output in (('yes',  output_yes),
-							   ('no',   output_no),
+		for useDns, output in (('yes', output_yes),
+							   ('no', output_no),
 							   ('warn', output_yes)):
 			jail = DummyJail()
 			filter_ = FileFilter(jail, useDns=useDns)
@@ -1055,4 +1055,3 @@ class JailTests(unittest.TestCase):
 		# smoke test
 		# Must not fail to initiate
 		Jail('test', backend='polling')
-

--- a/fail2ban/tests/misctestcase.py
+++ b/fail2ban/tests/misctestcase.py
@@ -61,7 +61,7 @@ class SetupTest(unittest.TestCase):
 	def setUp(self):
 		setup = os.path.join(os.path.dirname(__file__), '..', '..', 'setup.py')
 		self.setup = os.path.exists(setup) and setup or None
-		if not self.setup and sys.version_info >= (2,7): # pragma: no cover - running not out of the source
+		if not self.setup and sys.version_info >= (2, 7): # pragma: no cover - running not out of the source
 			raise unittest.SkipTest(
 				"Seems to be running not out of source distribution"
 				" -- cannot locate setup.py")
@@ -75,7 +75,7 @@ class SetupTest(unittest.TestCase):
 					  % (sys.executable, self.setup, tmp))
 
 			def strippath(l):
-				return [x[len(tmp)+1:] for x in l]
+				return [x[len(tmp) + 1:] for x in l]
 
 			got = strippath(sorted(glob('%s/*' % tmp)))
 			need = ['etc', 'usr', 'var']
@@ -140,7 +140,7 @@ class TestsUtilsTest(unittest.TestCase):
 
 			def deep_function(i):
 				if i:
-					deep_function(i-1)
+					deep_function(i - 1)
 				else:
 					func_raise()
 
@@ -179,7 +179,7 @@ class TestsUtilsTest(unittest.TestCase):
 
 		# in this case compressed and not should be the same (?)
 		self.assertTrue(pindex > 10)	  # we should have some traceback
-		self.assertEqual(s[:pindex], s[pindex+1:pindex*2 + 1])
+		self.assertEqual(s[:pindex], s[pindex + 1:pindex * 2 + 1])
 
 iso8601 = DatePatternRegex("%Y-%m-%d[T ]%H:%M:%S(?:\.%f)?%z")
 

--- a/fail2ban/tests/samplestestcase.py
+++ b/fail2ban/tests/samplestestcase.py
@@ -28,7 +28,6 @@ import inspect
 import json
 import os
 import re
-import sys
 import time
 import unittest
 from ..server.filter import Filter
@@ -115,7 +114,7 @@ def testSampleRegexsFactory(name):
 					"Line matched when shouldn't have: %s:%i %r" %
 					(logFile.filename(), logFile.filelineno(), line))
 				self.assertEqual(len(ret), 1, "Multiple regexs matched %r - %s:%i" %
-								 (map(lambda x: x[0], ret),logFile.filename(), logFile.filelineno()))
+								 (map(lambda x: x[0], ret), logFile.filename(), logFile.filelineno()))
 
 				# Verify timestamp and host as expected
 				failregex, host, fail2banTime, lines = ret[0]
@@ -123,19 +122,19 @@ def testSampleRegexsFactory(name):
 
 				t = faildata.get("time", None)
 				try:
-					jsonTimeLocal =	datetime.datetime.strptime(t, "%Y-%m-%dT%H:%M:%S")
+					jsonTimeLocal = datetime.datetime.strptime(t, "%Y-%m-%dT%H:%M:%S")
 				except ValueError:
-					jsonTimeLocal =	datetime.datetime.strptime(t, "%Y-%m-%dT%H:%M:%S.%f")
+					jsonTimeLocal = datetime.datetime.strptime(t, "%Y-%m-%dT%H:%M:%S.%f")
 
 				jsonTime = time.mktime(jsonTimeLocal.timetuple())
-				
+
 				jsonTime += jsonTimeLocal.microsecond / 1000000
 
 				self.assertEqual(fail2banTime, jsonTime,
-					"UTC Time  mismatch fail2ban %s (%s) != failJson %s (%s)  (diff %.3f seconds) on: %s:%i %r:" % 
+					"UTC Time  mismatch fail2ban %s (%s) != failJson %s (%s)  (diff %.3f seconds) on: %s:%i %r:" %
 					(fail2banTime, time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(fail2banTime)),
 					jsonTime, time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(jsonTime)),
-					fail2banTime - jsonTime, logFile.filename(), logFile.filelineno(), line ) )
+					fail2banTime - jsonTime, logFile.filename(), logFile.filelineno(), line))
 
 				regexsUsed.add(failregex)
 

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Cyril Jaquier
-# 
+#
 
 __author__ = "Cyril Jaquier"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier"
@@ -57,7 +57,7 @@ class TestServer(Server):
 
 
 class TransmitterBase(unittest.TestCase):
-	
+
 	def setUp(self):
 		"""Call before every test case."""
 		self.transm = self.server._Server__transm
@@ -86,7 +86,7 @@ class TransmitterBase(unittest.TestCase):
 
 		def v(x):
 			"""Prepare value for comparison"""
-			return (repr(x) if repr_ else x)
+			return repr(x) if repr_ else x
 
 		self.assertEqual(v(self.transm.proceed(setCmd)), v((outCode, outValue)))
 		if not outCode:
@@ -115,17 +115,17 @@ class TransmitterBase(unittest.TestCase):
 		for n, value in enumerate(values):
 			self.assertEqual(
 				self.transm.proceed(["set", jail, cmdAdd, value]),
-				(0, values[:n+1]))
+				(0, values[:n + 1]))
 			self.assertEqual(
 				self.transm.proceed(["get", jail, cmd]),
-				(0, values[:n+1]))
+				(0, values[:n + 1]))
 		for n, value in enumerate(values):
 			self.assertEqual(
 				self.transm.proceed(["set", jail, cmdDel, value]),
-				(0, values[n+1:]))
+				(0, values[n + 1:]))
 			self.assertEqual(
 				self.transm.proceed(["get", jail, cmd]),
-				(0, values[n+1:]))
+				(0, values[n + 1:]))
 
 	def jailAddDelRegexTest(self, cmd, inValues, outValues, jail):
 		cmdAdd = "add" + cmd
@@ -136,17 +136,17 @@ class TransmitterBase(unittest.TestCase):
 		for n, value in enumerate(inValues):
 			self.assertEqual(
 				self.transm.proceed(["set", jail, cmdAdd, value]),
-				(0, outValues[:n+1]))
+				(0, outValues[:n + 1]))
 			self.assertEqual(
 				self.transm.proceed(["get", jail, cmd]),
-				(0, outValues[:n+1]))
+				(0, outValues[:n + 1]))
 		for n, value in enumerate(inValues):
 			self.assertEqual(
 				self.transm.proceed(["set", jail, cmdDel, 0]), # First item
-				(0, outValues[n+1:]))
+				(0, outValues[n + 1:]))
 			self.assertEqual(
 				self.transm.proceed(["get", jail, cmd]),
-				(0, outValues[n+1:]))
+				(0, outValues[n + 1:]))
 
 
 class Transmitter(TransmitterBase):
@@ -311,7 +311,7 @@ class Transmitter(TransmitterBase):
 		# Unban IP which isn't banned
 		self.assertEqual(
 			self.transm.proceed(
-				["set", self.jailName, "unbanip", "192.168.1.1"])[0],1)
+				["set", self.jailName, "unbanip", "192.168.1.1"])[0], 1)
 
 	def testJailMaxRetry(self):
 		self.setGetTest("maxretry", "5", 5, jail=self.jailName)
@@ -542,6 +542,7 @@ class Transmitter(TransmitterBase):
 		else:
 			value = []
 
+		# noinspection PyPep8
 		self.assertEqual(self.transm.proceed(["status", self.jailName, "cymru"]),
 			(0,
 				[
@@ -620,7 +621,7 @@ class Transmitter(TransmitterBase):
 			(0, None))
 		self.assertEqual(
 			self.transm.proceed(
-				["set", self.jailName, "delaction", "Doesn't exist"])[0],1)
+				["set", self.jailName, "delaction", "Doesn't exist"])[0], 1)
 
 	def testPythonActionMethodsAndProperties(self):
 		action = "TestCaseAction"
@@ -642,7 +643,7 @@ class Transmitter(TransmitterBase):
 					"issue forbidding correct operation of Fail2Ban: "
 					"http://bugs.python.org/issue2646  Upgrade your Python and "
 					"meanwhile other intestPythonActionMethodsAndProperties will "
-					"be skipped" % (sys.version))
+					"be skipped" % sys.version)
 				return
 			raise
 		self.assertEqual(
@@ -675,19 +676,19 @@ class Transmitter(TransmitterBase):
 			(0, 'Hello world! another value'))
 
 	def testNOK(self):
-		self.assertEqual(self.transm.proceed(["INVALID", "COMMAND"])[0],1)
+		self.assertEqual(self.transm.proceed(["INVALID", "COMMAND"])[0], 1)
 
 	def testSetNOK(self):
 		self.assertEqual(
-			self.transm.proceed(["set", "INVALID", "COMMAND"])[0],1)
+			self.transm.proceed(["set", "INVALID", "COMMAND"])[0], 1)
 
 	def testGetNOK(self):
 		self.assertEqual(
-			self.transm.proceed(["get", "INVALID", "COMMAND"])[0],1)
+			self.transm.proceed(["get", "INVALID", "COMMAND"])[0], 1)
 
 	def testStatusNOK(self):
 		self.assertEqual(
-			self.transm.proceed(["status", "INVALID", "COMMAND"])[0],1)
+			self.transm.proceed(["status", "INVALID", "COMMAND"])[0], 1)
 
 	def testJournalMatch(self):
 		if not filtersystemd: # pragma: no cover
@@ -706,12 +707,12 @@ class Transmitter(TransmitterBase):
 			self.assertEqual(
 				self.transm.proceed(
 					["set", jailName, "addjournalmatch", value]),
-				(0, [[val] for val in values[:n+1]]))
+				(0, [[val] for val in values[:n + 1]]))
 		for n, value in enumerate(values):
 			self.assertEqual(
 				self.transm.proceed(
 					["set", jailName, "deljournalmatch", value]),
-				(0, [[val] for val in values[n+1:]]))
+				(0, [[val] for val in values[n + 1:]]))
 
 		# Try duplicates
 		value = "_COMM=sshd"
@@ -847,7 +848,7 @@ class TransmitterLogging(TransmitterBase):
 				l.warning("After file moved")
 				self.assertEqual(self.transm.proceed(["flushlogs"]), (0, "rolled over"))
 				l.warning("After flushlogs")
-				with open(fn2,'r') as f:
+				with open(fn2, 'r') as f:
 					line1 = f.next()
 					if line1.find('Changed logging target to') >= 0:
 						line1 = f.next()
@@ -856,13 +857,13 @@ class TransmitterLogging(TransmitterBase):
 					self.assertTrue(line2.endswith("After file moved\n"))
 					try:
 						n = f.next()
-						if n.find("Command: ['flushlogs']") >=0:
+						if n.find("Command: ['flushlogs']") >= 0:
 							self.assertRaises(StopIteration, f.next)
 						else:
 							self.fail("Exception StopIteration or Command: ['flushlogs'] expected. Got: %s" % n)
 					except StopIteration:
 						pass # on higher debugging levels this is expected
-				with open(fn,'r') as f:
+				with open(fn, 'r') as f:
 					line1 = f.next()
 					if line1.find('rollover performed on') >= 0:
 						line1 = f.next()
@@ -909,7 +910,7 @@ class RegexTests(unittest.TestCase):
 		# e.g. if we made it optional.
 		fr = FailRegex('%%<HOST>?')
 		self.assertFalse(fr.hasMatched())
-		fr.search([('%%',"","")])
+		fr.search([('%%', "", "")])
 		self.assertTrue(fr.hasMatched())
 		self.assertRaises(RegexException, fr.getHost)
 

--- a/fail2ban/tests/sockettestcase.py
+++ b/fail2ban/tests/sockettestcase.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 # Author: Steven Hiscocks
-# 
+#
 
 __author__ = "Steven Hiscocks"
 __copyright__ = "Copyright (c) 2013 Steven Hiscocks"

--- a/fail2ban/tests/utils.py
+++ b/fail2ban/tests/utils.py
@@ -25,7 +25,6 @@ __license__ = "GPL"
 import logging
 import os
 import re
-import sys
 import time
 import unittest
 from StringIO import StringIO
@@ -39,7 +38,7 @@ CONFIG_DIR = os.environ.get('FAIL2BAN_CONFIG_DIR', None)
 
 if not CONFIG_DIR:
 # Use heuristic to figure out where configuration files are
-	if os.path.exists(os.path.join('config','fail2ban.conf')):
+	if os.path.exists(os.path.join('config', 'fail2ban.conf')):
 		CONFIG_DIR = 'config'
 	else:
 		CONFIG_DIR = '/etc/fail2ban'
@@ -160,7 +159,7 @@ def gatherTests(regexps=None, no_network=False):
 	for file_ in os.listdir(
 		os.path.abspath(os.path.dirname(action_d.__file__))):
 		if file_.startswith("test_") and file_.endswith(".py"):
-			if no_network and file_ in ['test_badips.py','test_smtp.py']: #pragma: no cover
+			if no_network and file_ in ['test_badips.py', 'test_smtp.py']: #pragma: no cover
 				# Test required network
 				continue
 			tests.addTest(testloader.loadTestsFromName(

--- a/setup.py
+++ b/setup.py
@@ -89,42 +89,42 @@ if os.path.exists('/var/run'):
 exec(open(join("fail2ban", "version.py")).read())
 
 setup(
-	name = "fail2ban",
-	version = version,
-	description = "Ban IPs that make too many password failures",
-	long_description = longdesc,
-	author = "Cyril Jaquier & Fail2Ban Contributors",
-	author_email = "cyril.jaquier@fail2ban.org",
-	url = "http://www.fail2ban.org",
-	license = "GPL",
-	platforms = "Posix",
-	cmdclass = {'build_py': build_py, 'build_scripts': build_scripts},
-	scripts = [
+	name="fail2ban",
+	version=version,
+	description="Ban IPs that make too many password failures",
+	long_description=longdesc,
+	author="Cyril Jaquier & Fail2Ban Contributors",
+	author_email="cyril.jaquier@fail2ban.org",
+	url="http://www.fail2ban.org",
+	license="GPL",
+	platforms="Posix",
+	cmdclass={'build_py': build_py, 'build_scripts': build_scripts},
+	scripts=[
 		'bin/fail2ban-client',
 		'bin/fail2ban-server',
 		'bin/fail2ban-regex',
 		'bin/fail2ban-testcases',
 	],
-	packages = [
+	packages=[
 		'fail2ban',
 		'fail2ban.client',
 		'fail2ban.server',
 		'fail2ban.tests',
 		'fail2ban.tests.action_d',
 	],
-	package_data = {
+	package_data={
 		'fail2ban.tests':
-			[ join(w[0], f).replace("fail2ban/tests/", "", 1)
+			[join(w[0], f).replace("fail2ban/tests/", "", 1)
 				for w in os.walk('fail2ban/tests/files')
 				for f in w[2]] +
-			[ join(w[0], f).replace("fail2ban/tests/", "", 1)
+			[join(w[0], f).replace("fail2ban/tests/", "", 1)
 				for w in os.walk('fail2ban/tests/config')
 				for f in w[2]] +
-			[ join(w[0], f).replace("fail2ban/tests/", "", 1)
+			[join(w[0], f).replace("fail2ban/tests/", "", 1)
 				for w in os.walk('fail2ban/tests/action_d')
 				for f in w[2]]
 	},
-	data_files = [
+	data_files=[
 		('/etc/fail2ban',
 			glob("config/*.conf")
 		),


### PR DESCRIPTION
I noticed there were quite a few pep8 violations, including:
* Trailing spaces and tabs
* Depracted backticks (repr())
* Redundant parenthesis
* Unnecessary semicolons
* Inconsistent indentation
* Too many/few newlines/whitespaces
* Simplifyable assignments/comparisons
* Replaceable tests for membership with "not in/is"
* Unused imports

I don't know if you are interested in such a cleanup => Just take a look at it
FYI: I squashed all commits together for better reviewability, but if you like just some of them just let me know