### PR TITLE
Fix postfix/smtps/smtpd matching.

### DIFF
--- a/config/filter.d/postfix-sasl.conf
+++ b/config/filter.d/postfix-sasl.conf
@@ -7,7 +7,7 @@ before = common.conf
 
 [Definition]
 
-_daemon = postfix(-\w+)?/((?:submission|smtps)/)?smtpd
+_daemon = postfix(-\w+)?/(?:submission/|smtps/)?smtp[ds]
 
 failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL ((?i)LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/:]*={0,2})?\s*$
 

--- a/config/filter.d/postfix-sasl.conf
+++ b/config/filter.d/postfix-sasl.conf
@@ -7,7 +7,7 @@ before = common.conf
 
 [Definition]
 
-_daemon = postfix(-\w+)?/(submission/)?smtp(d|s)
+_daemon = postfix(-\w+)?/((?:submission|smtps)/)?smtpd
 
 failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL ((?i)LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/:]*={0,2})?\s*$
 

--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -10,7 +10,7 @@ before = common.conf
 
 [Definition]
 
-_daemon = postfix(-\w+)?/((?:submission|smtps)/)?smtpd
+_daemon = postfix(-\w+)?/(?:submission/|smtps/)?smtp[ds]
 
 failregex = ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 554 5\.7\.1 .*$
             ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 450 4\.7\.1 Client host rejected: cannot find your hostname, (\[\S*\]); from=<\S*> to=<\S+> proto=ESMTP helo=<\S*>$

--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -10,7 +10,7 @@ before = common.conf
 
 [Definition]
 
-_daemon = postfix(-\w+)?/(submission/)?smtp(d|s)
+_daemon = postfix(-\w+)?/((?:submission|smtps)/)?smtpd
 
 failregex = ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 554 5\.7\.1 .*$
             ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 450 4\.7\.1 Client host rejected: cannot find your hostname, (\[\S*\]); from=<\S*> to=<\S+> proto=ESMTP helo=<\S*>$

--- a/fail2ban/tests/files/logs/postfix
+++ b/fail2ban/tests/files/logs/postfix
@@ -32,3 +32,6 @@ Jan 31 13:55:24 xxx postfix/smtpd[3462]: NOQUEUE: reject: EHLO from s271272.stat
 
 # failJSON: { "time": "2005-01-31T13:55:24", "match": true , "host": "78.107.251.238" }
 Jan 31 13:55:24 xxx postfix-incoming/smtpd[3462]: NOQUEUE: reject: EHLO from s271272.static.corbina.ru[78.107.251.238]: 504 5.5.2 <User>: Helo command rejected: need fully-qualified hostname; proto=SMTP helo=<User>
+
+# failJSON: { "time": "2005-04-12T02:24:11", "match": true , "host": "62.138.2.143" }
+Apr 12 02:24:11 xxx postfix/smtps/smtpd[42]: NOQUEUE: reject: EHLO from astra4139.startdedicated.de[62.138.2.143]: 504 5.5.2 <User>: Helo command rejected: need fully-qualified hostname; proto=SMTP helo=<User>

--- a/fail2ban/tests/files/logs/postfix-sasl
+++ b/fail2ban/tests/files/logs/postfix-sasl
@@ -23,3 +23,6 @@ Feb  3 08:29:28 mail postfix/smtpd[21022]: warning: unknown[1.1.1.1]: SASL LOGIN
 
 # failJSON: { "time": "2005-01-29T08:11:45", "match": true , "host": "1.1.1.1" }
 Jan 29 08:11:45 mail postfix-incoming/smtpd[10752]: warning: unknown[1.1.1.1]: SASL LOGIN authentication failed: Password:
+
+# failJSON: { "time": "2005-04-12T02:24:11", "match": true , "host": "62.138.2.143" }
+Apr 12 02:24:11 xxx postfix/smtps/smtpd[42]: warning: astra4139.startdedicated.de[62.138.2.143]: SASL LOGIN authentication failed: UGFzc3dvcmQ6


### PR DESCRIPTION
Hi there,

Fail2Ban v0.9.4 has trouble to ban postfix auth attempts via the old (deprecated) smtps port (465). 

After study it seems that the filters doesn't match when `syslog_name=postfix/smtps` which looks like to be the default since 2011 in postfix (see https://github.com/vdukhovni/postfix/commit/9639819fd08c692e480958669b0e00975a86a04f).

Ok?

- [x] **CONSIDER adding a unit test** if your PR resolves an issue

Tests in the commit.

- [x] **LIST ISSUES** this PR resolves

Could not find a related issue.

- [x] **MAKE SURE** this PR doesn't break existing tests

Previous test cases still pass.

- [x] **KEEP PR small** so it could be easily reviewed.

Can't do smaller.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code

Ok.
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines 
      within `fail2ban/tests/files/logs/X` file

Done.
