### PR TITLE
New logtarget: systemd-journal

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,7 @@ ver. 0.9.5 (2016/XX/XXX) - wanna-be-released
 - New Features:
    * New Actions:
      - action.d/firewallcmd-rich-rules and action.d/firewallcmd-rich-logging (gh-1367)
+   * New logtarget SYSTEMD-JOURNAL
 - Enhancements:
    * journald journalmatch for pure-ftpd (gh-1362)
    * Add additional regex filter for dovecot ldap authentication failures (gh-1370)

--- a/THANKS
+++ b/THANKS
@@ -31,6 +31,7 @@ Christoph Haas
 Christos Psonis
 craneworks
 Cyril Jaquier
+Daniel Aleksandersen
 Daniel B. Cid
 Daniel B.
 Daniel Black

--- a/config/fail2ban.conf
+++ b/config/fail2ban.conf
@@ -24,13 +24,14 @@
 loglevel = INFO
 
 # Option: logtarget
-# Notes.: Set the log target. This could be a file, SYSLOG, STDERR or STDOUT.
+# Notes.: Set the log target. This could be a file path, SYSLOG,
+#         SYSTEMD-JOURNAL, STDERR, or STDOUT.
 #         Only one log target can be specified.
 #         If you change logtarget from the default value and you are
 #         using logrotate -- also adjust or disable rotation in the
 #         corresponding configuration file
 #         (e.g. /etc/logrotate.d/fail2ban on Debian systems)
-# Values: [ STDOUT | STDERR | SYSLOG | FILE ]  Default: STDERR
+# Values: [ STDOUT | STDERR | SYSLOG | SYSTEMD-JOURNAL | FILE ]  Default: STDERR
 #
 logtarget = /var/log/fail2ban.log
 

--- a/fail2ban/protocol.py
+++ b/fail2ban/protocol.py
@@ -52,7 +52,7 @@ protocol = [
 ['', "LOGGING", ""],
 ["set loglevel <LEVEL>", "sets logging level to <LEVEL>. Levels: CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG"], 
 ["get loglevel", "gets the logging level"], 
-["set logtarget <TARGET>", "sets logging target to <TARGET>. Can be STDOUT, STDERR, SYSLOG or a file"], 
+["set logtarget <TARGET>", "sets logging target to <TARGET>. Can be STDOUT, STDERR, SYSLOG, SYSTEMD-JOURNAL, or a file"],
 ["get logtarget", "gets logging target"], 
 ["set syslogsocket auto|<SOCKET>", "sets the syslog socket path to auto or <SOCKET>. Only used if logtarget is SYSLOG"],
 ["get syslogsocket", "gets syslog socket path"],

--- a/man/fail2ban-client.1
+++ b/man/fail2ban-client.1
@@ -87,8 +87,8 @@ gets the logging level
 .TP
 \fBset logtarget <TARGET>\fR
 sets logging target to <TARGET>.
-Can be STDOUT, STDERR, SYSLOG or a
-file
+Can be STDOUT, STDERR, SYSLOG,
+SYSTEMD-JOURNAL or a file
 .TP
 \fBget logtarget\fR
 gets logging target


### PR DESCRIPTION
Removed closing of all files as `python-systemd` uses persistent file descriptors that there is no way to identify nor reopen. Logging could be initialized after forking, but that would mean no logging prior to forking as the file descriptors aren’t reopened once they’ve been closed. Alternatively still, `os.closerange(0, maxfd)` could be set to start closing at `4` rather than `0` which is kind of magical and not guaranteed to work in all situations on all systems. I didn’t see any good reasons for why all file descriptors are brutally murdered in the first place. Looks to me like a case of premature optimization that even has caused problems in the past.

Didn’t add tests as I’m not familiar with the test framework and assumed the project probably doesn’t want to add `systemd` to the list of requirements for running tests anyways.
