### PR TITLE
Http badbots

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,8 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
        rest api and web interface (gh-1223)
      - nginx-limit-req - ban hosts, that were failed through nginx by limit
        request processing rate (ngx_http_limit_req_module)
+     - http-badbots - (previously apache-badbots) revised common filter to ban 
+       bad-bot hosts for apache/nginx (catches known spambots and software alike)
 
 - Enhancements:
    * Do not rotate empty log files

--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,13 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
      with new default variable `banaction_allports` (gh-1216)
 
 - New Features:
+   * New interpolation feature for definition config readers - `<known/parameter>`
+     (means last known init definition of filters or actions with name `parameter`).
+     This interpolation makes possible to extend a parameters of stock filter or 
+     action directly in jail inside jail.local file, without creating a separately
+     filter.d/*.local file.
+     As extension to interpolation `%(known/parameter)s`, that does not works for
+     filter and action init parameters
    * New filters:
      - openhab - domotic software authentication failure with the
        rest api and web interface (gh-1223)

--- a/config/filter.d/http-badbots.conf
+++ b/config/filter.d/http-badbots.conf
@@ -3,14 +3,25 @@
 # Regexp to catch known spambots and software alike. Please verify
 # that it is your intent to block IPs which were driven by
 # above mentioned bots.
+#
+# You can redefine or extend both parameters "badbots" and "badbotscustom" 
+# in your jails [apache-badbots] or [nginx-badbots]:
+#
+# - to redefine (totally overwrite) it using your own expression only:
+#     filter = http-badbots[badbots=BadBot0, badbotscustom=BadBot1|BadBot2]
+#
+# - to expand it with your own expression use <known/param> syntax:
+#     filter = http-badbots[badbots=BadBot0|<known/badbots>]
 
-
-[Definition]
+[Init]
 
 badbotscustom = EmailCollector|WebEMailExtrac|TrackBack/1\.02|sogou music spider
 badbots = Atomic_Email_Hunter/4\.0|atSpider/1\.0|autoemailspider|bwh3_user_agent|China Local Browse 2\.6|ContactBot/0\.2|ContentSmartz|DataCha0s/2\.0|DBrowse 1\.4b|DBrowse 1\.4d|Demo Bot DOT 16b|Demo Bot Z 16b|DSurf15a 01|DSurf15a 71|DSurf15a 81|DSurf15a VA|EBrowse 1\.4b|Educate Search VxB|EmailSiphon|EmailSpider|EmailWolf 1\.00|ESurf15a 15|ExtractorPro|Franklin Locator 1\.8|FSurf15a 01|Full Web Bot 0416B|Full Web Bot 0516B|Full Web Bot 2816B|Guestbook Auto Submitter|Industry Program 1\.0\.x|ISC Systems iRc Search 2\.1|IUPUI Research Bot v 1\.9a|LARBIN-EXPERIMENTAL \(efp@gmx\.net\)|LetsCrawl\.com/1\.0 \+http\://letscrawl\.com/|Lincoln State Web Browser|LMQueueBot/0\.2|LWP\:\:Simple/5\.803|Mac Finder 1\.0\.xx|MFC Foundation Class Library 4\.0|Microsoft URL Control - 6\.00\.8xxx|Missauga Locate 1\.0\.0|Missigua Locator 1\.9|Missouri College Browse|Mizzu Labs 2\.2|Mo College 1\.9|MVAClient|Mozilla/2\.0 \(compatible; NEWT ActiveX; Win32\)|Mozilla/3\.0 \(compatible; Indy Library\)|Mozilla/3\.0 \(compatible; scan4mail \(advanced version\) http\://www\.peterspages\.net/?scan4mail\)|Mozilla/4\.0 \(compatible; Advanced Email Extractor v2\.xx\)|Mozilla/4\.0 \(compatible; Iplexx Spider/1\.0 http\://www\.iplexx\.at\)|Mozilla/4\.0 \(compatible; MSIE 5\.0; Windows NT; DigExt; DTS Agent|Mozilla/4\.0 efp@gmx\.net|Mozilla/5\.0 \(Version\: xxxx Type\:xx\)|NameOfAgent \(CMS Spider\)|NASA Search 1\.0|Nsauditor/1\.x|PBrowse 1\.4b|PEval 1\.4b|Poirot|Port Huron Labs|Production Bot 0116B|Production Bot 2016B|Production Bot DOT 3016B|Program Shareware 1\.0\.2|PSurf15a 11|PSurf15a 51|PSurf15a VA|psycheclone|RSurf15a 41|RSurf15a 51|RSurf15a 81|searchbot admin@google\.com|ShablastBot 1\.0|snap\.com beta crawler v0|Snapbot/1\.0|Snapbot/1\.0 \(Snap Shots&#44; \+http\://www\.snap\.com\)|sogou develop spider|Sogou Orion spider/3\.0\(\+http\://www\.sogou\.com/docs/help/webmasters\.htm#07\)|sogou spider|Sogou web spider/3\.0\(\+http\://www\.sogou\.com/docs/help/webmasters\.htm#07\)|sohu agent|SSurf15a 11 |TSurf15a 11|Under the Rainbow 2\.2|User-Agent\: Mozilla/4\.0 \(compatible; MSIE 6\.0; Windows NT 5\.1\)|VadixBot|WebVulnCrawl\.unknown/1\.0 libwww-perl/5\.803|Wells Search II|WEP Search 00
 
-failregex = ^<HOST> -.*"(GET|POST|HEAD).*HTTP.*"(?:%(badbots)s|%(badbotscustom)s)"$
+
+[Definition]
+
+failregex = ^<HOST> - \S+ \[\] "([A-Z]+) \S+ HTTP[^"]+" \d+ \d+ "[^"]*" "(?:<badbots>|<badbotscustom>)"$
 
 ignoreregex =
 
@@ -19,3 +30,7 @@ ignoreregex =
 # Generated on Thu Nov  7 14:23:35 PST 2013 by files/gen_badbots.
 #
 # Author: Yaroslav Halchenko
+#
+# sebres:
+#   Since we use %(known/...)s and <known/...> syntax, the parameter "badbotscustom" no more 
+#   needed, but still used here for backwards compatibility.

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -253,6 +253,8 @@ logpath  = %(apache_error_log)s
 [apache-badbots]
 # Ban hosts which agent identifies spammer robots crawling the web
 # for email addresses. The mail outputs are buffered.
+# See filter.d/http-badbots for details
+filter   = http-badbots
 port     = http,https
 logpath  = %(apache_access_log)s
 bantime  = 172800
@@ -317,6 +319,16 @@ logpath = /opt/openhab/logs/request.log
 
 port    = http,https
 logpath = %(nginx_error_log)s
+
+[nginx-badbots]
+# Ban hosts which agent identifies spammer robots crawling the web
+# for email addresses. The mail outputs are buffered.
+# See filter.d/http-badbots for details
+filter   = http-badbots
+port     = http,https
+logpath  = %(nginx_access_log)s
+bantime  = 172800
+maxretry = 1
 
 # To use 'nginx-limit-req' jail you should have `ngx_http_limit_req_module` 
 # and define `limit_req` and `limit_req_zone` as described in nginx documentation

--- a/fail2ban/client/configreader.py
+++ b/fail2ban/client/configreader.py
@@ -285,8 +285,10 @@ class DefinitionInitConfigReader(ConfigReader):
 		
 		if self.has_section("Init"):
 			for opt in self.options("Init"):
+				v = self.get("Init", opt)
+				self._initOpts['known/'+opt] = v
 				if not opt in self._initOpts:
-					self._initOpts[opt] = self.get("Init", opt)
+					self._initOpts[opt] = v
 	
 	def convert(self):
 		raise NotImplementedError

--- a/fail2ban/tests/files/logs/http-badbots
+++ b/fail2ban/tests/files/logs/http-badbots
@@ -6,3 +6,8 @@
 
 # failJSON: { "time": "2007-03-05T14:41:21", "match": true , "host": "1.2.3.4" }
 1.2.3.4 - - [05/Mar/2007:14:41:21 +0100] "HEAD /123.html/trackback/ HTTP/1.0" 301 459 "http://www.mydomain.tld/123.html/trackback" "TrackBack/1.02"
+
+# failJSON: { "match": false }
+127.0.0.1 - user [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"
+# failJSON: { "time": "2000-10-10T22:55:36", "match": true , "host": "127.0.0.1" }
+127.0.0.1 - user [10/Oct/2000:13:55:36 -0700] "OPTIONS /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "EmailCollector"

--- a/man/jail.conf.5
+++ b/man/jail.conf.5
@@ -89,13 +89,33 @@ indicates that the specified file is to be parsed before the current file.
 indicates that the specified file is to be parsed after the current file.
 .RE
 
-Using Python "string interpolation" mechanisms, other definitions are allowed and can later be used within other definitions as %(name)s. For example.
+Using Python "string interpolation" mechanisms, other definitions are allowed and can later be used within other definitions as %(name)s. 
+Additionaly fail2ban has an extended interpolation feature named \fB%(known/parameter)s\fR (means last known option with name \fBparameter\fR). This interpolation makes possible to extend a stock filter or jail regexp in .local file (opposite to simply set failregex/ignoreregex that overwrites it). For example.
 
 .RS
+.nf
 baduseragents = IE|wget
+failregex = %(known/failregex)s
+            useragent=%(baduseragents)s
+.fi
 .RE
+
+Additionally to interpolation \fB%(known/parameter)s\fR, that does not works for filter/action init parameters, an interpolation tag \fB<known/parameter>\fR can be used (means last known init definition of filters or actions with name \fBparameter\fR). This interpolation makes possible to extend a parameters of stock filter or action directly in jail inside \fIjail.conf/jail.local\fR file without creating a separately filter.d/*.local file. For example.
+
 .RS
-failregex = useragent=%(baduseragents)s
+# filter.d/test.conf:
+.nf
+[Init]
+test.method = GET
+baduseragents = IE|wget
+[Definition]
+failregex = ^%(__prefix_line)\\s+"<test.method>"\\s+test\\s+regexp\\s+-\\s+useragent=(?:<baduseragents>)
+
+# jail.local:
+[test]
+# use filter "test", overwrite method to "POST" and extend known bad agents with "badagent":
+filter = test[test.method=POST, baduseragents="badagent|<known/baduseragents>"]
+.fi
 .RE
 
 Comments: use '#' for comment lines and '; ' (space is important) for inline comments. When using Python2.X '; ' can only be used on the first line due to an Python library bug.
@@ -253,7 +273,7 @@ The maximum period of time in seconds that a command can executed, before being 
 Commands specified in the [Definition] section are executed through a system shell so shell redirection and process control is allowed. The commands should
 return 0, otherwise error would be logged.  Moreover if \fBactioncheck\fR exits with non-0 status, it is taken as indication that firewall status has changed and fail2ban needs to reinitialize itself (i.e. issue \fBactionstop\fR and \fBactionstart\fR commands).  
 Tags are enclosed in <>.  All the elements of [Init] are tags that are replaced in all action commands.  Tags can be added by the
-\fBfail2ban-client\fR using the "set <JAIL> action <ACT>" command. \fB<br>\fR is a tag that is always a new line (\\n).
+\fBfail2ban-client\fR using the "set <JAIL> action <ACT>" command. \fB<br>\fR is a tag that is always a new line (\\n).     
 
 More than a single command is allowed to be specified. Each command needs to be on a separate line and indented with whitespace(s) without blank lines. The following example defines
 two commands to be executed.
@@ -312,7 +332,7 @@ is the regex to identify log entries that should be ignored by Fail2Ban, even if
 
 
 .PP
-Similar to actions, filters have an [Init] section which can be overridden in \fIjail.conf/jail.local\fR. The filter [Init] section is limited to the following options:
+Similar to actions, filters have an [Init] section which can be overridden in \fIjail.conf/jail.local\fR. Besides the filter-specific settings, the filter [Init] section can be used to set following standard options:
 .TP
 \fBmaxlines\fR
 specifies the maximum number of lines to buffer to match multi-line regexs. For some log formats this will not required to be changed. Other logs may require to increase this value if a particular log file is frequently written to.
@@ -327,6 +347,8 @@ Also, special values of \fIEpoch\fR (UNIX Timestamp), \fITAI64N\fR and \fIISO860
 \fBjournalmatch\fR
 specifies the systemd journal match used to filter the journal entries. See \fBjournalctl(1)\fR and \fBsystemd.journal-fields(7)\fR for matches syntax and more details on special journal fields. This option is only valid for the \fIsystemd\fR backend.
 .PP
+Similar to actions [Init] section enables filter-specific settings. All parameters specified in [Init] section can be redefined or extended in \fIjail.conf/jail.local\fR.
+
 Filters can also have a section called [INCLUDES]. This is used to read other configuration files.
 
 .TP


### PR DESCRIPTION
new apache/nginx jail and filter http-badbots - (previously apache-badbots) common filter to ban bad-bot hosts for apache/nginx (catches known spambots and software alike);
See gh-712

Based on #1241 because init definition of this filter can be extended using own regex, example:
```
[nginx-badbots]
filter = http-badbots[badbots="SomeBadBot|<known/badbots>"]
```
or
```
[nginx-badbots]
filter = http-badbots[badbots=ThisBadBotOnly, badbotscustom=ThisBadBotOnly]
```