### PR TITLE
Added regex for LDAP authentication failures

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@ ver. 0.9.5 (2015/XX/XXX) - wanna-be-released
 
 - Enhancements:
    * journald journalmatch for pure-ftpd (gh-1362)
+   * Add additional regex filter for dovecot ldap authentication failures
 
 
 ver. 0.9.4 (2016/03/08) - for-you-ladies

--- a/config/filter.d/dovecot.conf
+++ b/config/filter.d/dovecot.conf
@@ -13,6 +13,7 @@ failregex = ^%(__prefix_line)s(%(__pam_auth)s(\(dovecot:auth\))?:)?\s+authentica
             ^%(__prefix_line)s(pop3|imap)-login: (Info: )?(Aborted login|Disconnected)(: Inactivity)? \(((auth failed, \d+ attempts)( in \d+ secs)?|tried to use (disabled|disallowed) \S+ auth)\):( user=<\S*>,)?( method=\S+,)? rip=<HOST>(, lip=(\d{1,3}\.){3}\d{1,3})?(, TLS( handshaking(: SSL_accept\(\) failed: error:[\dA-F]+:SSL routines:[TLS\d]+_GET_CLIENT_HELLO:unknown protocol)?)?(: Disconnected)?)?(, session=<\S+>)?\s*$
             ^%(__prefix_line)s(Info|dovecot: auth\(default\)|auth-worker\(\d+\)): pam\(\S+,<HOST>\): pam_authenticate\(\) failed: (User not known to the underlying authentication module: \d+ Time\(s\)|Authentication failure \(password mismatch\?\))\s*$
             ^%(__prefix_line)s(auth|auth-worker\(\d+\)): (pam|passwd-file)\(\S+,<HOST>\): unknown user\s*$
+            ^%(__prefix_line)s(auth|auth-worker\(\d+\)): Info: ldap\(\S*,<HOST>,\S*\): invalid credentials\s*$
 
 ignoreregex = 
 
@@ -22,9 +23,10 @@ journalmatch = _SYSTEMD_UNIT=dovecot.service
 
 # DEV Notes:
 # * the first regex is essentially a copy of pam-generic.conf
-# * Probably doesn't do dovecot sql/ldap backends properly
+# * Probably doesn't do dovecot sql/ldap backends properly (resolved in edit 21/03/2016)
 # * Removed the 'no auth attempts' log lines from the matches because produces
 #    lots of false positives on misconfigured MTAs making regexp unusable
 #
 # Author: Martin Waschbuesch
 #         Daniel Black (rewrote with begin and end anchors)
+#         Martin O'Neal (added LDAP authentication failure regex)

--- a/fail2ban/tests/files/logs/dovecot
+++ b/fail2ban/tests/files/logs/dovecot
@@ -70,3 +70,6 @@ Jun 13 21:48:06 platypus dovecot: pop3-login: Disconnected: Inactivity (no auth 
 Jun 13 20:20:21 platypus dovecot: imap-login: Disconnected (no auth attempts): rip=180.189.168.166, lip=113.212.99.194, TLS handshaking: Disconnected
 # failJSON: { "time": "2005-07-02T13:49:32", "match": false , "host": "192.51.100.13" }
 Jul 02 13:49:32 hostname dovecot[442]: pop3-login: Disconnected (no auth attempts in 58 secs): user=<>, rip=192.51.100.13, lip=203.0.113.17, session=<LgDINsQCkttVIMPg>
+
+# failJSON: { "time": "2005-03-23T06:10:52", "match": true , "host": "52.37.139.121" }
+Mar 23 06:10:52 auth: Info: ldap(dog,52.37.139.121,): invalid credentials


### PR DESCRIPTION
resolves #1291

Mar 23 06:10:52 auth: Info: ldap(dog,52.37.139.121,<jhgsdfhgjSDF3>): invalid credentials
