### PR TITLE
Show the most recent 100 lines instead of the first 1000

### DIFF
--- a/config/action.d/sendmail-whois-lines.conf
+++ b/config/action.d/sendmail-whois-lines.conf
@@ -26,7 +26,7 @@ actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Here is more information about <ip> :\n
             `/usr/bin/whois <ip> || echo missing whois program`\n\n
             Lines containing IP:<ip> in <logpath>\n
-            `grep -E <grepopts> '(^|[^0-9])<ip>([^0-9]|$)' <logpath>`\n\n
+            `grep -E <grepopts> '(^|[^0-9])<ip>([^0-9]|$)' <logpath> | tail <tailopts>`\n\n
             Regards,\n
             Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
 
@@ -40,6 +40,10 @@ name = default
 #
 logpath = /dev/null
 
-# Number of log lines to include in the email
+# grep options
 #
-grepopts = -m 1000
+grepopts = 
+
+# tail options
+#
+tailopts = -n 100


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests 
- [ ] **KEEP PR small** so it could be easily reviewed.
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines 
    within `fail2ban/tests/files/logs/X` file
  I recently had an IP get banned that had many thousands of entries in today's log file. Showing the first 1000 lines gives no context to why the IP is banned if they had 10,000 valid requests today and then "sped up" and got banned. Showing the most recent X lines is probably what most people want.
