### PR TITLE
ENH+BF: Provide <fail2ban-agent-string> tag

### DIFF
--- a/config/action.d/badips.conf
+++ b/config/action.d/badips.conf
@@ -10,7 +10,7 @@
 
 [Definition]
 
-actionban = curl --fail  --user-agent "fail2ban v0.8.12" http://www.badips.com/add/<category>/<ip>
+actionban = curl --fail  --user-agent "<fail2ban-agent-string>" http://www.badips.com/add/<category>/<ip>
 
 [Init]
 

--- a/config/action.d/blocklist_de.conf
+++ b/config/action.d/blocklist_de.conf
@@ -54,7 +54,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = curl --fail --data-urlencode 'server=<email>' --data 'apikey=<apikey>' --data 'service=<service>' --data 'ip=<ip>' --data-urlencode 'logs=<matches>' --data 'format=text' --user-agent "fail2ban v0.8.12" "https://www.blocklist.de/en/httpreports.html"
+actionban = curl --fail --data-urlencode 'server=<email>' --data 'apikey=<apikey>' --data 'service=<service>' --data 'ip=<ip>' --data-urlencode 'logs=<matches>' --data 'format=text' --user-agent "<fail2ban-agent-string>" "https://www.blocklist.de/en/httpreports.html"
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the

--- a/fail2ban/server/action.py
+++ b/fail2ban/server/action.py
@@ -101,6 +101,10 @@ class CallingMap(MutableMapping):
 	def copy(self):
 		return self.__class__(self.data.copy())
 
+	def update(self, values):
+		"""Update content with items from another container"""
+		self.data.update(values)
+
 
 class ActionBase(object):
 	"""An abstract base class for actions in Fail2Ban.

--- a/fail2ban/tests/actionstestcase.py
+++ b/fail2ban/tests/actionstestcase.py
@@ -33,6 +33,8 @@ from ..server.ticket import FailTicket
 from .dummyjail import DummyJail
 from .utils import LogCaptureTestCase
 
+from ..version import agent_string
+
 TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "files")
 
 
@@ -165,3 +167,9 @@ class ExecuteActions(LogCaptureTestCase):
 		self.assertNotLogged("Failed to execute unban")
 		self.assertLogged("action1 unban deleted aInfo IP")
 		self.assertLogged("action2 unban deleted aInfo IP")
+
+	def test_prepare_aInfo(self):
+		ticket = FailTicket("1.2.3.4", 0)
+		aInfo = self.__jail.actions._prepare_aInfo(ticket)
+		self.assertEqual(aInfo['ip'], '1.2.3.4')
+		self.assertEqual(aInfo['fail2ban-agent-string'], agent_string)

--- a/fail2ban/version.py
+++ b/fail2ban/version.py
@@ -25,3 +25,5 @@ __copyright__ = "Copyright (c) 2004 Cyril Jaquier, 2005-2015 Yaroslav Halchenko,
 __license__ = "GPL-v2+"
 
 version = "0.9.3.dev"
+
+agent_string = "Fail2Ban %s" % version

--- a/fail2ban/version.py
+++ b/fail2ban/version.py
@@ -26,4 +26,5 @@ __license__ = "GPL-v2+"
 
 version = "0.9.3.dev"
 
-agent_string = "Fail2Ban %s" % version
+# Format https://tools.ietf.org/html/rfc7231#section-5.5.3
+agent_string = "Fail2Ban/%s" % version


### PR DESCRIPTION
Was crafted to resolve #1271 but actually not sure now if is worth this approach over "let's execute fail2ban-client version" and define that variable for string interpolations in e.g. actions/common.conf