### PR TITLE
BF+ENH: fixed up testing querying cymru information + assert_dict_equal

### DIFF
--- a/fail2ban/tests/utils.py
+++ b/fail2ban/tests/utils.py
@@ -313,3 +313,9 @@ else:
 			return True
 		else:
 			return False
+
+# Python 2.6 compatibility. in 2.7 assertDictEqual
+def assert_dict_equal(a, b):
+	assert isinstance(a, dict), "Object is not dictionary: %r" % a
+	assert isinstance(b, dict), "Object is not dictionary: %r" % b
+	assert a==b, "Dictionaries differ:\n%r !=\n%r" % (a, b)


### PR DESCRIPTION
Our tests started to fail recently since cymru started to provide record for private IP 10.0.0.0.  Fixed for that and extended the test 

- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
