### PR TITLE
ensure /var/run/fail2ban is created in systemd service file

### DIFF
--- a/files/fail2ban.service
+++ b/files/fail2ban.service
@@ -6,6 +6,7 @@ PartOf=iptables.service firewalld.service
 
 [Service]
 Type=forking
+ExecStartPre=/bin/mkdir -p /var/run/fail2ban
 ExecStart=/usr/bin/fail2ban-client -x start
 ExecStop=/usr/bin/fail2ban-client stop
 ExecReload=/usr/bin/fail2ban-client reload


### PR DESCRIPTION
Hi, this pull request adds one line to the systemd service file, making sure that the folder `/var/run/fail2ban` is created.

I ran into this problem in gentoo, when I installed fail2ban, but it did not start because `/run/fail2ban` did not exist. Gentoo installs bundled tmpfiles.d file, but it takes effect only on reboot, or on manual invocation of `systemd-tmpfiles`. Making sure that the directory is created before the service is run by means of systemd command seems clean and simple.
