### PR TITLE
New filter `nginx-limit-req` 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,11 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
    * Fix jail.conf.5 man's section (gh-1226)
 
 - New Features:
+   * New filters:
+     - openhab - domotic software authentication failure with the
+       rest api and web interface (gh-1223)
+     - nginx-limit-req - ban hosts, that were failed through nginx by limit
+       request processing rate (ngx_http_limit_req_module)
 
 - Enhancements:
    * Do not rotate empty log files
@@ -37,8 +42,6 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
      (Thanks Pablo Rodriguez Fernandez)
    * Enhance filter against atacker's Googlebot PTR fake records
      (gh-1226)
-   * Added filter for openhab domotic software authentication failure with the
-     rest api and web interface (gh-1223)
 
 ver. 0.9.3 (2015/08/01) - lets-all-stay-friends
 ----------

--- a/config/filter.d/nginx-limit-req.conf
+++ b/config/filter.d/nginx-limit-req.conf
@@ -33,7 +33,13 @@
 #
 ngx_limit_req_zones = [^"]+
 
-failregex = ^\s*\[error\] \d+#\d+: \*\d+ limiting requests, excess: [\d\.]+ by zone "(?:%(ngx_limit_req_zones)s)", client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"(, referrer: "\S+")?\s*$
+# Use following full expression if you should range limit request to specified 
+# servers, requests, referrers etc. only :
+#
+# failregex = ^\s*\[error\] \d+#\d+: \*\d+ limiting requests, excess: [\d\.]+ by zone "(?:%(ngx_limit_req_zones)s)", client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"(, referrer: "\S+")?\s*$
+
+# Shortly, much faster and stable version of regexp:
+failregex = ^\s*\[error\] \d+#\d+: \*\d+ limiting requests, excess: [\d\.]+ by zone "(?:%(ngx_limit_req_zones)s)", client: <HOST>
 
 ignoreregex = 
 

--- a/config/filter.d/nginx-limit-req.conf
+++ b/config/filter.d/nginx-limit-req.conf
@@ -1,0 +1,39 @@
+# Fail2ban filter configuration for nginx :: limit_req
+# used to ban hosts, that were failed through nginx by limit request processing rate 
+#
+# Author: Serg G. Brester (sebres)
+#
+# To use 'nginx-limit-req' filter you should have `ngx_http_limit_req_module`
+# and define `limit_req` and `limit_req_zone` as described in nginx documentation
+# http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
+#
+# Example:
+#
+#   http {
+#     ...
+#     limit_req_zone $binary_remote_addr zone=lr_zone:10m rate=1r/s;
+#     ...
+#     # http, server, or location:
+#     location ... {
+#       limit_req zone=lr_zone burst=1 nodelay;
+#       ...
+#     }
+#     ...
+#   }
+#   ...
+#
+
+[Definition]
+
+# Specify following expression to define exact zones, if you want to ban IPs limited 
+# from specified zones only.
+# Example:
+#
+#   ngx_limit_req_zones = lr_zone|lr_zone2
+#
+ngx_limit_req_zones = [^"]+
+
+failregex = ^\s*\[error\] \d+#\d+: \*\d+ limiting requests, excess: [\d\.]+ by zone "(?:%(ngx_limit_req_zones)s)", client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"(, referrer: "\S+")?\s*$
+
+ignoreregex = 
+

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -317,6 +317,14 @@ logpath = /opt/openhab/logs/request.log
 port    = http,https
 logpath = %(nginx_error_log)s
 
+# To use 'nginx-limit-req' jail you should have `ngx_http_limit_req_module` 
+# and define `limit_req` and `limit_req_zone` as described in nginx documentation
+# http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
+# or for example see in 'config/filter.d/nginx-limit-req.conf'
+[nginx-limit-req]
+port    = http,https
+logpath = %(nginx_error_log)s
+
 [nginx-botsearch]
 
 port     = http,https

--- a/fail2ban/tests/files/logs/nginx-limit-req
+++ b/fail2ban/tests/files/logs/nginx-limit-req
@@ -1,0 +1,6 @@
+
+# failJSON: { "time": "2015-10-29T20:01:02", "match": true , "host": "1.2.3.4" }
+2015/10/29 20:01:02 [error] 256554#0: *99927 limiting requests, excess: 1.852 by zone "one", client: 1.2.3.4, server: example.com, request: "POST /index.htm HTTP/1.0", host: "exmaple.com"
+
+# failJSON: { "time": "2015-10-29T19:24:05", "match": true , "host": "192.0.2.0" }
+2015/10/29 19:24:05 [error] 12684#12684: *22174 limiting requests, excess: 1.495 by zone "one", client: 192.0.2.0, server: example.com, request: "GET /index.php HTTP/1.1", host: "example.com", referrer: "https://example.com"


### PR DESCRIPTION
used to ban hosts, that were failed through nginx by limit request processing rate (ngx_http_limit_req_module)