### PR TITLE
Small fixes for Gentoo initd script

### DIFF
--- a/files/gentoo-initd
+++ b/files/gentoo-initd
@@ -30,14 +30,10 @@ depend() {
 
 start() {
 	ebegin "Starting fail2ban"
-	if [ ! -d /var/run/fail2ban ]; then
-		mkdir /var/run/fail2ban || return 1
-	fi
-	if [ -e /var/run/fail2ban/fail2ban.sock ]; then
-		# remove stalled sock file after system crash
-		# bug 347477
-		rm -rf /var/run/fail2ban/fail2ban.sock || return 1
-	fi
+	mkdir -p /var/run/fail2ban || return 1
+	# remove stalled sock file after system crash
+	# bug 347477
+	rm -f /var/run/fail2ban/fail2ban.sock || return 1
 	${FAIL2BAN} start &> /dev/null
 	eend $? "Failed to start fail2ban"
 }


### PR DESCRIPTION
These fixes are pretty pedantic, but they do simplify the script a
little.

* Checking the existence of a file/directory before creating/deleting
  it adds complexity and raciness.  There are better options.
* mkdir -p does the job of making sure a directory exists.  (It only
  fails if there's a filesystem error or something.)
* Likewise, rm -f doesn't fail if the file doesn't exist.
* rm -r isn't neccessary because the socket shouldn't be a directory.
  (If it is for some reason, that should be an error.)