### PR TITLE
Remove compression and count from logrotate

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,8 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
    * filters.d/postfix.conf - add 'Sender address rejected: Domain not found' failregex
    * use `fail2ban_agent` as user-agent in actions badips, blocklist_de, etc (gh-1271)
    * Fix ignoring the sender option by action_mw, action_mwl and action_c_mwl
+   * Remove compression and rotation count from logrotate (inherit them from
+     the global logrotate config)
 
 - New Features:
    * New interpolation feature for definition config readers - `<known/parameter>`

--- a/files/fail2ban-logrotate
+++ b/files/fail2ban-logrotate
@@ -6,11 +6,9 @@
 # https://github.com/fail2ban/fail2ban/blob/debian/debian/fail2ban.logrotate
 
 /var/log/fail2ban.log {
-    rotate 7
     missingok
     notifempty
-    compress
     postrotate
-      /usr/bin/fail2ban-client flushlogs  1>/dev/null || true
+      /usr/bin/fail2ban-client flushlogs >/dev/null || true
     endscript
 }


### PR DESCRIPTION
Initially reported at https://bugs.gentoo.org/show_bug.cgi?id=549856
As the reporter mentioned, the `count` parameter means logs are deleted regardless of the global logrotate config; the compression setting should also inherit the global defaults.