### PR TITLE
ENH+BF: Provide `fail2ban_agent` and `fail2ban_version` config options

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,7 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
      for python version < 3.x (gh-1248)
    * Use postfix_log logpath for postfix-rbl jail
    * filters.d/postfix.conf - add 'Sender address rejected: Domain not found' failregex
+   * use `fail2ban_agent` as user-agent in actions badips, blocklist_de, etc (gh-1271)
 
 - New Features:
    * New interpolation feature for definition config readers - `<known/parameter>`
@@ -72,6 +73,8 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
      operations. Thanks @kshetragia
    * Specified that fail2ban is PartOf iptables.service firewalld.service in
      .service file -- would reload fail2ban if those services are restarted
+   * Provides new default `fail2ban_version` and interpolation variable
+     `fail2ban_agent` in jail.conf
 
 
 ver. 0.9.3 (2015/08/01) - lets-all-stay-friends

--- a/config/action.d/badips.conf
+++ b/config/action.d/badips.conf
@@ -10,7 +10,7 @@
 
 [Definition]
 
-actionban = curl --fail  --user-agent "fail2ban v0.8.12" http://www.badips.com/add/<category>/<ip>
+actionban = curl --fail  --user-agent "<agent>" http://www.badips.com/add/<category>/<ip>
 
 [Init]
 

--- a/config/action.d/badips.py
+++ b/config/action.d/badips.py
@@ -32,7 +32,6 @@ else:
 	from urllib import urlencode
 
 from fail2ban.server.actions import ActionBase
-from fail2ban.version import version as f2bVersion
 
 
 class BadIPsAction(ActionBase):
@@ -86,10 +85,10 @@ class BadIPsAction(ActionBase):
 		return Request(url, headers={'User-Agent': self.agent}, **argv)
 
 	def __init__(self, jail, name, category, score=3, age="24h", key=None,
-		banaction=None, bancategory=None, bankey=None, updateperiod=900, agent=None):
+		banaction=None, bancategory=None, bankey=None, updateperiod=900, agent="Fail2Ban"):
 		super(BadIPsAction, self).__init__(jail, name)
 
-		self.agent = agent if agent is not None else ("Fail2Ban/%s" % f2bVersion)
+		self.agent = agent
 		self.category = category
 		self.score = score
 		self.age = age

--- a/config/action.d/badips.py
+++ b/config/action.d/badips.py
@@ -21,7 +21,6 @@ import sys
 if sys.version_info < (2, 7):
 	raise ImportError("badips.py action requires Python >= 2.7")
 import json
-from functools import partial
 import threading
 import logging
 if sys.version_info >= (3, ):
@@ -72,6 +71,9 @@ class BadIPsAction(ActionBase):
 	updateperiod : int, optional
 		Time in seconds between updating bad IPs blacklist.
 		Default 900 (15 minutes)
+	agent : str, optional
+		User agent transmitted to server.
+		Default `Fail2Ban/ver.`
 
 	Raises
 	------
@@ -80,13 +82,14 @@ class BadIPsAction(ActionBase):
 	"""
 
 	_badips = "http://www.badips.com"
-	_Request = partial(
-		Request, headers={'User-Agent': "Fail2Ban %s" % f2bVersion})
+	def _Request(self, url, **argv):
+		return Request(url, headers={'User-Agent': self.agent}, **argv)
 
 	def __init__(self, jail, name, category, score=3, age="24h", key=None,
-		banaction=None, bancategory=None, bankey=None, updateperiod=900):
+		banaction=None, bancategory=None, bankey=None, updateperiod=900, agent=None):
 		super(BadIPsAction, self).__init__(jail, name)
 
+		self.agent = agent if agent is not None else ("Fail2Ban/%s" % f2bVersion)
 		self.category = category
 		self.score = score
 		self.age = age

--- a/config/action.d/blocklist_de.conf
+++ b/config/action.d/blocklist_de.conf
@@ -54,7 +54,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = curl --fail --data-urlencode 'server=<email>' --data 'apikey=<apikey>' --data 'service=<service>' --data 'ip=<ip>' --data-urlencode 'logs=<matches>' --data 'format=text' --user-agent "fail2ban v0.8.12" "https://www.blocklist.de/en/httpreports.html"
+actionban = curl --fail --data-urlencode 'server=<email>' --data 'apikey=<apikey>' --data 'service=<service>' --data 'ip=<ip>' --data-urlencode 'logs=<matches>' --data 'format=text' --user-agent "<agent>" "https://www.blocklist.de/en/httpreports.html"
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the

--- a/config/action.d/mynetwatchman.conf
+++ b/config/action.d/mynetwatchman.conf
@@ -111,13 +111,17 @@ myip = `ip -4 addr show dev eth0 | grep inet | head -n 1 | sed -r 's/.*inet ([0-
 #
 protocol = tcp
 
+# Option:  agent
+# Default: Fail2ban
+agent = Fail2ban
+
 # Option:  getcmd
 # Notes.:  A command to fetch a URL. Should output page to STDOUT
 # Values:  CMD  Default: wget
 #
-getcmd = wget --no-verbose --tries=3 --waitretry=10 --connect-timeout=10 --read-timeout=60 --retry-connrefused --output-document=- --user-agent=Fail2Ban
+getcmd = wget --no-verbose --tries=3 --waitretry=10 --connect-timeout=10 --read-timeout=60 --retry-connrefused --output-document=- --user-agent=<agent>
 # Alternative value:
-# getcmd = curl --silent --show-error --retry 3 --connect-timeout 10 --max-time 60 --user-agent Fail2Ban
+# getcmd = curl --silent --show-error --retry 3 --connect-timeout 10 --max-time 60 --user-agent <agent>
 
 # Option:  srcport
 # Notes.:  The source port of the attack. You're unlikely to have this info, so

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -146,6 +146,9 @@ chain = INPUT
 # Usually should be overridden in a particular jail
 port = 0:65535
 
+# Format of user-agent https://tools.ietf.org/html/rfc7231#section-5.5.3
+fail2ban_agent = Fail2Ban/%(fail2ban_version)s
+
 #
 # Action shortcuts. To be used to define action parameter
 
@@ -187,7 +190,7 @@ action_cf_mwl = cloudflare[cfuser="%(cfemail)s", cftoken="%(cfapikey)s"]
 # [Init]
 # blocklist_de_apikey = {api key from registration]
 #
-action_blocklist_de  = blocklist_de[email="%(sender)s", service=%(filter)s, apikey="%(blocklist_de_apikey)s"]
+action_blocklist_de  = blocklist_de[email="%(sender)s", service=%(filter)s, apikey="%(blocklist_de_apikey)s", agent="%(fail2ban_agent)s"]
 
 # Report ban via badips.com, and use as blacklist
 #
@@ -197,7 +200,11 @@ action_blocklist_de  = blocklist_de[email="%(sender)s", service=%(filter)s, apik
 # NOTE: This action relies on banaction being present on start and therefore
 # should be last action defined for a jail.
 #
-action_badips = badips.py[category="%(name)s", banaction="%(banaction)s"]
+action_badips = badips.py[category="%(__name__)s", banaction="%(banaction)s", agent="%(fail2ban_agent)s"]
+#
+# Report ban via badips.com (uses action.d/badips.conf for reporting only)
+#
+action_badips_report = badips[category="%(__name__)s", agent="%(fail2ban_agent)s"]
 
 # Choose default action.  To change, just override value of 'action' with the
 # interpolation to the chosen action shortcut (e.g.  action_mw, action_mwl, etc) in jail.local

--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -32,6 +32,7 @@ import re
 from .configreader import ConfigReaderUnshared, ConfigReader
 from .filterreader import FilterReader
 from .actionreader import ActionReader
+from ..version import version
 from ..helpers import getLogger
 from ..helpers import splitcommaspace
 
@@ -107,6 +108,10 @@ class JailReader(ConfigReader):
 				["string", "ignoreip", None],
 				["string", "filter", ""],
 				["string", "action", ""]]
+
+		# Before interpolation (substitution) add static options always available as default:
+		defsec = self._cfg.get_defaults()
+		defsec["fail2ban_version"] = version
 
 		# Read first options only needed for merge defaults ('known/...' from filter):
 		self.__opts = ConfigReader.getOptions(self, self.__name, opts1st)


### PR DESCRIPTION
Provides fail2ban version to jail (as interpolation variable during parse of jail.conf);
BF: use `fail2ban_agent` as user-agent in actions badips, blocklist_de, etc. (closes #1271, closes #1272)