### PR TITLE
ENH: version Fail2Ban in this branch as 0.10.0 alpha 1

### DIFF
--- a/fail2ban/version.py
+++ b/fail2ban/version.py
@@ -24,4 +24,4 @@ __author__ = "Cyril Jaquier, Yaroslav Halchenko, Steven Hiscocks, Daniel Black"
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier, 2005-2016 Yaroslav Halchenko, 2013-2014 Steven Hiscocks, Daniel Black"
 __license__ = "GPL-v2+"
 
-version = "0.9.4.dev0"
+version = "0.10.0a1"


### PR DESCRIPTION
- [x] **KEEP PR small** so it could be easily reviewed.

Spotted that fail2ban reports being 0.9.... while running from this branch, so thought time to fix it ;)

Versioning follows https://www.python.org/dev/peps/pep-0440/  so `a1` suffix would precede the eventual release `0.10.0` if compared with distutils.version.StrictVersion