### PR TITLE
extremely speedup of all database operations:

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,11 @@ ver. 0.9.5 (2016/XX/XXX) - wanna-be-released
    * New Actions:
      - action.d/firewallcmd-rich-rules and action.d/firewallcmd-rich-logging (gh-1367)
 - Enhancements:
+   * Extreme speedup of all sqlite database operations (gh-1436),
+     by using of following sqlite options:
+     - (synchronous = OFF) write data through OS without syncing
+     - (journal_mode = MEMORY) use memory for the transaction logging
+     - (temp_store = MEMORY) temporary tables and indices are kept in memory
    * journald journalmatch for pure-ftpd (gh-1362)
    * Add additional regex filter for dovecot ldap authentication failures (gh-1370)
    * added additional regex filters for exim (gh-1371)

--- a/fail2ban/server/database.py
+++ b/fail2ban/server/database.py
@@ -182,8 +182,11 @@ class Fail2BanDb(object):
 			raise
 
 		cur = self._db.cursor()
-		cur.execute("PRAGMA foreign_keys = ON;")
-
+		cur.execute("PRAGMA foreign_keys = ON")
+		# speedup: write data through OS without syncing (no wait):
+		cur.execute("PRAGMA synchronous = OFF")
+		# speedup: transaction log in memory, alternate using OFF (disable, rollback will be impossible):
+		cur.execute("PRAGMA journal_mode = MEMORY")
 		try:
 			cur.execute("SELECT version FROM fail2banDb LIMIT 1")
 		except sqlite3.OperationalError:


### PR DESCRIPTION
- (synchronous = OFF) write data through OS without syncing
- (journal_mode = MEMORY) use memory for the transaction logging
- (temp_store = MEMORY) temporary tables and indices are kept in memory