### PR TITLE
Add check in apache-fakegooglebot to protect against PTR fake record

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,6 +32,8 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
    * Allow to split ignoreip entries by ',' as well as by ' ' (gh-1197)
    * Added a timeout (3 sec) to urlopen within badips.py action
      (Thanks M. Maraun)
+   * Added check against atacker's Googlebot PTR fake records
+     (Thanks Pablo Rodriguez Fernandez)
 
 ver. 0.9.3 (2015/08/01) - lets-all-stay-friends
 ----------

--- a/THANKS
+++ b/THANKS
@@ -89,6 +89,7 @@ Mika (mkl)
 Nick Munger
 onorua
 Orion Poplawski
+Pablo Rodriguez Fernandez
 Paul Marrapese
 Paul Traina
 Noel Butler

--- a/config/filter.d/ignorecommands/apache-fakegooglebot
+++ b/config/filter.d/ignorecommands/apache-fakegooglebot
@@ -26,7 +26,10 @@ def is_googlebot(ip):
     from fail2ban.server.filter import DNSUtils
 
     host = DNSUtils.ipToName(ip)
-    sys.exit(0 if (host and re.match('crawl-.*\.googlebot\.com', host)) else 1)
+    if not host or not re.match('crawl-.*\.googlebot\.com', host):
+       sys.exit(1)
+    host_ips = DNSUtils.dnsToIp(host)
+    sys.exit(0 if ip in host_ips else 1)
 
 if __name__ == '__main__':
     is_googlebot(process_args(sys.argv))


### PR DESCRIPTION
An attacker may return a PTR record which fakes a Googlebot's domain
name. This modification resolves the PTR records to verify it.

See "Verifying Googlebot":
<https://support.google.com/webmasters/answer/80553?vid=1-635800030504666679-1963774919>