### PR TITLE
datedetector: epoch time expression fix 

### DIFF
--- a/fail2ban/server/datetemplate.py
+++ b/fail2ban/server/datetemplate.py
@@ -132,7 +132,7 @@ class DateEpoch(DateTemplate):
 
 	def __init__(self):
 		DateTemplate.__init__(self)
-		self.regex = "(?:^|(?P<square>(?<=^\[))|(?P<selinux>(?<=audit\()))\d{10}(?:\.\d{3,6})?(?(selinux)(?=:\d+\))(?(square)(?=\])))"
+		self.regex = r"(?:^|(?P<square>(?<=^\[))|(?P<selinux>(?<=audit\()))\d{10,11}\b(?:\.\d{3,6})?(?:(?(selinux)(?=:\d+\)))|(?(square)(?=\])))"
 
 	def getDate(self, line):
 		"""Method to return the date for a log line.

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -668,7 +668,7 @@ class FileFilter(Filter):
 			logSys.error("Error opening %s" % filename)
 			logSys.exception(e)
 			return False
-		except OSError, e: # pragma: no cover - Requires implemention error in FileContainer to generate
+		except Exception, e: # pragma: no cover - Requires implemention error in FileContainer to generate
 			logSys.error("Internal errror in FileContainer open method - please report as a bug to https://github.com/fail2ban/fail2ban/issues")
 			logSys.exception(e)
 			return False

--- a/fail2ban/tests/datedetectortestcase.py
+++ b/fail2ban/tests/datedetectortestcase.py
@@ -46,13 +46,23 @@ class DateDetectorTest(unittest.TestCase):
 		tearDownMyTime()
 	
 	def testGetEpochTime(self):
-		log = "1138049999 [sshd] error: PAM: Authentication failure"
-		#date = [2006, 1, 23, 21, 59, 59, 0, 23, 0]
-		dateUnix = 1138049999.0
-
-		( datelog, matchlog ) = self.__datedetector.getTime(log)
-		self.assertEqual(datelog, dateUnix)
-		self.assertEqual(matchlog.group(), '1138049999')
+		# correct epoch time, using all variants:
+		for dateUnix in (1138049999, 32535244799):
+			for date in ("%s", "[%s]", "[%s.555]", "audit(%s.555:101)"):
+				date = date % dateUnix
+				log = date + " [sshd] error: PAM: Authentication failure"
+				datelog = self.__datedetector.getTime(log)
+				self.assertTrue(datelog, "Parse epoch time for %s failed" % (date,))
+				( datelog, matchlog ) = datelog
+				self.assertEqual(int(datelog), dateUnix)
+				self.assertIn(matchlog.group(), (str(dateUnix), str(dateUnix)+'.555'))
+		# wrong, no epoch time (< 10 digits, more as 11 digits, begin/end of word) :
+		for dateUnix in ('123456789', '9999999999999999', '1138049999A', 'A1138049999'):
+			for date in ("%s", "[%s]", "[%s.555]", "audit(%s.555:101)"):
+				date = date % dateUnix
+				log = date + " [sshd] error: PAM: Authentication failure"
+				datelog = self.__datedetector.getTime(log)
+				self.assertFalse(datelog)
 	
 	def testGetTime(self):
 		log = "Jan 23 21:59:59 [sshd] error: PAM: Authentication failure"

--- a/fail2ban/tests/utils.py
+++ b/fail2ban/tests/utils.py
@@ -208,6 +208,18 @@ def gatherTests(regexps=None, no_network=False):
 	return tests
 
 
+# forwards compatibility of unittest.TestCase for some early python versions
+if not hasattr(unittest.TestCase, 'assertIn'):
+	def __assertIn(self, a, b, msg=None):
+		if a not in b: # pragma: no cover
+			self.fail(msg or "%r was not found in %r" % (a, b))
+	unittest.TestCase.assertIn = __assertIn
+	def __assertNotIn(self, a, b, msg=None):
+		if a in b: # pragma: no cover
+			self.fail(msg or "%r was found in %r" % (a, b))
+	unittest.TestCase.assertNotIn = __assertNotIn
+
+
 class LogCaptureTestCase(unittest.TestCase):
 
 	def setUp(self):


### PR DESCRIPTION
- epoch time expression bug fixed: wrong recognition of epoch time (now accepts only whole number {10,11} - anchored ^...\b or by special case within [], audit())
- test cases extended (positive/negative case)
