### PR TITLE
Make sshd jail default to systemd on Fedora

### DIFF
--- a/config/jail.conf
+++ b/config/jail.conf
@@ -216,6 +216,7 @@ action = %(action_)s
 
 port    = ssh
 logpath = %(sshd_log)s
+backend = %(sshd_backend)s
 
 
 [sshd-ddos]
@@ -224,6 +225,7 @@ logpath = %(sshd_log)s
 # in the body.
 port    = ssh
 logpath = %(sshd_log)s
+backend = %(sshd_backend)s
 
 
 [dropbear]

--- a/config/paths-debian.conf
+++ b/config/paths-debian.conf
@@ -9,6 +9,8 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
+sshd_backed = auto
+
 syslog_mail = /var/log/mail.log
 
 syslog_mail_warn = /var/log/mail.warn

--- a/config/paths-fedora.conf
+++ b/config/paths-fedora.conf
@@ -9,6 +9,8 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
+sshd_backed = systemd
+
 syslog_mail = /var/log/maillog
 
 syslog_mail_warn = /var/log/maillog

--- a/config/paths-freebsd.conf
+++ b/config/paths-freebsd.conf
@@ -9,6 +9,8 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
+sshd_backed = auto
+
 # http://www.freebsd.org/doc/handbook/configtuning-syslog.html
 #
 syslog_mail = /var/log/maillog

--- a/config/paths-opensuse.conf
+++ b/config/paths-opensuse.conf
@@ -9,6 +9,8 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
+sshd_backed = auto
+
 syslog_local0  = /var/log/messages
 
 syslog_mail = /var/log/mail

--- a/config/paths-osx.conf
+++ b/config/paths-osx.conf
@@ -10,6 +10,8 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
+sshd_backed = auto
+
 syslog_mail = /var/log/mail.log
 
 syslog_mail_warn = /var/log/mail.warn


### PR DESCRIPTION
A lot of nice work was done a while back to allow distros to configure the default logpaths, e.g. 
~~~~~
logpath = %(sshd_log)s
~~~~~
I'd like to be able to do the same for configuring fail2ban to use the journal by default for certain jails without having to maintain a cumbersome patch.  This is an attempt to start doing so.  Thoughts?

See also https://bugzilla.redhat.com/show_bug.cgi?id=1269226