### PR TITLE
Documentation: explicit enumeration of backend and usedns options

### DIFF
--- a/fail2ban/protocol.py
+++ b/fail2ban/protocol.py
@@ -63,7 +63,7 @@ protocol = [
 ["set dbpurgeage <SECONDS>", "sets the max age in <SECONDS> that history of bans will be kept"], 
 ["get dbpurgeage", "gets the max age in seconds that history of bans will be kept"], 
 ['', "JAIL CONTROL", ""],
-["add <JAIL> <BACKEND>", "creates <JAIL> using <BACKEND>"], 
+["add <JAIL> <BACKEND>", "creates <JAIL> using <BACKEND>. <BACKEND> can be auto, gamin, polling or pyinotify"], 
 ["start <JAIL>", "starts the jail <JAIL>"], 
 ["stop <JAIL>", "stops the jail <JAIL>. The jail is removed"], 
 ["status <JAIL> [FLAVOR]", "gets the current status of <JAIL>, with optional flavor or extended info"],

--- a/fail2ban/protocol.py
+++ b/fail2ban/protocol.py
@@ -84,7 +84,7 @@ protocol = [
 ["set <JAIL> findtime <TIME>", "sets the number of seconds <TIME> for which the filter will look back for <JAIL>"], 
 ["set <JAIL> bantime <TIME>", "sets the number of seconds <TIME> a host will be banned for <JAIL>"], 
 ["set <JAIL> datepattern <PATTERN>", "sets the <PATTERN> used to match date/times for <JAIL>"],
-["set <JAIL> usedns <VALUE>", "sets the usedns mode for <JAIL>"],
+["set <JAIL> usedns <VALUE>", "sets the usedns mode for <JAIL>. Can be yes, no or warn"],
 ["set <JAIL> banip <IP>", "manually Ban <IP> for <JAIL>"], 
 ["set <JAIL> unbanip <IP>", "manually Unban <IP> in <JAIL>"], 
 ["set <JAIL> maxretry <RETRY>", "sets the number of failures <RETRY> before banning the host for <JAIL>"], 

--- a/man/fail2ban-client.1
+++ b/man/fail2ban-client.1
@@ -127,7 +127,8 @@ history of bans will be kept
 JAIL CONTROL
 .TP
 \fBadd <JAIL> <BACKEND>\fR
-creates <JAIL> using <BACKEND>
+creates <JAIL> using <BACKEND>.
+<BACKEND> can be auto, gamin, polling or pyinotify
 .TP
 \fBstart <JAIL>\fR
 starts the jail <JAIL>

--- a/man/fail2ban-client.1
+++ b/man/fail2ban-client.1
@@ -212,7 +212,8 @@ sets the <PATTERN> used to match
 date/times for <JAIL>
 .TP
 \fBset <JAIL> usedns <VALUE>\fR
-sets the usedns mode for <JAIL>
+sets the usedns mode for <JAIL>.
+Can be yes, no or warn
 .TP
 \fBset <JAIL> banip <IP>\fR
 manually Ban <IP> for <JAIL>


### PR DESCRIPTION
Analogous to
["set logtarget <TARGET>", "sets logging target to <TARGET>. Can be STDOUT, STDERR, SYSLOG or a file"].
