### PR TITLE
bug fix: retracts wrong disregarding of defaults from includes like 'jail.d/*.conf' etc. (#1225 was to blame for this)

### DIFF
--- a/bin/fail2ban-client
+++ b/bin/fail2ban-client
@@ -376,8 +376,10 @@ class Fail2banClient:
 			logSys.setLevel(logging.WARNING)
 		elif verbose == 2:
 			logSys.setLevel(logging.INFO)
-		else:
+		elif verbose == 3:
 			logSys.setLevel(logging.DEBUG)
+		else:
+			logSys.setLevel(logging.HEAVYDEBUG)
 		# Add the default logging handler to dump to stderr
 		logout = logging.StreamHandler(sys.stderr)
 		# set a format which is simpler for console use

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -222,15 +222,20 @@ action = %(action_)s
 
 [sshd]
 
+[default.sshd]
+
 port    = ssh
 logpath = %(sshd_log)s
 backend = %(sshd_backend)s
 
 
-[sshd-ddos]
 # This jail corresponds to the standard configuration in Fail2ban.
 # The mail-whois action send a notification e-mail with a whois request
 # in the body.
+[sshd-ddos]
+
+[default.sshd-ddos]
+
 port    = ssh
 logpath = %(sshd_log)s
 backend = %(sshd_backend)s
@@ -238,12 +243,16 @@ backend = %(sshd_backend)s
 
 [dropbear]
 
+[default.dropbear]
+
 port     = ssh
 logpath  = %(dropbear_log)s
 backend  = %(dropbear_backend)s
 
 
 [selinux-ssh]
+
+[default.selinux-ssh]
 
 port     = ssh
 logpath  = %(auditd_log)s
@@ -255,13 +264,17 @@ logpath  = %(auditd_log)s
 
 [apache-auth]
 
+[default.apache-auth]
+
 port     = http,https
 logpath  = %(apache_error_log)s
 
 
-[apache-badbots]
 # Ban hosts which agent identifies spammer robots crawling the web
 # for email addresses. The mail outputs are buffered.
+[apache-badbots]
+
+[default.apache-badbots]
 port     = http,https
 logpath  = %(apache_access_log)s
 bantime  = 172800
@@ -270,11 +283,15 @@ maxretry = 1
 
 [apache-noscript]
 
+[default.apache-noscript]
+
 port     = http,https
 logpath  = %(apache_error_log)s
 
 
 [apache-overflows]
+
+[default.apache-overflows]
 
 port     = http,https
 logpath  = %(apache_error_log)s
@@ -283,6 +300,8 @@ maxretry = 2
 
 [apache-nohome]
 
+[default.apache-nohome]
+
 port     = http,https
 logpath  = %(apache_error_log)s
 maxretry = 2
@@ -290,12 +309,16 @@ maxretry = 2
 
 [apache-botsearch]
 
+[default.apache-botsearch]
+
 port     = http,https
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-fakegooglebot]
+
+[default.apache-fakegooglebot]
 
 port     = http,https
 logpath  = %(apache_access_log)s
@@ -305,12 +328,16 @@ ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
 
 [apache-modsecurity]
 
+[default.apache-modsecurity]
+
 port     = http,https
 logpath  = %(apache_error_log)s
 maxretry = 2
 
 
 [apache-shellshock]
+
+[default.apache-shellshock]
 
 port    = http,https
 logpath = %(apache_error_log)s
@@ -319,12 +346,16 @@ maxretry = 1
 
 [openhab-auth]
 
+[default.openhab-auth]
+
 filter = openhab
 action = iptables-allports[name=NoAuthFailures]
 logpath = /opt/openhab/logs/request.log
 
 
 [nginx-http-auth]
+
+[default.nginx-http-auth]
 
 port    = http,https
 logpath = %(nginx_error_log)s
@@ -334,10 +365,15 @@ logpath = %(nginx_error_log)s
 # http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
 # or for example see in 'config/filter.d/nginx-limit-req.conf'
 [nginx-limit-req]
+
+[default.nginx-limit-req]
+
 port    = http,https
 logpath = %(nginx_error_log)s
 
 [nginx-botsearch]
+
+[default.nginx-botsearch]
 
 port     = http,https
 logpath  = %(nginx_error_log)s
@@ -347,8 +383,9 @@ maxretry = 2
 # Ban attackers that try to use PHP's URL-fopen() functionality
 # through GET/POST variables. - Experimental, with more than a year
 # of usage in production environments.
-
 [php-url-fopen]
+
+[default.php-url-fopen]
 
 port    = http,https
 logpath = %(nginx_access_log)s
@@ -357,13 +394,18 @@ logpath = %(nginx_access_log)s
 
 [suhosin]
 
+[default.suhosin]
+
 port    = http,https
 logpath = %(suhosin_log)s
 
 
-[lighttpd-auth]
 # Same as above for Apache's mod_auth
 # It catches wrong authentifications
+[lighttpd-auth]
+
+[default.lighttpd-auth]
+
 port    = http,https
 logpath = %(lighttpd_error_log)s
 
@@ -374,11 +416,15 @@ logpath = %(lighttpd_error_log)s
 
 [roundcube-auth]
 
+[default.roundcube-auth]
+
 port     = http,https
 logpath  = %(roundcube_errors_log)s
 
 
 [openwebmail]
+
+[default.openwebmail]
 
 port     = http,https
 logpath  = /var/log/openwebmail.log
@@ -386,17 +432,23 @@ logpath  = /var/log/openwebmail.log
 
 [horde]
 
+[default.horde]
+
 port     = http,https
 logpath  = /var/log/horde/horde.log
 
 
 [groupoffice]
 
+[default.groupoffice]
+
 port     = http,https
 logpath  = /home/groupoffice/log/info.log
 
 
 [sogo-auth]
+
+[default.sogo-auth]
 # Monitor SOGo groupware server
 # without proxy this would be:
 # port    = 20000
@@ -405,6 +457,8 @@ logpath  = /var/log/sogo/sogo.log
 
 
 [tine20]
+
+[default.tine20]
 
 logpath  = /var/log/tine20/tine20.log
 port     = http,https
@@ -417,16 +471,22 @@ port     = http,https
 
 [drupal-auth]
 
+[default.drupal-auth]
+
 port     = http,https
 logpath  = %(syslog_daemon)s
 backend  = %(syslog_backend)s
 
 [guacamole]
 
+[default.guacamole]
+
 port     = http,https
 logpath  = /var/log/tomcat*/catalina.out
 
 [monit]
+
+[default.monit]
 #Ban clients brute-forcing the monit gui login
 port = 2812
 logpath  = /var/log/monit
@@ -434,12 +494,16 @@ logpath  = /var/log/monit
 
 [webmin-auth]
 
+[default.webmin-auth]
+
 port    = 10000
 logpath = %(syslog_authpriv)s
 backend = %(syslog_backend)s
 
 
 [froxlor-auth]
+
+[default.froxlor-auth]
 
 port    = http,https
 logpath  = %(syslog_authpriv)s
@@ -453,11 +517,15 @@ backend  = %(syslog_backend)s
 
 [squid]
 
+[default.squid]
+
 port     =  80,443,3128,8080
 logpath = /var/log/squid/access.log
 
 
 [3proxy]
+
+[default.3proxy]
 
 port    = 3128
 logpath = /var/log/3proxy.log
@@ -470,12 +538,16 @@ logpath = /var/log/3proxy.log
 
 [proftpd]
 
+[default.proftpd]
+
 port     = ftp,ftp-data,ftps,ftps-data
 logpath  = %(proftpd_log)s
 backend  = %(proftpd_backend)s
 
 
 [pure-ftpd]
+
+[default.pure-ftpd]
 
 port     = ftp,ftp-data,ftps,ftps-data
 logpath  = %(pureftpd_log)s
@@ -484,6 +556,8 @@ backend  = %(pureftpd_backend)s
 
 [gssftpd]
 
+[default.gssftpd]
+
 port     = ftp,ftp-data,ftps,ftps-data
 logpath  = %(syslog_daemon)s
 backend  = %(syslog_backend)s
@@ -491,12 +565,17 @@ backend  = %(syslog_backend)s
 
 [wuftpd]
 
+[default.wuftpd]
+
 port     = ftp,ftp-data,ftps,ftps-data
 logpath  = %(wuftpd_log)s
 backend  = %(wuftpd_backend)s
 
 
 [vsftpd]
+
+[default.vsftpd]
+
 # or overwrite it in jails.local to be
 # logpath = %(syslog_authpriv)s
 # if you want to rely on PAM failed login attempts
@@ -512,11 +591,15 @@ logpath  = %(vsftpd_log)s
 # ASSP SMTP Proxy Jail
 [assp]
 
+[default.assp]
+
 port     = smtp,465,submission
 logpath  = /root/path/to/assp/logs/maillog.txt
 
 
 [courier-smtp]
+
+[default.courier-smtp]
 
 port     = smtp,465,submission
 logpath  = %(syslog_mail)s
@@ -525,12 +608,16 @@ backend  = %(syslog_backend)s
 
 [postfix]
 
+[default.postfix]
+
 port     = smtp,465,submission
 logpath  = %(postfix_log)s
 backend  = %(postfix_backend)s
 
 
 [postfix-rbl]
+
+[default.postfix-rbl]
 
 port     = smtp,465,submission
 logpath  = %(postfix_log)s
@@ -540,6 +627,8 @@ maxretry = 1
 
 [sendmail-auth]
 
+[default.sendmail-auth]
+
 port    = submission,465,smtp
 logpath = %(syslog_mail)s
 backend = %(syslog_backend)s
@@ -547,12 +636,16 @@ backend = %(syslog_backend)s
 
 [sendmail-reject]
 
+[default.sendmail-reject]
+
 port     = smtp,465,submission
 logpath  = %(syslog_mail)s
 backend  = %(syslog_backend)s
 
 
 [qmail-rbl]
+
+[default.qmail-rbl]
 
 filter  = qmail
 port    = smtp,465,submission
@@ -563,12 +656,16 @@ logpath = /service/qmail/log/main/current
 # but can be set by syslog_facility in the dovecot configuration.
 [dovecot]
 
+[default.dovecot]
+
 port    = pop3,pop3s,imap,imaps,submission,465,sieve
 logpath = %(dovecot_log)s
 backend = %(dovecot_backend)s
 
 
 [sieve]
+
+[default.sieve]
 
 port   = smtp,465,submission
 logpath = %(dovecot_log)s
@@ -577,11 +674,15 @@ backend = %(dovecot_backend)s
 
 [solid-pop3d]
 
+[default.solid-pop3d]
+
 port    = pop3,pop3s
 logpath = %(solidpop3d_log)s
 
 
 [exim]
+
+[default.exim]
 
 port   = smtp,465,submission
 logpath = %(exim_main_log)s
@@ -589,11 +690,15 @@ logpath = %(exim_main_log)s
 
 [exim-spam]
 
+[default.exim-spam]
+
 port   = smtp,465,submission
 logpath = %(exim_main_log)s
 
 
 [kerio]
+
+[default.kerio]
 
 port    = imap,smtp,imaps,465
 logpath = /opt/kerio/mailserver/store/logs/security.log
@@ -606,12 +711,16 @@ logpath = /opt/kerio/mailserver/store/logs/security.log
 
 [courier-auth]
 
+[default.courier-auth]
+
 port     = smtp,465,submission,imap3,imaps,pop3,pop3s
 logpath  = %(syslog_mail)s
 backend  = %(syslog_backend)s
 
 
 [postfix-sasl]
+
+[default.postfix-sasl]
 
 port     = smtp,465,submission,imap3,imaps,pop3,pop3s
 # You might consider monitoring /var/log/mail.warn instead if you are
@@ -623,6 +732,8 @@ backend  = %(postfix_backend)s
 
 [perdition]
 
+[default.perdition]
+
 port   = imap3,imaps,pop3,pop3s
 logpath = %(syslog_mail)s
 backend = %(syslog_backend)s
@@ -630,11 +741,15 @@ backend = %(syslog_backend)s
 
 [squirrelmail]
 
+[default.squirrelmail]
+
 port = smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 
 [cyrus-imap]
+
+[default.cyrus-imap]
 
 port   = imap3,imaps
 logpath = %(syslog_mail)s
@@ -642,6 +757,8 @@ backend = %(syslog_backend)s
 
 
 [uwimap-auth]
+
+[default.uwimap-auth]
 
 port   = imap3,imaps
 logpath = %(syslog_mail)s
@@ -676,11 +793,15 @@ backend = %(syslog_backend)s
 
 [named-refused]
 
+[default.named-refused]
+
 port     = domain,953
 logpath  = /var/log/named/security.log
 
 
 [nsd]
+
+[default.nsd]
 
 port     = 53
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
@@ -694,6 +815,8 @@ logpath = /var/log/nsd.log
 
 [asterisk]
 
+[default.asterisk]
+
 port     = 5060,5061
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
@@ -703,6 +826,8 @@ maxretry = 10
 
 
 [freeswitch]
+
+[default.freeswitch]
 
 port     = 5060,5061
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
@@ -725,6 +850,8 @@ maxretry = 10
 # log-error=/var/log/mysqld.log
 [mysqld-auth]
 
+[default.mysqld-auth]
+
 port     = 3306
 logpath  = %(mysql_log)s
 backend  = %(mysql_backend)s
@@ -739,6 +866,8 @@ backend  = %(mysql_backend)s
 #    to maintain entries for failed logins for sufficient amount of time
 [recidive]
 
+[default.recidive]
+
 logpath  = /var/log/fail2ban.log
 banaction = %(banaction_allports)s
 bantime  = 604800  ; 1 week
@@ -749,6 +878,9 @@ findtime = 86400   ; 1 day
 # ports such as iptables-allports, shorewall
 
 [pam-generic]
+
+[default.pam-generic]
+
 # pam-generic filter can be customized to monitor specific subset of 'tty's
 banaction = %(banaction_allports)s
 logpath  = %(syslog_authpriv)s
@@ -756,6 +888,8 @@ backend  = %(syslog_backend)s
 
 
 [xinetd-fail]
+
+[default.xinetd-fail]
 
 banaction = iptables-multiport-log
 logpath   = %(syslog_daemon)s
@@ -766,16 +900,22 @@ maxretry  = 2
 # stunnel - need to set port for this
 [stunnel]
 
+[default.stunnel]
+
 logpath = /var/log/stunnel4/stunnel.log
 
 
 [ejabberd-auth]
+
+[default.ejabberd-auth]
 
 port    = 5222
 logpath = /var/log/ejabberd/ejabberd.log
 
 
 [counter-strike]
+
+[default.counter-strike]
 
 logpath = /opt/cstrike/logs/L[0-9]*.log
 # Firewall: http://www.cstrike-planet.com/faq/6
@@ -788,25 +928,39 @@ action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp
 # nobody except your own Nagios server should ever probe nrpe
 [nagios]
 
+[default.nagios]
+
 logpath  = %(syslog_daemon)s     ; nrpe.cfg may define a different log_facility
 backend  = %(syslog_backend)s
 maxretry = 1
 
 
 [oracleims]
+
+[default.oracleims]
+
 # see "oracleims" filter file for configuration requirement for Oracle IMS v6 and above
 logpath = /opt/sun/comms/messaging64/log/mail.log_current
 banaction = %(banaction_allports)s
 
 [directadmin]
+
+[default.directadmin]
+
 logpath = /var/log/directadmin/login.log
 port = 2222
 
 [portsentry]
+
+[default.portsentry]
+
 logpath  = /var/lib/portsentry/portsentry.history
 maxretry = 1
 
 [pass2allow-ftp]
+
+[default.pass2allow-ftp]
+
 # this pass2allow example allows FTP traffic after successful HTTP authentication
 port         = ftp,ftp-data,ftps,ftps-data
 # knocking_url variable must be overridden to some secret value in filter.d/apache-pass.local
@@ -821,6 +975,9 @@ findtime     = 1
 
 
 [murmur]
+
+[default.murmur]
+
 # AKA mumble-server
 port     = 64738
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol=tcp, chain="%(chain)s", actname=%(banaction)s-tcp]
@@ -829,11 +986,17 @@ logpath  = /var/log/mumble-server/mumble-server.log
 
 
 [screensharingd]
+
+[default.screensharingd]
+
 # For Mac OS Screen Sharing Service (VNC)
 logpath  = /var/log/system.log
 logencoding = utf-8
 
 [haproxy-http-auth]
+
+[default.haproxy-http-auth]
+
 # HAProxy by default doesn't log to file you'll need to set it up to forward
 # logs to a syslog server which would then write them to disk.
 # See "haproxy-http-auth" filter for a brief cautionary note when setting

--- a/fail2ban/client/configreader.py
+++ b/fail2ban/client/configreader.py
@@ -209,17 +209,18 @@ class ConfigReaderUnshared(SafeConfigParserWithIncludes):
 	# 2 -> the default value for the option
 	
 	def getOptions(self, sec, options, pOptions=None):
+		self.merge_defaults(sec)
 		values = dict()
 		for option in options:
 			try:
+				if not pOptions is None and option[1] in pOptions:
+					continue
 				if option[0] == "bool":
 					v = self.getboolean(sec, option[1])
 				elif option[0] == "int":
 					v = self.getint(sec, option[1])
 				else:
 					v = self.get(sec, option[1])
-				if not pOptions is None and option[1] in pOptions:
-					continue
 				values[option[1]] = v
 			except NoSectionError, e:
 				# No "Definition" section or wrong basedir

--- a/man/jail.conf.5
+++ b/man/jail.conf.5
@@ -158,6 +158,9 @@ This sets the age at which bans should be purged from the database.
 
 .SH "JAIL CONFIGURATION FILE(S) (\fIjail.conf\fB)"
 The following options are applicable to any jail. They appear in a section specifying the jail name or in the \fI[DEFAULT]\fR section which defines default values to be used if not specified in the individual section.
+Another way to define default options per jail is to specify those in the section \fI[default.jail-name]\fR.
+The option is looked up in \fI[jail]\fR section, in jail defaults \fI[default.jail]\fR and in global \fI[DEFAULT]\fR section in exactly that order.
+Setting of some options in \fI[DEFAULT]\fR overwrites per section defaults for this options of the previous includes. This applies to all configuration files that file2ban uses by read of jail parameters.
 .TP
 .B filter
 name of the filter -- filename of the filter in /etc/fail2ban/filter.d/ without the .conf/.local extension.


### PR DESCRIPTION
move explicit jail parameters within jail specifications to section defaults (from [jail] to [default.jail]);

logic of config reader extended: introduced per section defaults functionality (section with named convention [default.name]);

Pros:
  - we can precise define defaults for separate sections (for example without define it for all jails);
  - we can define defaults for sections, without that they involve currently not existing section;
  - resolves unclear defaults/locals handling between multiple includes and standard values (for example by issues like #1270);

Cons:
   - atm unknown, because it should be backwards compatibly

closes gh-1372