### PR TITLE
ENH: log at heavydebug level what actually we are matching for failregex

### DIFF
--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -491,6 +491,7 @@ class Filter(JailThread):
 
 		self.__lineBuffer = (
 			self.__lineBuffer + [tupleLine])[-self.__lineBufferSize:]
+		logSys.log(5, "Looking for failregex match of %r" % self.__lineBuffer)
 
 		# Iterates over all the regular expressions.
 		for failRegexIndex, failRegex in enumerate(self.__failRegex):


### PR DESCRIPTION
Just found it useful while troubleshooting using fail2ban-regex