### PR TITLE
mysqld: failregex fixed (accepts different log level, more secure expression now)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,7 +15,7 @@ ver. 0.9.4 (2015/XX/XXX) - wanna-be-released
    * filter.d/apache-badbots.conf
      - Updated useragent string regex adding escape for `+`
    * filter.d/mysqld-auth.conf
-     - Updated "Access denied ..." regex for MySQL 5.6 and later (gh-1211)
+     - Updated "Access denied ..." regex for MySQL 5.6 and later (gh-1211, gh-1332)
    * filter.d/sshd.conf
      - Updated "Auth fail" regex for OpenSSH 5.9 and later
    * Treat failed and killed execution of commands identically (only

--- a/config/filter.d/mysqld-auth.conf
+++ b/config/filter.d/mysqld-auth.conf
@@ -17,7 +17,7 @@ before = common.conf
 
 _daemon = mysqld
 
-failregex = ^%(__prefix_line)s(?:\d+ |\d{6} \s?\d{1,2}:\d{2}:\d{2} )?\[Warning\] Access denied for user '\w+'@'<HOST>' (to database '[^']*'|\(using password: (YES|NO)\))*\s*$
+failregex = ^%(__prefix_line)s(?:\d+ |\d{6} \s?\d{1,2}:\d{2}:\d{2} )?\[\w+\] Access denied for user '[^']+'@'<HOST>' 
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/mysqld-auth
+++ b/fail2ban/tests/files/logs/mysqld-auth
@@ -17,3 +17,5 @@ Sep 16 21:30:32 catinthehat mysqld: 130916 21:30:32 [Warning] Access denied for 
 
 # failJSON: { "time": "2015-10-07T06:09:42", "match": true , "host": "127.0.0.1", "desc": "mysql 5.6 log format" }
 2015-10-07 06:09:42 5907 [Warning] Access denied for user 'root'@'127.0.0.1' (using password: YES)
+# failJSON: { "time": "2016-02-24T15:26:18", "match": true , "host": "localhost", "desc": "mysql 5.6 log format, Note instead of Warning" }
+2016-02-24T15:26:18.237955 6 [Note] Access denied for user 'root'@'localhost' (using password: YES)


### PR DESCRIPTION
closes #1332 

Pro rata already "fixed" in #1212 (for issue #1211). 
Here taken into account a different log level: `Note` vs. `Warning`