### PR TITLE
ENH: use codecov + templates for PRs and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,40 @@
+_Please fill out following information while also paying attention to comments.
+Depending on your issue not all fields might apply -- just remove those which
+do not apply, and remove the comments.  Thanks!_
+
+### Environment:
+
+#### Your OS (including release name/version):
+#### Fail2Ban version:
+
+_If your Fail2Ban version is outdated, and you can't verify that the issue persists in
+the recent release, better seek support from the distribution you obtained Fail2Ban from_
+
+### The issue:
+
+_Summary here_
+
+#### Steps to reproduce
+
+#### Expected behavior
+
+#### Observed behavior
+
+#### Any additional information
+
+### Supplementals
+
+#### Any customizations done to /etc/fail2ban/ configuration
+```
+```
+
+#### Relevant parts of /var/log/fail2ban.log file:
+_preferably obtained while running fail2ban with `loglevel = 4`_
+
+```
+```
+
+#### Relevant lines from monitored log files in question:
+
+```
+```

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,14 +1,23 @@
-_Please fill out following information while also paying attention to comments.
-Depending on your issue not all fields might apply -- just remove those which
-do not apply, and remove the comments.  Thanks!_
+_We will be very grateful, if your problem was described as completely as possible,
+enclosing excerpts from logs (if possible within DEBUG mode, if no errors evident
+within INFO mode), and configuration in particular of effected relevant settings
+(e.g., with ` fail2ban-client -d | grep 'affected-jail-name' ` for a particular
+jail troubleshooting).
+Thank you in advance for the details, because such issues like "It does not work" 
+alone could not help to resolve anything!
+Thanks! (remove this paragraph and other comments upon reading)_
 
 ### Environment:
 
-#### Your OS (including release name/version):
-#### Fail2Ban version:
+_Fill out and check (`[x]`) the boxes which apply. If your Fail2Ban version is outdated, 
+and you can't verify that the issue persists in the recent release, better seek support 
+from the distribution you obtained Fail2Ban from_
 
-_If your Fail2Ban version is outdated, and you can't verify that the issue persists in
-the recent release, better seek support from the distribution you obtained Fail2Ban from_
+- Fail2Ban version (including any possible distribution suffixes):
+- OS, including release name/version: 
+- [ ] Fail2Ban installed via OS/distribution mechanisms
+- [ ] You have not applied any additional foreign patches to the codebase
+- [ ] Some customizations were done to the configuration (provide details below is so)
 
 ### The issue:
 
@@ -22,7 +31,7 @@ _Summary here_
 
 #### Any additional information
 
-### Supplementals
+### Configuration, dump and another helpful excerpts
 
 #### Any customizations done to /etc/fail2ban/ configuration
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+Before submitting your PR, please review the following checklist:
+
+- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
+- [ ] **LIST ISSUES** this PR resolves
+- [ ] **MAKE SURE** this PR doesn't break existing tests 
+- [ ] **KEEP PR small** so it could be easily reviewed.
+- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
+- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines 
+      within `fail2ban/tests/files/logs/X` file

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   #   coverage
   - travis_retry pip install coverage
   #   coveralls
-  - travis_retry pip install coveralls
+  - travis_retry pip install coveralls codecov
   #   dnspython or dnspython3
   - if [[ "$F2B_PY_2" ]]; then travis_retry pip install dnspython; fi
   - if [[ "$F2B_PY_3" ]]; then travis_retry pip install dnspython3; fi
@@ -43,6 +43,7 @@ script:
   - sudo $VENV_BIN/pip install .
 after_success:
   - coveralls
+  - codecov
 matrix:
   fast_finish: true
 # Might be worth looking into

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Code status:
 
 * [![Coverage Status](https://coveralls.io/repos/fail2ban/fail2ban/badge.png?branch=master)](https://coveralls.io/r/fail2ban/fail2ban)
 
+* [![codecov.io](https://codecov.io/github/fail2ban/fail2ban/coverage.svg?branch=master)](https://codecov.io/github/fail2ban/fail2ban?branch=master)
+
 Contact:
 --------
 


### PR DESCRIPTION
codecov is quite neat -- in contrast to coveralls provides browser extensions so you could see what covered in code right by browsing github website.

Templates are new feature, finally, and here you could find pointers to already existing ones for more ideas and improvements:  https://github.com/devspace/awesome-github-templates