### PR TITLE
Fixed directly defined banaction for allports jails like pam-generic, recidive, etc

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,8 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
      different log messages), which addresses different behavior on different
      exit codes of dash and bash (gh-1155)
    * Fix jail.conf.5 man's section (gh-1226)
+   * Fixed default banaction for allports jails like pam-generic, recidive, etc
+     with new default variable `banaction_allports` (gh-1216)
 
 - New Features:
    * New filters:

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -154,6 +154,7 @@ port = 0:65535
 # action_* variables. Can be overridden globally or per
 # section within jail.local file
 banaction = iptables-multiport
+banaction_allports = iptables-allports
 
 # The simplest action to take: ban only
 action_ = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
@@ -713,7 +714,7 @@ maxretry = 5
 [recidive]
 
 logpath  = /var/log/fail2ban.log
-banaction = iptables-allports
+banaction = %(banaction_allports)s
 bantime  = 604800  ; 1 week
 findtime = 86400   ; 1 day
 maxretry = 5
@@ -724,7 +725,7 @@ maxretry = 5
 
 [pam-generic]
 # pam-generic filter can be customized to monitor specific subset of 'tty's
-banaction = iptables-allports
+banaction = %(banaction_allports)s
 logpath  = %(syslog_authpriv)s
 
 
@@ -770,7 +771,7 @@ maxretry = 1
 enabled = false
 logpath = /opt/sun/comms/messaging64/log/mail.log_current
 maxretry = 6
-banaction = iptables-allports
+banaction = %(banaction_allports)s
 
 [directadmin]
 enabled = false

--- a/man/jail.conf.5
+++ b/man/jail.conf.5
@@ -146,6 +146,12 @@ Ensure syslog or the program that generates the log file isn't configured to com
 .B logencoding
 encoding of log files used for decoding. Default value of "auto" uses current system locale.
 .TP
+.B banaction
+default banning action (iptables-multiport) for all jails specified in the \fI[DEFAULT]\fR section.
+.TP
+.B banaction_allports
+default allports banning action (iptables-allports) for some jails like "pam-generic" or "recidive", specified in the \fI[DEFAULT]\fR section.
+.TP
 .B action
 action(s) from \fI/etc/fail2ban/action.d/\fR without the \fI.conf\fR/\fI.local\fR extension. Arguments can be passed to actions to override the default values from the [Init] section in the action file. Arguments are specified by:
 .RS


### PR DESCRIPTION
Fixed directly defined banaction for allports jails like pam-generic, recidive, etc with new default variable `banaction_allports` (+ man entries for both variables added);

closes gh-1216