### PR TITLE
Enhancements on the ignorecommand execution

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,9 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
      (gh-1226)
    * Added filter for openhab domotic software authentication failure with the
      rest api and web interface (gh-1223)
+   * ignorecommand is executed just before banning, instead of every time an ip
+     is found (gh-1229)
+   * Fail of ignorecommand is not logged with ERROR level, but INFO (gh-1229)
 
 ver. 0.9.3 (2015/08/01) - lets-all-stay-friends
 ----------

--- a/fail2ban/server/action.py
+++ b/fail2ban/server/action.py
@@ -532,7 +532,7 @@ class CommandAction(ActionBase):
 		return self.executeCmd(realCmd, self.timeout)
 
 	@staticmethod
-	def executeCmd(realCmd, timeout=60):
+	def executeCmd(realCmd, timeout=60, testCmd=False):
 		"""Executes a command.
 
 		Parameters
@@ -541,6 +541,8 @@ class CommandAction(ActionBase):
 			The command to execute.
 		timeout : int
 			The time out in seconds for the command.
+		testCmd : bool
+			If the command is used as a test; return nonzero is not an error.
 
 		Returns
 		-------
@@ -591,7 +593,7 @@ class CommandAction(ActionBase):
 			_cmd_lock.release()
 
 		std_level = retcode == 0 and logging.DEBUG or logging.ERROR
-		if std_level >= logSys.getEffectiveLevel():
+		if std_level >= logSys.getEffectiveLevel() and not testCmd:
 			stdout.seek(0)
 			logSys.log(std_level, "%s -- stdout: %r" % (realCmd, stdout.read()))
 			stderr.seek(0)
@@ -611,7 +613,8 @@ class CommandAction(ActionBase):
 				(realCmd, signame.get(sigcode, "signal %i" % sigcode), retcode))
 		else:
 			msg = _RETCODE_HINTS.get(retcode, None)
-			logSys.error("%s -- returned %i" % (realCmd, retcode))
+			std_level = logging.INFO if testCmd else logging.ERROR
+			logSys.log(std_level, "%s -- returned %i" % (realCmd, retcode))
 			if msg:
 				logSys.info("HINT on %i: %s"
 							% (retcode, msg % locals()))

--- a/fail2ban/server/actions.py
+++ b/fail2ban/server/actions.py
@@ -312,6 +312,15 @@ class Actions(JailThread, Mapping):
 				aInfo["ipjailmatches"]  = lambda: "\n".join(mi4ip().getMatches())
 				aInfo["ipfailures"]     = lambda: mi4ip(True).getAttempt()
 				aInfo["ipjailfailures"] = lambda: mi4ip().getAttempt()
+
+			try:
+				if self._jail.filter.ignoredIPByCommand(ip, True):
+					return False
+			except AttributeError as e: # pragma: no cover
+				logSys.error(
+					"Failed to execute ignorecommand: jail '%s' has not "
+					"filter" % self._jail.name)
+
 			if self.__banManager.addBanTicket(bTicket):
 				logSys.notice("[%s] Ban %s" % (self._jail.name, aInfo["ip"]))
 				for name, action in self._actions.iteritems():

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -385,6 +385,17 @@ class Filter(JailThread):
 				self.logIgnoreIp(ip, log_ignore, ignore_source="ip")
 				return True
 
+		return False
+
+	##
+	# Check if IP has to be ignored accordingly to ignorecommand
+	#
+	# Check if the given IP address has to be ignored accordingly to
+	# ignorecommand.
+	# @param ip IP address
+	# @return True if IP address is ignored
+
+	def ignoredIPByCommand(self, ip, log_ignore=False):
 		if self.__ignoreCommand:
 			command = CommandAction.replaceTag(self.__ignoreCommand, { 'ip': ip } )
 			logSys.debug('ignore command: ' + command)

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -399,7 +399,7 @@ class Filter(JailThread):
 		if self.__ignoreCommand:
 			command = CommandAction.replaceTag(self.__ignoreCommand, { 'ip': ip } )
 			logSys.debug('ignore command: ' + command)
-			ret_ignore = CommandAction.executeCmd(command)
+			ret_ignore = CommandAction.executeCmd(command, 30, True)
 			self.logIgnoreIp(ip, log_ignore and ret_ignore, ignore_source="command")
 			return ret_ignore
 

--- a/fail2ban/tests/actionstestcase.py
+++ b/fail2ban/tests/actionstestcase.py
@@ -29,6 +29,7 @@ import os
 import tempfile
 
 from ..server.actions import Actions
+from ..server.mytime import MyTime
 from ..server.ticket import FailTicket
 from .dummyjail import DummyJail
 from .utils import LogCaptureTestCase
@@ -165,3 +166,10 @@ class ExecuteActions(LogCaptureTestCase):
 		self.assertNotLogged("Failed to execute unban")
 		self.assertLogged("action1 unban deleted aInfo IP")
 		self.assertLogged("action2 unban deleted aInfo IP")
+
+	def testCheckBanWithIgnoredIP(self):
+		self.__jail.filter.setIgnoreCommand(
+			os.path.join(TEST_FILES_DIR, "ignorecommand.py <ip>"))
+		ticket = FailTicket("10.0.0.1", MyTime.time(), ['test', 'test'])
+		self.__jail.putFailTicket(ticket)
+		self.assertFalse(self.__actions._Actions__checkBan())

--- a/fail2ban/tests/dummyjail.py
+++ b/fail2ban/tests/dummyjail.py
@@ -25,6 +25,7 @@ __license__ = "GPL"
 from threading import Lock
 
 from ..server.actions import Actions
+from ..server.filter import Filter
 
 
 class DummyJail(object):
@@ -36,6 +37,7 @@ class DummyJail(object):
 		self.idle = False
 		self.database = None
 		self.actions = Actions(self)
+		self.filter = Filter(self)
 
 	def __len__(self):
 		try:

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -271,8 +271,8 @@ class IgnoreIP(LogCaptureTestCase):
 
 	def testIgnoreCommand(self):
 		self.filter.setIgnoreCommand(sys.executable + ' ' + os.path.join(TEST_FILES_DIR, "ignorecommand.py <ip>"))
-		self.assertTrue(self.filter.inIgnoreIPList("10.0.0.1"))
-		self.assertFalse(self.filter.inIgnoreIPList("10.0.0.0"))
+		self.assertTrue(self.filter.ignoredIPByCommand("10.0.0.1"))
+		self.assertFalse(self.filter.ignoredIPByCommand("10.0.0.0"))
 
 	def testIgnoreCauseOK(self):
 		ip = "93.184.216.34"


### PR DESCRIPTION
- ignorecommand is executed just before banning, instead of every time an ip is found
- Fail of ignorecommand is not logged with ERROR level, but INFO
