### PR TITLE
SmartOS PAM Authentication failed (not failURE)

### DIFF
--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -18,7 +18,7 @@ before = common.conf
 
 _daemon = sshd
 
-failregex = ^%(__prefix_line)s(?:error: PAM: )?[aA]uthentication (?:failed|failure|error) for .* from <HOST>( via \S+)?\s*$
+failregex = ^%(__prefix_line)s(?:error: PAM: )?[aA]uthentication (?:failure|error|failed) for .* from <HOST>( via \S+)?\s*$
             ^%(__prefix_line)s(?:error: PAM: )?User not known to the underlying authentication module for .* from <HOST>\s*$
             ^%(__prefix_line)sFailed \S+ for .*? from <HOST>(?: port \d*)?(?: ssh\d*)?(: (ruser .*|(\S+ ID \S+ \(serial \d+\) CA )?\S+ %(__md5hex)s(, client user ".*", client host ".*")?))?\s*$
             ^%(__prefix_line)sROOT LOGIN REFUSED.* FROM <HOST>\s*$

--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -18,7 +18,7 @@ before = common.conf
 
 _daemon = sshd
 
-failregex = ^%(__prefix_line)s(?:error: PAM: )?[aA]uthentication (?:failure|error) for .* from <HOST>( via \S+)?\s*$
+failregex = ^%(__prefix_line)s(?:error: PAM: )?[aA]uthentication (?:failed|failure|error) for .* from <HOST>( via \S+)?\s*$
             ^%(__prefix_line)s(?:error: PAM: )?User not known to the underlying authentication module for .* from <HOST>\s*$
             ^%(__prefix_line)sFailed \S+ for .*? from <HOST>(?: port \d*)?(?: ssh\d*)?(: (ruser .*|(\S+ ID \S+ \(serial \d+\) CA )?\S+ %(__md5hex)s(, client user ".*", client host ".*")?))?\s*$
             ^%(__prefix_line)sROOT LOGIN REFUSED.* FROM <HOST>\s*$


### PR DESCRIPTION
On SmartOS (and likely other Illumos platforms -- OmniOS, OpenIndiana, Delphix, etc.) sshd + PAM enters authentication failure entries in the log file of the form:

`Authentication failed for USER from HOST`

However, the current regex in `sshd.conf` matches fail**ure** not fail**ed**. I added an additional match to support SmartOS and other platforms.

This is a one-line change; I did not run any automated testing.
