### PR TITLE
Fedora use mariadb by default, fix log path

### DIFF
--- a/config/paths-fedora.conf
+++ b/config/paths-fedora.conf
@@ -34,7 +34,7 @@ apache_access_log = /var/log/httpd/*access_log
 
 exim_main_log = /var/log/exim/main.log
 
-mysql_log = /var/lib/mysql/mysqld.log
+mysql_log = /var/log/mariadb/mariadb.log
 
 roundcube_errors_log = /var/log/roundcubemail/errors
 

--- a/config/paths-fedora.conf
+++ b/config/paths-fedora.conf
@@ -35,6 +35,7 @@ apache_access_log = /var/log/httpd/*access_log
 exim_main_log = /var/log/exim/main.log
 
 mysql_log = /var/log/mariadb/mariadb.log
+            /var/log/mysqld.log
 
 roundcube_errors_log = /var/log/roundcubemail/errors
 
@@ -48,4 +49,3 @@ pureftpd_backend = systemd
 wuftpd_backend = systemd
 postfix_backend = systemd
 dovecot_backend = systemd
-mysql_backend = systemd


### PR DESCRIPTION
Fixes issue #1354 