### PR TITLE
0.10 fixes

### DIFF
--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -1452,10 +1452,23 @@ class DNSUtilsNetworkTests(unittest.TestCase):
 		self.assertEqual(IPAddr('93.184.0.1', 24).ntoa, '93.184.0.0/24')
 		self.assertEqual(IPAddr('192.168.1.0/255.255.255.128').ntoa, '192.168.1.0/25')
 
+		self.assertEqual(IPAddr('93.184.0.1/32').ntoa, '93.184.0.1')
+		self.assertEqual(IPAddr('93.184.0.1/255.255.255.255').ntoa, '93.184.0.1')
+
 		self.assertEqual(str(IPAddr('2606:2800:220:1:248:1893:25c8::', 120)), '2606:2800:220:1:248:1893:25c8:0/120')
 		self.assertEqual(IPAddr('2606:2800:220:1:248:1893:25c8::', 120).ntoa, '2606:2800:220:1:248:1893:25c8:0/120')
 		self.assertEqual(str(IPAddr('2606:2800:220:1:248:1893:25c8:0/120')), '2606:2800:220:1:248:1893:25c8:0/120')
 		self.assertEqual(IPAddr('2606:2800:220:1:248:1893:25c8:0/120').ntoa, '2606:2800:220:1:248:1893:25c8:0/120')
+
+		self.assertEqual(str(IPAddr('2606:28ff:220:1:248:1893:25c8::', 25)), '2606:2880::/25')
+		self.assertEqual(str(IPAddr('2606:28ff:220:1:248:1893:25c8::/ffff:ff80::')), '2606:2880::/25')
+		self.assertEqual(str(IPAddr('2606:28ff:220:1:248:1893:25c8::/ffff:ffff:ffff:ffff:ffff:ffff:ffff::')), 
+			'2606:28ff:220:1:248:1893:25c8:0/112')
+
+		self.assertEqual(str(IPAddr('2606:28ff:220:1:248:1893:25c8::/128')), 
+			'2606:28ff:220:1:248:1893:25c8:0')
+		self.assertEqual(str(IPAddr('2606:28ff:220:1:248:1893:25c8::/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff')), 
+			'2606:28ff:220:1:248:1893:25c8:0')
 
 	def testIPAddr_CIDR_Repr(self):
 		self.assertEqual(["127.0.0.0/8", "::/32", "2001:db8::/32"],

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -1021,7 +1021,11 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 						cmd[2] = 'polling'
 					# change log path to test log of jail (to prevent "Permission denied" on /var/logs/ for test-user):
 					elif len(cmd) > 3 and cmd[0] == 'set' and cmd[2] == 'addlogpath':
-						cmd[3] = os.path.join(TEST_FILES_DIR, 'logs', cmd[1])
+						fn = os.path.join(TEST_FILES_DIR, 'logs', cmd[1])
+						# fallback to testcase01 if jail has not an own test log-file (currently should be no matter):
+						if not os.path.exists(fn): # pragma: no cover
+							fn = os.path.join(TEST_FILES_DIR, 'testcase01.log')
+						cmd[3] = fn
 					# if fast add dummy regex to prevent too long compile of all regexp (we don't use it in this test at all):
 					elif unittest.F2B.fast and (
 						len(cmd) > 3 and cmd[0] in ('set', 'multi-set') and cmd[2] == 'addfailregex'


### PR DESCRIPTION
small fixes for 0.10:
* prevent to fail stock configs test case, if any jail custom config does not have own test log-file (perhaps not clean copy), see https://github.com/fail2ban/fail2ban/pull/1413#issuecomment-218764683

* allow using of IPv6 address style mask (analog to the IPv4), for example: `2606:28ff::/ffff:ff80::` -> `2606:2880::/25`
* fast calculating of maskplen using map table MAP_ADDR2MASKPLEN, with pre-calculated addr->maskplen values;
test cases extended;

