### PR TITLE
Add a regex into postfix.conf filter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -79,6 +79,7 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
      .service file -- would reload fail2ban if those services are restarted
    * Provides new default `fail2ban_version` and interpolation variable
      `fail2ban_agent` in jail.conf
+   * Enhance filter 'postfix' to ban incoming SMTP client with no fqdn hostname
 
 
 ver. 0.9.3 (2015/08/01) - lets-all-stay-friends

--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -15,6 +15,7 @@ _daemon = postfix/(submission/)?smtp(d|s)
 failregex = ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 554 5\.7\.1 .*$
             ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 450 4\.7\.1 Client host rejected: cannot find your hostname, (\[\S*\]); from=<\S*> to=<\S+> proto=ESMTP helo=<\S*>$
             ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 450 4\.7\.1 : Helo command rejected: Host not found; from=<> to=<> proto=ESMTP helo= *$
+            ^%(__prefix_line)sNOQUEUE: reject: EHLO from \S+\[<HOST>\]: 504 5\.5\.2 <\S+>: Helo command rejected: need fully-qualified hostname; proto=SMTP helo=<\S+> *$
             ^%(__prefix_line)sNOQUEUE: reject: VRFY from \S+\[<HOST>\]: 550 5\.1\.1 .*$
             ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 450 4\.1\.8 <\S*>: Sender address rejected: Domain not found; from=<\S*> to=<\S+> proto=ESMTP helo=<\S*>$
             ^%(__prefix_line)simproper command pipelining after \S+ from [^[]*\[<HOST>\]:?$

--- a/fail2ban/tests/files/logs/postfix
+++ b/fail2ban/tests/files/logs/postfix
@@ -26,3 +26,6 @@ Dec 21 21:17:29 xxx postfix/smtpd[7150]: NOQUEUE: reject: RCPT from badserver.ex
 
 # failJSON: { "time": "2004-11-22T22:33:44", "match": true , "host": "1.2.3.4" }
 Nov 22 22:33:44 xxx postfix/smtpd[11111]: NOQUEUE: reject: RCPT from 1-2-3-4.example.com[1.2.3.4]: 450 4.1.8 <some@nonexistant.tld>: Sender address rejected: Domain not found; from=<some@nonexistant.tld> to=<goodguy@example.com> proto=ESMTP helo=<1-2-3-4.example.com>
+
+# failJSON: { "time": "2016-01-31T13:55:24", "match": true , "host": "78.107.251.238" }
+Jan 31 13:55:24 xxx postfix/smtpd[3462]: NOQUEUE: reject: EHLO from s271272.static.corbina.ru[78.107.251.238]: 504 5.5.2 <User>: Helo command rejected: need fully-qualified hostname; proto=SMTP helo=<User>


### PR DESCRIPTION
The new regexp is able to detect bad formatted SMTP EHLO command