### PR TITLE
remove redundant IPAddr import

### DIFF
--- a/fail2ban/server/actions.py
+++ b/fail2ban/server/actions.py
@@ -42,7 +42,6 @@ from .banmanager import BanManager
 from .jailthread import JailThread
 from .action import ActionBase, CommandAction, CallingMap
 from .mytime import MyTime
-from .filter import IPAddr
 from .utils import Utils
 from ..helpers import getLogger
 


### PR DESCRIPTION
This PR is quite cosmetic and just removes a redundant import statement of *IPAddr* in actions.py