### PR TITLE
BF: maintain previous default beh for pf -- default ban type is multiport 

### DIFF
--- a/config/action.d/pf.conf
+++ b/config/action.d/pf.conf
@@ -72,10 +72,6 @@ tablename = f2b
 protocol = tcp
 
 
-# Option:  port
-# Notes.:  specifies port to monitor
-# Values:  [ NUM | STRING ]  Default:
-port = ssh
 
 # Option: actiontype
 # Notes.: defines additions to the blocking rule
@@ -90,5 +86,5 @@ allports = any
 
 # Option: multiport
 # Notes.: addition to block access only to specific ports
-# Usage.: use in jail config: "banaction = pf[actiontype=<multiport>, port="%(port)s"]"
+# Usage.: use in jail config: "banaction = pf[actiontype=<multiport>]"
 multiport = any port <port>

--- a/config/action.d/pf.conf
+++ b/config/action.d/pf.conf
@@ -75,14 +75,13 @@ protocol = tcp
 # Option:  port
 # Notes.:  specifies port to monitor
 # Values:  [ NUM | STRING ]  Default:
-#
-#port = telnet
+port = ssh
 
 # Option: actiontype
 # Notes.: defines additions to the blocking rule
 # Values: leave empty to block all attempts from the host
-# Default: Value of the allports
-actiontype = any
+# Default: Value of the multiport
+actiontype = <multiport>
 
 # Option: allports
 # Notes.: default addition to block all ports
@@ -91,5 +90,5 @@ allports = any
 
 # Option: multiport
 # Notes.: addition to block access only to specific ports
-# Usage.: use in jail config: "banaction = pf[actiontype=<multiport>]"
+# Usage.: use in jail config: "banaction = pf[actiontype=<multiport>, port="%(port)s"]"
 multiport = any port <port>

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -1370,14 +1370,14 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					),
 					'ip6-unban': (
 						r"`echo -2001:db8:: > /proc/net/xt_recent/f2b-j-w-iptables-xtre6`",
-					),					
+					),
 				}),
-				# pf allports --
+				# pf default - multiport on ssh --
 				('j-w-pf', 'pf[name=%(__name__)s]', {
 					'ip4': (), 'ip6': (),
 					'start': (
 						'`echo "table <f2b-j-w-pf> persist counters" | pfctl -f-`',
-						'`echo "block proto tcp from <f2b-j-w-pf> to any" | pfctl -f-`',
+						'`echo "block proto tcp from <f2b-j-w-pf> to any port ssh" | pfctl -f-`',
 					),
 					'stop': (
 						'`pfctl -sr 2>/dev/null | grep -v f2b-j-w-pf | pfctl -f-`',
@@ -1391,7 +1391,7 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					'ip6-ban':   ("`pfctl -t f2b-j-w-pf -T add 2001:db8::`",),
 					'ip6-unban': ("`pfctl -t f2b-j-w-pf -T delete 2001:db8::`",),
 				}),
-				# pf multiport --
+				# pf multiport with custom port --
 				('j-w-pf-mp', 'pf[actiontype=<multiport>][name=%(__name__)s, port=http]', {
 					'ip4': (), 'ip6': (),
 					'start': (
@@ -1409,6 +1409,25 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					'ip4-unban': ("`pfctl -t f2b-j-w-pf-mp -T delete 192.0.2.1`",),
 					'ip6-ban':   ("`pfctl -t f2b-j-w-pf-mp -T add 2001:db8::`",),
 					'ip6-unban': ("`pfctl -t f2b-j-w-pf-mp -T delete 2001:db8::`",),
+				}),
+				# pf allports --
+				('j-w-pf-ap', 'pf[name=%(__name__)s,actiontype=<allports>]', {
+					'ip4': (), 'ip6': (),
+					'start': (
+						'`echo "table <f2b-j-w-pf-ap> persist counters" | pfctl -f-`',
+						'`echo "block proto tcp from <f2b-j-w-pf-ap> to any" | pfctl -f-`',
+					),
+					'stop': (
+						'`pfctl -sr 2>/dev/null | grep -v f2b-j-w-pf-ap | pfctl -f-`',
+						'`pfctl -t f2b-j-w-pf-ap -T flush`',
+						'`pfctl -t f2b-j-w-pf-ap -T kill`',
+					),
+					'ip4-check': ("`pfctl -sr | grep -q f2b-j-w-pf-ap`",),
+					'ip6-check': ("`pfctl -sr | grep -q f2b-j-w-pf-ap`",),
+					'ip4-ban':   ("`pfctl -t f2b-j-w-pf-ap -T add 192.0.2.1`",),
+					'ip4-unban': ("`pfctl -t f2b-j-w-pf-ap -T delete 192.0.2.1`",),
+					'ip6-ban':   ("`pfctl -t f2b-j-w-pf-ap -T add 2001:db8::`",),
+					'ip6-unban': ("`pfctl -t f2b-j-w-pf-ap -T delete 2001:db8::`",),
 				}),
 				# firewallcmd-multiport --
 				('j-w-fwcmd-mp', 'firewallcmd-multiport[name=%(__name__)s, bantime="600", port="http,https", protocol="tcp", chain="INPUT"]', {

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -1372,12 +1372,12 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 						r"`echo -2001:db8:: > /proc/net/xt_recent/f2b-j-w-iptables-xtre6`",
 					),
 				}),
-				# pf default - multiport on ssh --
+				# pf default -- multiport on default port (tag <port> set in jail.conf, but not in this test case)
 				('j-w-pf', 'pf[name=%(__name__)s]', {
 					'ip4': (), 'ip6': (),
 					'start': (
 						'`echo "table <f2b-j-w-pf> persist counters" | pfctl -f-`',
-						'`echo "block proto tcp from <f2b-j-w-pf> to any port ssh" | pfctl -f-`',
+						'`echo "block proto tcp from <f2b-j-w-pf> to any port <port>" | pfctl -f-`',
 					),
 					'stop': (
 						'`pfctl -sr 2>/dev/null | grep -v f2b-j-w-pf | pfctl -f-`',
@@ -1411,7 +1411,7 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					'ip6-unban': ("`pfctl -t f2b-j-w-pf-mp -T delete 2001:db8::`",),
 				}),
 				# pf allports --
-				('j-w-pf-ap', 'pf[name=%(__name__)s,actiontype=<allports>]', {
+				('j-w-pf-ap', 'pf[actiontype=<allports>][name=%(__name__)s]', {
 					'ip4': (), 'ip6': (),
 					'start': (
 						'`echo "table <f2b-j-w-pf-ap> persist counters" | pfctl -f-`',


### PR DESCRIPTION
I felt that it is not time/place to change default behavior of pf banning a single port, as the majority (if not all) actions do by default.  So I have complemented to merged #1429, and reverted back to original behaviour -- ban a single port, BUT changed which port to ban (ssh, not telnet). Adjusted doc also to note that port specification is desired if multiport is used

- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **MAKE SURE** this PR doesn't break existing tests 
- [x] **KEEP PR small** so it could be easily reviewed.
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code (did remove one trailing space thing right before my changes)
