### PR TITLE
gentoo-initd: Use start-stop-daemon in order to handle crashes better

### DIFF
--- a/files/gentoo-initd
+++ b/files/gentoo-initd
@@ -34,13 +34,15 @@ start() {
 	# remove stalled sock file after system crash
 	# bug 347477
 	rm -f /var/run/fail2ban/fail2ban.sock || return 1
-	${FAIL2BAN} start
+	start-stop-daemon --start --exec ${FAIL2BAN} start \
+	--pidfile /var/run/fail2ban/fail2ban.pid
 	eend $? "Failed to start fail2ban"
 }
 
 stop() {
 	ebegin "Stopping fail2ban"
-	${FAIL2BAN} stop
+	start-stop-daemon --stop --exec ${FAIL2BAN} stop \
+	--pidfile /var/run/fail2ban/fail2ban.pid
 	eend $? "Failed to stop fail2ban"
 }
 


### PR DESCRIPTION
Currently, if fail2ban is killed (or crashes), its status will be
reported by '/etc/init.d/fail2ban status' as 'running' even though it
is not. Attempting to restart the service also fails, because Gentoo
unsuccessfully tries to stop the service.

By using start-stop-daemon and providing a pidfile, Gentoo will
instead report the status as 'crashed' and allow the service to be
restarted as normal.