### PR TITLE
fail2ban-regex coverage

### DIFF
--- a/bin/fail2ban-regex
+++ b/bin/fail2ban-regex
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: t -*-
+# vi: set ft=python sts=4 ts=4 sw=4 noet :
+#
+# This file is part of Fail2Ban.
+#
+# Fail2Ban is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Fail2Ban is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Fail2Ban; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""
+Fail2Ban  reads log file that contains password failure report
+and bans the corresponding IP addresses using firewall rules.
+
+This tools can test regular expressions for "fail2ban".
+
+"""
+
+__author__ = "Fail2Ban Developers"
+__copyright__ = "Copyright (c) 2004-2008 Cyril Jaquier, 2012-2014 Yaroslav Halchenko"
+__license__ = "GPL"
+
+from fail2ban.client.fail2banregex import exec_command_line
+
+exec_command_line()

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -792,22 +792,26 @@ class FileContainer:
 		self.__handler.seek(self.__pos)
 		return True
 
-	def readline(self):
-		if self.__handler is None:
-			return ""
-		line = self.__handler.readline()
+	@staticmethod
+	def decode_line(filename, enc, line):
 		try:
-			line = line.decode(self.getEncoding(), 'strict')
+			line = line.decode(enc, 'strict')
 		except UnicodeDecodeError:
 			logSys.warning(
 				"Error decoding line from '%s' with '%s'."
 				" Consider setting logencoding=utf-8 (or another appropriate"
 				" encoding) for this jail. Continuing"
 				" to process line ignoring invalid characters: %r" %
-				(self.getFileName(), self.getEncoding(), line))
+				(filename, enc, line))
 			# decode with replacing error chars:
-			line = line.decode(self.getEncoding(), 'replace')
+			line = line.decode(enc, 'replace')
 		return line
+
+	def readline(self):
+		if self.__handler is None:
+			return ""
+		return FileContainer.decode_line(
+			self.getFileName(), self.getEncoding(), self.__handler.readline())
 
 	def close(self):
 		if not self.__handler is None:

--- a/fail2ban/tests/fail2banregextestcase.py
+++ b/fail2ban/tests/fail2banregextestcase.py
@@ -1,0 +1,155 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: t -*-
+# vi: set ft=python sts=4 ts=4 sw=4 noet :
+
+# This file is part of Fail2Ban.
+#
+# Fail2Ban is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Fail2Ban is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Fail2Ban; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+# Fail2Ban developers
+
+__author__ = "Serg Brester"
+__copyright__ = "Copyright (c) 2015 Serg G. Brester (sebres), 2008- Fail2Ban Contributors"
+__license__ = "GPL"
+
+from __builtin__ import open as fopen
+import unittest
+import getpass
+import os
+import sys
+import time
+import tempfile
+import uuid
+
+try:
+	from systemd import journal
+except ImportError:
+	journal = None
+
+from ..client import fail2banregex
+from ..client.fail2banregex import Fail2banRegex, get_opt_parser, output
+from .utils import LogCaptureTestCase, logSys
+
+
+fail2banregex.logSys = logSys
+def _test_output(*args):
+	logSys.info(args[0])
+
+fail2banregex.output = _test_output
+
+CONF_FILES_DIR = os.path.abspath(
+	os.path.join(os.path.dirname(__file__),"..", "..", "config"))
+TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "files")
+
+
+def _Fail2banRegex(*args):
+	parser = get_opt_parser()
+	(opts, args) = parser.parse_args(list(args))
+	return (opts, args, Fail2banRegex(opts))
+
+class Fail2banRegexTest(LogCaptureTestCase):
+
+	FILENAME_01 = os.path.join(TEST_FILES_DIR, "testcase01.log")
+	FILENAME_02 = os.path.join(TEST_FILES_DIR, "testcase02.log")
+	FILENAME_WRONGCHAR = os.path.join(TEST_FILES_DIR, "testcase-wrong-char.log")
+
+	FILTER_SSHD = os.path.join(CONF_FILES_DIR, 'filter.d', 'sshd.conf')
+
+	def setUp(self):
+		"""Call before every test case."""
+		LogCaptureTestCase.setUp(self)
+
+	def tearDown(self):
+		"""Call after every test case."""
+		LogCaptureTestCase.tearDown(self)
+
+	def testWrongRE(self):
+		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"test", r".** from <HOST>$"
+		)
+		self.assertRaises(Exception, lambda: fail2banRegex.start(opts, args))
+		self.assertLogged("Unable to compile regular expression")
+
+	def testWrongIngnoreRE(self):
+		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"test", r".*? from <HOST>$", r".**"
+		)
+		self.assertRaises(Exception, lambda: fail2banRegex.start(opts, args))
+		self.assertLogged("Unable to compile regular expression")
+
+	def testDirectFound(self):
+		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--print-all-matched", "--print-no-missed",
+			"Dec 31 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 192.0.2.0",
+			r"Authentication failure for .*? from <HOST>$"
+		)
+		self.assertTrue(fail2banRegex.start(opts, args))
+		self.assertLogged('Lines: 1 lines, 0 ignored, 1 matched, 0 missed')
+
+	def testDirectNotFound(self):
+		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--print-all-missed",
+			"Dec 31 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 192.0.2.0",
+			r"XYZ from <HOST>$"
+		)
+		self.assertTrue(fail2banRegex.start(opts, args))
+		self.assertLogged('Lines: 1 lines, 0 ignored, 0 matched, 1 missed')
+
+	def testDirectIgnored(self):
+		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--print-all-ignored",
+			"Dec 31 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 192.0.2.0",
+			r"Authentication failure for .*? from <HOST>$",
+			r"kevin from 192.0.2.0$"
+		)
+		self.assertTrue(fail2banRegex.start(opts, args))
+		self.assertLogged('Lines: 1 lines, 1 ignored, 0 matched, 0 missed')
+
+	def testDirectRE_1(self):
+		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--print-all-matched",
+			Fail2banRegexTest.FILENAME_01, 
+			r"(?:(?:Authentication failure|Failed [-/\w+]+) for(?: [iI](?:llegal|nvalid) user)?|[Ii](?:llegal|nvalid) user|ROOT LOGIN REFUSED) .*(?: from|FROM) <HOST>"
+		)
+		self.assertTrue(fail2banRegex.start(opts, args))
+		self.assertLogged('Lines: 19 lines, 0 ignored, 13 matched, 6 missed')
+
+		self.assertLogged('Error decoding line');
+		self.assertLogged('Continuing to process line ignoring invalid characters')
+
+		self.assertLogged('Dez 31 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 193.168.0.128')
+		self.assertLogged('Dec 31 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 87.142.124.10')
+
+	def testDirectRE_2(self):
+		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--print-all-matched",
+			Fail2banRegexTest.FILENAME_02, 
+			r"(?:(?:Authentication failure|Failed [-/\w+]+) for(?: [iI](?:llegal|nvalid) user)?|[Ii](?:llegal|nvalid) user|ROOT LOGIN REFUSED) .*(?: from|FROM) <HOST>"
+		)
+		self.assertTrue(fail2banRegex.start(opts, args))
+		self.assertLogged('Lines: 13 lines, 0 ignored, 5 matched, 8 missed')
+
+	def testWronChar(self):
+		(opts, args, fail2banRegex) = _Fail2banRegex(
+			Fail2banRegexTest.FILENAME_WRONGCHAR, Fail2banRegexTest.FILTER_SSHD
+		)
+		self.assertTrue(fail2banRegex.start(opts, args))
+		self.assertLogged('Lines: 4 lines, 0 ignored, 2 matched, 2 missed')
+
+		self.assertLogged('Error decoding line');
+		self.assertLogged('Continuing to process line ignoring invalid characters:', '2015-01-14 20:00:58 user ');
+		self.assertLogged('Continuing to process line ignoring invalid characters:', '2015-01-14 20:00:59 user ');
+
+		self.assertLogged('Nov  8 00:16:12 main sshd[32548]: input_userauth_request: invalid user llinco')
+		self.assertLogged('Nov  8 00:16:12 main sshd[32547]: pam_succeed_if(sshd:auth): error retrieving information about user llinco')

--- a/fail2ban/tests/files/testcase-wrong-char.log
+++ b/fail2ban/tests/files/testcase-wrong-char.log
@@ -1,0 +1,4 @@
+Nov  8 00:16:12 main sshd[32547]: Invalid user llinco\361ir from 192.0.2.0
+Nov  8 00:16:12 main sshd[32548]: input_userauth_request: invalid user llinco\361ir
+Nov  8 00:16:12 main sshd[32547]: pam_succeed_if(sshd:auth): error retrieving information about user llincoñir
+Nov  8 00:16:14 main sshd[32547]: Failed password for invalid user llinco\361ir from 192.0.2.0 port 57025 ssh2

--- a/fail2ban/tests/utils.py
+++ b/fail2ban/tests/utils.py
@@ -85,6 +85,7 @@ def gatherTests(regexps=None, no_network=False):
 	from . import misctestcase
 	from . import databasetestcase
 	from . import samplestestcase
+	from . import fail2banregextestcase
 
 	if not regexps: # pragma: no cover
 		tests = unittest.TestSuite()
@@ -151,6 +152,9 @@ def gatherTests(regexps=None, no_network=False):
 	tests.addTest(unittest.makeSuite(datedetectortestcase.DateDetectorTest))
 	# Filter Regex tests with sample logs
 	tests.addTest(unittest.makeSuite(samplestestcase.FilterSamplesRegex))
+
+	# bin/fail2ban-regex
+	tests.addTest(unittest.makeSuite(fail2banregextestcase.Fail2banRegexTest))
 
 	#
 	# Python action testcases


### PR DESCRIPTION
fail2ban-regex moved to the client + test cases for initial coverage added;
small fixes (debuggexURL on wrong encoded chars, etc.)
based on #1249 (because was not covered at all)

Initially `fail2ban-regex` was renamed into `client/fail2banregex.py`, see 0877d662287bb74cb403c0159841dbbafda28c08.

All other changes are relevant to the coverage.