### PR TITLE
ENH: harmonize jail.conf + 1 more test that passed bantime is non-degenerate and int

### DIFF
--- a/config/jail.conf
+++ b/config/jail.conf
@@ -240,7 +240,6 @@ backend  = %(dropbear_backend)s
 
 port     = ssh
 logpath  = %(auditd_log)s
-maxretry = 5
 
 
 #
@@ -266,7 +265,6 @@ maxretry = 1
 
 port     = http,https
 logpath  = %(apache_error_log)s
-maxretry = 6
 
 
 [apache-overflows]
@@ -304,17 +302,20 @@ port     = http,https
 logpath  = %(apache_error_log)s
 maxretry = 2
 
+
 [apache-shellshock]
 
 port    = http,https
 logpath = %(apache_error_log)s
 maxretry = 1
 
+
 [openhab-auth]
 
 filter = openhab
 action = iptables-allports[name=NoAuthFailures]
 logpath = /opt/openhab/logs/request.log
+
 
 [nginx-http-auth]
 
@@ -334,6 +335,7 @@ logpath = %(nginx_error_log)s
 port     = http,https
 logpath  = %(nginx_error_log)s
 maxretry = 2
+
 
 # Ban attackers that try to use PHP's URL-fopen() functionality
 # through GET/POST variables. - Experimental, with more than a year
@@ -399,7 +401,6 @@ logpath  = /var/log/sogo/sogo.log
 
 logpath  = /var/log/tine20/tine20.log
 port     = http,https
-maxretry = 5
 
 
 #
@@ -420,7 +421,6 @@ logpath  = /var/log/tomcat*/catalina.out
 
 [monit]
 #Ban clients brute-forcing the monit gui login
-filter   = monit
 port = 2812
 logpath  = /var/log/monit
 
@@ -473,7 +473,6 @@ backend  = %(proftpd_backend)s
 port     = ftp,ftp-data,ftps,ftps-data
 logpath  = %(pureftpd_log)s
 backend  = %(pureftpd_backend)s
-maxretry = 6
 
 
 [gssftpd]
@@ -481,7 +480,6 @@ maxretry = 6
 port     = ftp,ftp-data,ftps,ftps-data
 logpath  = %(syslog_daemon)s
 backend  = %(syslog_backend)s
-maxretry = 6
 
 
 [wuftpd]
@@ -489,7 +487,6 @@ maxretry = 6
 port     = ftp,ftp-data,ftps,ftps-data
 logpath  = %(wuftpd_log)s
 backend  = %(wuftpd_backend)s
-maxretry = 6
 
 
 [vsftpd]
@@ -724,7 +721,6 @@ maxretry = 10
 port     = 3306
 logpath  = %(mysql_log)s
 backend  = %(mysql_backend)s
-maxretry = 5
 
 
 # Jail for more extended banning of persistent abusers
@@ -740,7 +736,6 @@ logpath  = /var/log/fail2ban.log
 banaction = %(banaction_allports)s
 bantime  = 604800  ; 1 week
 findtime = 86400   ; 1 day
-maxretry = 5
 
 
 # Generic filter for PAM. Has to be used with action which bans all
@@ -786,7 +781,6 @@ action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp
 # nobody except your own Nagios server should ever probe nrpe
 [nagios]
 
-enabled  = false
 logpath  = %(syslog_daemon)s     ; nrpe.cfg may define a different log_facility
 backend  = %(syslog_backend)s
 maxretry = 1
@@ -794,18 +788,14 @@ maxretry = 1
 
 [oracleims]
 # see "oracleims" filter file for configuration requirement for Oracle IMS v6 and above
-enabled = false
 logpath = /opt/sun/comms/messaging64/log/mail.log_current
-maxretry = 6
 banaction = %(banaction_allports)s
 
 [directadmin]
-enabled = false
 logpath = /var/log/directadmin/login.log
 port = 2222
 
 [portsentry]
-enabled  = false
 logpath  = /var/lib/portsentry/portsentry.history
 maxretry = 1
 
@@ -826,16 +816,12 @@ findtime     = 1
 [murmur]
 # AKA mumble-server
 port     = 64738
-filter   = murmur
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol=tcp, chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol=udp, chain="%(chain)s", actname=%(banaction)s-udp]
 logpath  = /var/log/mumble-server/mumble-server.log
 
 
-[screensharing]
+[screensharingd]
 # For Mac OS Screen Sharing Service (VNC)
-enabled  = false
-filter   = screensharingd
 logpath  = /var/log/system.log
-logencoding=utf-8
-maxretry = 4
+logencoding = utf-8

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -594,6 +594,12 @@ class JailsReaderTest(LogCaptureTestCase):
 			# by default we have lots of jails ;)
 			self.assertTrue(len(comm_commands))
 
+			# some common sanity checks for commands
+			for command in comm_commands:
+				if len(command) >= 3 and [command[0], command[2]] == ['set', 'bantime']:
+					self.assertTrue(isinstance(command[3], int))
+					self.assertTrue(command[3] > 0)
+
 			# and we know even some of them by heart
 			for j in ['sshd', 'recidive']:
 				# by default we have 'auto' backend ATM


### PR DESCRIPTION
- there is no need for maxretry ~= 5 in each jail
- separate jails for different services with 2 empty lines
- no need for explicit filter specification if matches jail name
- renamed jail introduced in #1232 to match filter and thus remove explicit filter name

also had worries that bantime with ';' comment might be screwed in Python 3 so added a unittest for that  (didn't run locally -- let travis test it)