### PR TITLE
fixed fail2ban-regex reads invalid character (in sense of given encoding) ...

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,8 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
    * Fix jail.conf.5 man's section (gh-1226)
    * Fixed default banaction for allports jails like pam-generic, recidive, etc
      with new default variable `banaction_allports` (gh-1216)
+   * Fixed `fail2ban-regex` stops working on invalid (wrong encoded) character
+     for python version < 3.x (gh-1248)
 
 - New Features:
    * New filters:

--- a/bin/fail2ban-regex
+++ b/bin/fail2ban-regex
@@ -84,8 +84,14 @@ def file_lines_gen(hdlr):
 		try:
 			line = line.decode(fail2banRegex.encoding, 'strict')
 		except UnicodeDecodeError:
-			if sys.version_info >= (3,): # Python 3 must be decoded
-				line = line.decode(fail2banRegex.encoding, 'ignore')
+			logSys.warning(
+				"Error decoding line from '%s' with '%s'."
+				" Consider setting logencoding=utf-8 (or another appropriate"
+				" encoding) for this jail. Continuing"
+				" to process line ignoring invalid characters: %r" %
+				('<LOG>', fail2banRegex.encoding, line))
+			# decode with replacing error chars:
+			line = line.decode(fail2banRegex.encoding, 'replace')
 		yield line
 
 def journal_lines_gen(myjournal):

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -822,7 +822,7 @@ def get_monitor_failures_journal_testcase(Filter_): # pragma: systemd no cover
 	return MonitorJournalFailures
 
 
-class GetFailures(unittest.TestCase):
+class GetFailures(LogCaptureTestCase):
 
 	FILENAME_01 = os.path.join(TEST_FILES_DIR, "testcase01.log")
 	FILENAME_02 = os.path.join(TEST_FILES_DIR, "testcase02.log")
@@ -837,6 +837,7 @@ class GetFailures(unittest.TestCase):
 
 	def setUp(self):
 		"""Call before every test case."""
+		LogCaptureTestCase.setUp(self)
 		setUpMyTime()
 		self.jail = DummyJail()
 		self.filter = FileFilter(self.jail)
@@ -848,6 +849,7 @@ class GetFailures(unittest.TestCase):
 	def tearDown(self):
 		"""Call after every test case."""
 		tearDownMyTime()
+		LogCaptureTestCase.tearDown(self)
 
 	def testTail(self):
 		self.filter.addLogPath(GetFailures.FILENAME_01, tail=True)
@@ -929,20 +931,20 @@ class GetFailures(unittest.TestCase):
 			output = ('192.0.2.0', 3, 1421262060.0)
 			failregex = "^\s*user \"[^\"]*\" from \"<HOST>\"\s*$"
 
-			# encoding - auto
-			self.filter.addLogPath(fname)
-			self.filter.addFailRegex(failregex)
-			self.filter.getFailures(fname)
-			_assert_correct_last_attempt(self, self.filter, output)
-
-			# test direct set of encoding:
-			for enc in ('utf-8', 'ascii'):
-				self.tearDown();self.setUp();
-				self.filter.setLogEncoding('utf-8');
+			# test encoding auto or direct set of encoding:
+			for enc in (None, 'utf-8', 'ascii'):
+				if enc is not None:
+					self.tearDown();self.setUp();
+					self.filter.setLogEncoding(enc);
+				self.assertNotLogged('Error decoding line');
 				self.filter.addLogPath(fname)
 				self.filter.addFailRegex(failregex)
 				self.filter.getFailures(fname)
 				_assert_correct_last_attempt(self, self.filter, output)
+				
+				self.assertLogged('Error decoding line');
+				self.assertLogged('Continuing to process line ignoring invalid characters:', '2015-01-14 20:00:58 user ');
+				self.assertLogged('Continuing to process line ignoring invalid characters:', '2015-01-14 20:00:59 user ');
 
 		finally:
 			_killfile(fout, fname)


### PR DESCRIPTION
continuing to process line ignoring invalid characters (still has no test cases);
filter test cases added for same issue inside fail2ban-server / fail2ban-testcases;
closes gh-1248