### PR TITLE
files: Strip trailing whitespace from files

### DIFF
--- a/files/bash-completion
+++ b/files/bash-completion
@@ -31,7 +31,7 @@ __fail2ban_jail_action_methods () {
 
 _fail2ban () {
     local cur prev words cword
-    _init_completion || return 
+    _init_completion || return
 
     case $prev in
         -V|--version|-h|--help)

--- a/files/gen_badbots
+++ b/files/gen_badbots
@@ -26,7 +26,7 @@
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the 
+#  along with this program; if not, write to the
 #  Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
 #  MA 02110-1301, USA.
 #

--- a/files/nagios/README
+++ b/files/nagios/README
@@ -8,8 +8,8 @@ How to use
 ----------
 Just have to run the following command:
     $ ./check_fail2ban --help
- 
-If you need to use this script with NRPE you just have to do the 
+
+If you need to use this script with NRPE you just have to do the
 following steps:
 
 1 allow your user to run the script with the sudo rights. Just add
@@ -20,7 +20,7 @@ following steps:
   command[check_fail2ban]=/usr/bin/sudo /<path-to>/check_fail2ban
 
 3 don't forget to restart your NRPE daemon
-   
+
 /!\ be careful to let no one able to update the check_fail2ban ;)
 ------------------------------------------------------------------------------
 
@@ -37,7 +37,7 @@ HELP:
 2.) delete the socket if available
 rm /var/run/fail2ban/fail2ban.sock
 
-3.) start the Service 
+3.) start the Service
 /etc/init.d/fail2ban start
 
 4.) check if fail2ban is working
@@ -58,7 +58,7 @@ Options:
  -V, --version
     Print version information
  -D, --display=STRING
-    To modify the output display 
+    To modify the output display
     default is "CHECK FAIL2BAN ACTIVITY"
  -P, --path-fail2ban_client=STRING
     Specify the path to the tw_cli binary

--- a/files/nagios/check_fail2ban
+++ b/files/nagios/check_fail2ban
@@ -4,12 +4,12 @@
 #             -=- <check_fail2ban> -=-
 #  -------------------------------------------------------
 #
-#  Description : This plugin checks if the fail2ban server is running 
+#  Description : This plugin checks if the fail2ban server is running
 #  and how many IPs are currently banned.
-#  
+#
 #
 # inspired by the work of Sebastian Mueller - http://www.elchtest.eu
-# 
+#
 #
 #  Version : 0.1
 #  -------------------------------------------------------
@@ -17,7 +17,7 @@
 #     - see the How to use section
 #
 #  Out :
-#     - only print on the standard output 
+#     - only print on the standard output
 #
 #  Features :
 #     - perfdata output
@@ -51,8 +51,8 @@
 #
 # Just have to run the following command:
 #       $ ./check_fail2ban --help
-# 
-# If you need to use this script with NRPE you just have to do the 
+#
+# If you need to use this script with NRPE you just have to do the
 # following steps:
 #
 # 1 allow your user to run the script with the sudo rights. Just add
@@ -64,7 +64,7 @@
 #
 # 3 don't forget to restart your NRPE daemon
 #
-#	
+#
 # /!\ be careful to let no one able to update the check_fail2ban ;)
 # ------------------------------------------------------------------------------
 #
@@ -251,7 +251,7 @@ Options:
  -V, --version
     Print version information
  -D, --display=STRING
-    To modify the output display 
+    To modify the output display
     default is "CHECK FAIL2BAN ACTIVITY"
  -P, --path-fail2ban_client=STRING
     Specify the path to the tw_cli binary
@@ -269,7 +269,7 @@ Options:
     If you want to activate the perfdata output
  -v, --verbose
     Show details for command-line debugging (Nagios may truncate the output)
-    
+
 Send email to $a_mail if you have questions
 regarding use of this software. To submit patches or suggest improvements,
 send email to $a_mail
@@ -315,7 +315,7 @@ sub obtain_jail_list {
     if ($return_code) {
         return -1;
     }
-    
+
     my @jail_list;
     foreach (@command_output) {
         if ($_=~/^.*Jail list:\t+(.*)/) {
@@ -323,7 +323,7 @@ sub obtain_jail_list {
             @jail_list = split(/,/, $1);
         }
     }
-    
+
     return @jail_list;
 }
 

--- a/files/solaris-svc-fail2ban
+++ b/files/solaris-svc-fail2ban
@@ -2,7 +2,7 @@
 #
 # fail2ban		This init.d script is used to start fail2ban.
 # (C) by Hanno Wagner <wagner@rince.de>, License is GPL
- 
+
 #set -x
 
 . /lib/svc/share/smf_include.sh

--- a/files/suse-initd
+++ b/files/suse-initd
@@ -60,12 +60,12 @@ case "$1" in
 
 	if [ -f $FAIL2BAN_SOCKET ]
          then
-         echo "$FAIL2BAN_SOCKET  not removed .. removing .." 
+         echo "$FAIL2BAN_SOCKET  not removed .. removing .."
          rm $FAIL2BAN_SOCKET
         fi
         if [ -f $FAIL2BAN_PID ]
          then
-         echo "$FAIL2BAN_PID  not removed .. removing .." 
+         echo "$FAIL2BAN_PID  not removed .. removing .."
          rm $FAIL2BAN_PID
         fi
 


### PR DESCRIPTION
Run the command `StripWhitespace` from the [Vim Better Whitespace
Plugin](https://github.com/ntpeters/vim-better-whitespace).