### PR TITLE
[WIP] add ability to use memory db while running and save to file on …

### DIFF
--- a/fail2ban/server/database.py
+++ b/fail2ban/server/database.py
@@ -34,6 +34,14 @@ from .mytime import MyTime
 from .ticket import FailTicket
 from ..helpers import getLogger
 
+try:
+	import sqlitebck
+except ImportError:
+	# Dont print error here, as sqlitebck may not even be used
+	sqlite_backup = False
+else:
+	sqlite_backup = True
+	
 # Gets the instance of the logger.
 logSys = getLogger(__name__)
 
@@ -162,13 +170,26 @@ class Fail2BanDb(object):
 			"CREATE INDEX bans_ip ON bans(ip);" \
 
 
-	def __init__(self, filename, purgeAge=24*60*60):
+	def __init__(self, filename, purgeAge=24*60*60, backupFilename=None):
 		try:
 			self._lock = RLock()
 			self._db = sqlite3.connect(
 				filename, check_same_thread=False,
 				detect_types=sqlite3.PARSE_DECLTYPES)
+			self._backupDb = None
+			if backupFilename:
+				if not sqlite_backup:
+					logSys.error(
+						"Wanting to put backup DB in memory, but sqlitebck module not found")
+				else:
+					self._backupDb = sqlite3.connect(
+						backupFilename, check_same_thread=False,
+						detect_types=sqlite3.PARSE_DECLTYPES)
+					sqlitebck.copy(self._backupDb, self._db)
+					logSys.info(
+						"Copied backupDB '%s' to memory '%s'", backupFilename, filename)
 			self._dbFilename = filename
+			self._backupDbFilename = backupFilename
 			self._purgeAge = purgeAge
 
 			self._bansMergedCache = {}
@@ -219,6 +240,16 @@ class Fail2BanDb(object):
 	@purgeage.setter
 	def purgeage(self, value):
 		self._purgeAge = int(value)
+
+	def backupDbIfNeeded(self):
+		if self._backupDb:
+			if not sqlite_backup:
+				logSys.error(
+					"Wanting to put backup DB in memory, but sqlitebck module not found")
+			else:
+				sqlitebck.copy(self._db, self._backupDb)
+				logSys.info(
+					"Copied memory '%s' to backupDB '%s'", self._dbFilename, self._backupDbFilename)
 
 	@commitandrollback
 	def createDb(self, cur):

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -137,6 +137,9 @@ class Server:
 		# Now stop all the jails
 		self.stopAllJail()
 
+		if self.__db is not None:
+			self.__db.backupDbIfNeeded()
+
 		# Only now shutdown the logging.
 		try:
 			self.__loggingLock.acquire()
@@ -509,8 +512,12 @@ class Server:
 		if filename.lower() == "none":
 			self.__db = None
 		else:
+			if filename.startswith(':memory:,'):
+				filename, backupFilename = filename.split(',', 1)
+			else:
+				backupFilename = None
 			if Fail2BanDb is not None:
-				self.__db = Fail2BanDb(filename)
+				self.__db = Fail2BanDb(filename, backupFilename=backupFilename)
 				self.__db.delAllJails()
 			else:
 				logSys.error(


### PR DESCRIPTION
Early pull-request to check if this is wanted functionality, and if I am on the right track.
Code is not tested yet
What it does:
If you put dbfile = :memory:,/path/to/backup/dbfile.sqlite3 in your config, this will on startup read the db in /path/to/backup/dbfile.sqlite3 and copy it to memory. Then it will use the db in memory, and finally on shutdown it will copy the memory db to /path/to/backup/dbfile.sqlite3 again.

I wrote this because I noticed that on a busy server fail2ban is doing quite a few iops, when switching to memory this is gone but that means a longer startup time

Comments welcome!