### PR TITLE
monit filter fixup for the new version (gh-1355)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,9 @@ ver. 0.9.5 (2015/XX/XXX) - wanna-be-released
 -----------
 
 - Fixes:
+   * filter.d/monit.conf
+     - extended failregex with new monit "access denied" version (gh-1355);
+     - failregex of previous monit version merged as single expression.
 
 - New Features:
 

--- a/THANKS
+++ b/THANKS
@@ -34,6 +34,7 @@ Daniel B. Cid
 Daniel B.
 Daniel Black
 David Nutter
+David Reagan (jerrac)
 Derek Atkins
 Donald Yandt
 Eric Gerbier

--- a/config/filter.d/monit.conf
+++ b/config/filter.d/monit.conf
@@ -2,9 +2,20 @@
 #
 #
 
+[INCLUDES]
+
+# Read common prefixes. If any customizations available -- read them from
+# common.local
+before = common.conf
+
 [Definition]
 
-failregex = ^\[[A-Z]+\s+\]\s*error\s*:\s*Warning:\s+Client '<HOST>' supplied unknown user '\w+' accessing monit httpd$
-            ^\[[A-Z]+\s+\]\s*error\s*:\s*Warning:\s+Client '<HOST>' supplied wrong password for user '\w+' accessing monit httpd$
+_daemon = monit
 
+# Regexp for previous (accessing monit httpd) and new (access denied) versions
+failregex = ^\[[A-Z]+\s+\]\s*error\s*:\s*Warning:\s+Client '<HOST>' supplied (?:unknown user '[^']+'|wrong password for user '[^']*') accessing monit httpd$
+            ^%(__prefix_line)s\w+: access denied -- client <HOST>: (?:unknown user '[^']+'|wrong password for user '[^']*'|empty password)$
+
+# Ignore login with empty user (first connect, no user specified)
+# ignoreregex = %(__prefix_line)s\w+: access denied -- client <HOST>: (?:unknown user '')
 ignoreregex =

--- a/fail2ban/tests/files/logs/monit
+++ b/fail2ban/tests/files/logs/monit
@@ -1,6 +1,21 @@
+# Previous version --
 # failJSON: { "time": "2005-04-16T21:05:29", "match": true , "host": "69.93.127.111" }
 [PDT Apr 16 21:05:29] error    : Warning: Client '69.93.127.111' supplied unknown user 'foo' accessing monit httpd
-
 # failJSON: { "time": "2005-04-16T20:59:33", "match": true , "host": "97.113.189.111" }
 [PDT Apr 16 20:59:33] error    : Warning: Client '97.113.189.111' supplied wrong password for user 'admin' accessing monit httpd
 
+# Current version -- corresponding "https://bitbucket.org/tildeslash/monit/src/6905335aa903d425cae732cab766bd88ea5f2d1d/src/http/processor.c?at=master&fileviewer=file-view-default#processor.c-728"
+# failJSON: { "time": "2005-03-09T09:18:28", "match": false, "desc": "should be ignored: no login" }
+Mar  9 09:18:28 hostname monit[5731]: HttpRequest: access denied -- client 1.2.3.4: missing or invalid Authorization header
+# failJSON: { "time": "2005-03-09T09:18:28", "match": false, "desc": "should be ignored: no login" }
+Mar  9 09:18:28 hostname monit[5731]: HttpRequest: access denied -- client 1.2.3.4: invalid Authorization header
+# failJSON: { "time": "2005-03-09T09:18:29", "match": false, "desc": "should be ignored: connect, still no user specified" }
+Mar  9 09:18:29 hostname monit[5731]: HttpRequest: access denied -- client 1.2.3.4: empty username
+# failJSON: { "time": "2005-03-09T09:18:31", "match": false, "desc": "should be ignored: connect, still no user specified" }
+Mar  9 09:18:31 hostname monit[5731]: HttpRequest: access denied -- client 1.2.3.4: unknown user ''
+# failJSON: { "time": "2005-03-09T09:18:32", "match": true, "host": "1.2.3.4", "desc": "no password try" }
+Mar  9 09:18:32 hostname monit[5731]: HttpRequest: access denied -- client 1.2.3.4: empty password
+# failJSON: { "time": "2005-03-09T09:18:33", "match": true, "host": "1.2.3.4", "desc": "unknown user try" }
+Mar  9 09:18:33 hostname monit[5731]: HttpRequest: access denied -- client 1.2.3.4: unknown user 'test1'
+# failJSON: { "time": "2005-03-09T09:18:34", "match": true, "host": "1.2.3.4", "desc": "wrong password try" }
+Mar  9 09:18:34 hostname monit[5731]: HttpRequest: access denied -- client 1.2.3.4: wrong password for user 'test2'


### PR DESCRIPTION
fixed monit filter: failregex find now both previous and new versions:
- failregex of previous monit version merged as single expression;
- extended failregex with new monit "access denied" version;

closes #1355