### PR TITLE
revised exim regexes to cover entries with rDNS

### DIFF
--- a/fail2ban/tests/files/logs/exim
+++ b/fail2ban/tests/files/logs/exim
@@ -56,3 +56,10 @@
 2016-03-21 04:07:49 [25874] 1ahr79-0006jK-G9 SMTP connection from (voyeur.webair.com) [174.137.147.204]:44884 I=[172.89.0.6]:25 closed by DROP in ACL
 # failJSON: { "time": "2016-03-21T04:33:13", "match": true , "host": "206.214.71.53" }
 2016-03-21 04:33:13 [26074] 1ahrVl-0006mY-79 SMTP connection from riveruse.com [206.214.71.53]:39865 I=[172.89.0.6]:25 closed by DROP in ACL
+
+# failJSON: { "time": "2016-04-01T11:08:39", "match": true , "host": "192.0.2.1" }
+2016-04-01 11:08:39 [18643] no MAIL in SMTP connection from host.example.com (SERVER) [192.0.2.1]:1418 I=[172.89.0.6]:25 D=34s C=EHLO,AUTH
+# failJSON: { "time": "2016-04-01T11:09:21", "match": true , "host": "192.0.2.1" }
+2016-04-01 11:09:21 [18648] SMTP protocol error in "AUTH LOGIN" H=host.example.com (SERVER) [192.0.2.1]:4692 I=[172.89.0.6]:25 AUTH command used when not advertised
+# failJSON: { "time": "2016-03-27T16:48:48", "match": true , "host": "192.0.2.1" }
+2016-03-27 16:48:48 [21478] 1akDqs-0005aQ-9b SMTP connection from host.example.com (SERVER) [192.0.2.1]:47714 I=[172.89.0.6]:25 closed by DROP in ACL


### PR DESCRIPTION
The original regexes I added were skipping hosts with rDNS entries, so I fixed them. 

Also added additional tests (this time anonymised).

changelog still stands so not updated.



