### PR TITLE
fixed --pidfile bug, introduced in gh-1322

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,8 @@ ver. 0.9.5 (2016/XX/XXX) - wanna-be-released
    * fixed a grave bug within tags substitutions because of incorrect detection of recursion 
      in case of multiple inline substitutions of the same tag (affected actions: `bsd-ipfw`, etc). 
      Now tracks the actual list of the already substituted tags (per tag instead of single list)
+   * gentoo-initd fixed --pidfile bug: `--pidfile` is option of start-stop-daemon, 
+     not argument of fail2ban (see gh-1434)
 
 - New Features:
    * New Actions:

--- a/files/gentoo-initd
+++ b/files/gentoo-initd
@@ -34,15 +34,15 @@ start() {
 	# remove stalled sock file after system crash
 	# bug 347477
 	rm -f /var/run/fail2ban/fail2ban.sock || return 1
-	start-stop-daemon --start --exec ${FAIL2BAN} start \
-	--pidfile /var/run/fail2ban/fail2ban.pid
+	start-stop-daemon --start --pidfile /var/run/fail2ban/fail2ban.pid \
+	--exec ${FAIL2BAN} start
 	eend $? "Failed to start fail2ban"
 }
 
 stop() {
 	ebegin "Stopping fail2ban"
-	start-stop-daemon --stop --exec ${FAIL2BAN} stop \
-	--pidfile /var/run/fail2ban/fail2ban.pid
+	start-stop-daemon --stop --pidfile /var/run/fail2ban/fail2ban.pid \
+	--exec ${FAIL2BAN} stop
 	eend $? "Failed to stop fail2ban"
 }
 


### PR DESCRIPTION
gentoo-initd fixed --pidfile bug: `--pidfile` is option of start-stop-daemon, not argument of fail2ban (see gh-1434)
closes gh-1434