### PR TITLE
ssh.conf: Fix disconnect "Auth fail" matching

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,8 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
    * Fix dnsToIp resolver for fqdn with large list of IPs (gh-1164)
    * filter.d/apache-badbots.conf
      - Updated useragent string regex adding escape for `+`
+   * filter.d/sshd.conf
+     - Updated "Auth fail" regex for OpenSSH 5.9 and later
    * Treat failed and killed execution of commands identically (only
      different log messages), which addresses different behavior on different
      exit codes of dash and bash (gh-1155)

--- a/THANKS
+++ b/THANKS
@@ -65,6 +65,7 @@ Joël Bertrand
 JP Espinosa
 jserrachinha
 Justin Shore
+Kevin Locke
 Kévin Drapel
 kjohnsonecl
 kojiro

--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -27,7 +27,7 @@ failregex = ^%(__prefix_line)s(?:error: PAM: )?[aA]uthentication (?:failure|erro
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because listed in DenyUsers\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because not in any group\s*$
             ^%(__prefix_line)srefused connect from \S+ \(<HOST>\)\s*$
-            ^%(__prefix_line)sReceived disconnect from <HOST>: 3: \S+: Auth fail$
+            ^%(__prefix_line)s(?:error: )?Received disconnect from <HOST>: 3: .*: Auth fail(?: \[preauth\])?$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because a group is listed in DenyGroups\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because none of user's groups are listed in AllowGroups\s*$
             ^(?P<__prefix>%(__prefix_line)s)User .+ not allowed because account is locked<SKIPLINES>(?P=__prefix)(?:error: )?Received disconnect from <HOST>: 11: .+ \[preauth\]$

--- a/fail2ban/tests/files/logs/sshd
+++ b/fail2ban/tests/files/logs/sshd
@@ -132,6 +132,12 @@ Nov 23 21:50:37 sshd[7148]: Connection closed by 61.0.0.1 [preauth]
 # failJSON: { "time": "2005-07-13T18:44:28", "match": true , "host": "89.24.13.192", "desc": "from gh-289" }
 Jul 13 18:44:28 mdop sshd[4931]: Received disconnect from 89.24.13.192: 3: com.jcraft.jsch.JSchException: Auth fail
 
+# failJSON: { "time": "2004-10-01T17:27:44", "match": true , "host": "94.249.236.6", "desc": "newer format per commit 36919d9f" }
+Oct  1 17:27:44 localhost sshd[24077]: error: Received disconnect from 94.249.236.6: 3: com.jcraft.jsch.JSchException: Auth fail [preauth]
+
+# failJSON: { "time": "2004-10-01T17:27:44", "match": true , "host": "94.249.236.6", "desc": "space in disconnect description per commit 36919d9f" }
+Oct  1 17:27:44 localhost sshd[24077]: error: Received disconnect from 94.249.236.6: 3: Ha ha, suckers!: Auth fail [preauth]
+
 # failJSON: { "match": false }
 Feb 12 04:09:18 localhost sshd[26713]: Connection from 115.249.163.77 port 51353
 # failJSON: { "time": "2005-02-12T04:09:21", "match": true , "host": "115.249.163.77", "desc": "from gh-457" }


### PR DESCRIPTION
The regex for matching against the "Auth fail" disconnect log message from sshd does not match against current versions of OpenSSH.  OpenSSH 5.9 introduced privilege separation of the pre-auth process, which included [logging through monitor.c](http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/monitor.c.diff?r1=1.113&r2=1.114) which adds " [preauth]" to the end of each message and causes the log level to be prepended to each message.

It also fails to match against clients which send a disconnect message with a description that is either empty or includes a space, since this is the content in the log message after the disconnect code, per [packet.c:1785](http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/packet.c?annotate=1.215), which was matched by `\S+`.  Although I have not observed this yet, I couldn't find anything which would preclude it in [RFC 4253](https://tools.ietf.org/html/rfc4253#section-11.1) and since the message is attacker-controlled it provides a way to avoid getting banned.

This PR fixes both issues.  I hope you find it useful.

Thanks for considering,
Kevin