### PR TITLE
Added PartOf to service file so f2b restarts when deps do

### DIFF
--- a/files/fail2ban.service
+++ b/files/fail2ban.service
@@ -2,6 +2,7 @@
 Description=Fail2Ban Service
 Documentation=man:fail2ban(1)
 After=network.target iptables.service firewalld.service
+PartOf=iptables.service firewalld.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
If `iptables` restarts the jails aren't re-created automatically and the rules are not re-added until fail2ban restarts. Adding `PartOf`[1] solves this by restarting `fail2ban` whenever `iptables` is restarted. I added `firewalld` to the `PartOf` command since that might resolve #1005 but I'm not sure since we don't use that.

If there's a better way to achieve this, please let me know.

[1] http://www.freedesktop.org/software/systemd/man/systemd.unit.html#PartOf=