### PR TITLE
gentoo-initd: do not hide useful output

### DIFF
--- a/files/gentoo-initd
+++ b/files/gentoo-initd
@@ -34,19 +34,19 @@ start() {
 	# remove stalled sock file after system crash
 	# bug 347477
 	rm -f /var/run/fail2ban/fail2ban.sock || return 1
-	${FAIL2BAN} start &> /dev/null
+	${FAIL2BAN} start
 	eend $? "Failed to start fail2ban"
 }
 
 stop() {
 	ebegin "Stopping fail2ban"
-	${FAIL2BAN} stop &> /dev/null
+	${FAIL2BAN} stop
 	eend $? "Failed to stop fail2ban"
 }
 
 reload() {
 	ebegin "Reloading fail2ban"
-	${FAIL2BAN} reload > /dev/null
+	${FAIL2BAN} reload
 	eend $? "Failed to reload fail2ban"
 }
 


### PR DESCRIPTION
Gentoo has been applying a patch to work around this issue: https://bugs.gentoo.org/show_bug.cgi?id=536320
It would be nice if we could drop it.