### PR TITLE
0.10 fix multi set: 

### DIFF
--- a/fail2ban/client/csocket.py
+++ b/fail2ban/client/csocket.py
@@ -44,7 +44,9 @@ class CSocket:
 	
 	def send(self, msg):
 		# Convert every list member to string
-		obj = dumps([str(m) for m in msg], HIGHEST_PROTOCOL)
+		obj = dumps(map(
+			lambda m: str(m) if not isinstance(m, (list, dict, set)) else m, msg),
+		  HIGHEST_PROTOCOL)
 		self.__csock.send(obj + CSPROTO.END)
 		return self.receive(self.__csock)
 

--- a/fail2ban/server/database.py
+++ b/fail2ban/server/database.py
@@ -455,7 +455,7 @@ class Fail2BanDb(object):
 			queryArgs.append(MyTime.time() - bantime)
 		if ip is not None:
 			query += " AND ip=?"
-			queryArgs.append(ip)
+			queryArgs.append(str(ip))
 		query += " ORDER BY ip, timeofban desc"
 
 		return cur.execute(query, queryArgs)

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -266,8 +266,10 @@ class Server:
 		flt = self.__jails[name].filter
 		if multiple:
 			for value in value:
+				logSys.debug("  failregex: %r", value)
 				flt.addFailRegex(value)
 		else:
+			logSys.debug("  failregex: %r", value)
 			flt.addFailRegex(value)
 	
 	def delFailRegex(self, name, index):
@@ -280,8 +282,10 @@ class Server:
 		flt = self.__jails[name].filter
 		if multiple:
 			for value in value:
+				logSys.debug("  ignoreregex: %r", value)
 				flt.addIgnoreRegex(value)
 		else:
+			logSys.debug("  ignoreregex: %r", value)
 			flt.addIgnoreRegex(value)
 	
 	def delIgnoreRegex(self, name, index):

--- a/fail2ban/server/transmitter.py
+++ b/fail2ban/server/transmitter.py
@@ -52,7 +52,7 @@ class Transmitter:
 	
 	def proceed(self, command):
 		# Deserialize object
-		logSys.debug("Command: " + repr(command))
+		logSys.debug("Command: %r", command)
 		try:
 			ret = self.__commandHandler(command)
 			ack = 0, ret
@@ -263,6 +263,7 @@ class Transmitter:
 			action = self.__server.getAction(name, actionname)
 			if multiple:
 				for cmd in command[3]:
+					logSys.debug("  %r", cmd)
 					actionkey = cmd[0]
 					if callable(getattr(action, actionkey, None)):
 						actionvalue = json.loads(cmd[1]) if len(cmd)>1 else {}


### PR DESCRIPTION
Fixes:
*  csocket multi-set fix: prevent to convert `list`, `dict`, `set` during transfer (send), this offers a sending of 'multi-set' arrays 
(forgotten by cherry-picking from my multi-set branch)
* a little bit more details (in debug logging) if multi-set used
* database: always explicit convert `ip` to `str`, because may be an IPAddr, that will be unsupported type by bind parameter (as long as we've found any default wrapper handler for sqlite3)
