### PR TITLE
Added SELinux module draft

### DIFF
--- a/files/nagios/README
+++ b/files/nagios/README
@@ -28,17 +28,13 @@ following steps:
 SELinux Notes:
 If you're using SELinux in Enforcing mode, you will need to create a SELinux module - otherwise the check will abort with the typical "NRPE: Unable to read output" error.
 An SELinux module draft is part of this folder, you only need to compile and install it:
-```
 # checkmodule -M -m -o nrpe_fail2ban.mod nrpe_fail2ban.te
 # semodule_package -o nrpe_fail2ban.pp -m nrpe_fail2ban.mod
 # semodule -i nrpe_fail2ban.pp
-```
 
 After installation, ensure that the module is loaded:
-```
 # semodule -l | grep nrpe
 nrpe_fail2ban   1.0
-```
 
 
 

--- a/files/nagios/README
+++ b/files/nagios/README
@@ -25,6 +25,23 @@ following steps:
 ------------------------------------------------------------------------------
 
 
+SELinux Notes:
+If you're using SELinux in Enforcing mode, you will need to create a SELinux module - otherwise the check will abort with the typical "NRPE: Unable to read output" error.
+An SELinux module draft is part of this folder, you only need to compile and install it:
+```
+# checkmodule -M -m -o nrpe_fail2ban.mod nrpe_fail2ban.te
+# semodule_package -o nrpe_fail2ban.pp -m nrpe_fail2ban.mod
+# semodule -i nrpe_fail2ban.pp
+```
+
+After installation, ensure that the module is loaded:
+```
+# semodule -l | grep nrpe
+nrpe_fail2ban   1.0
+```
+
+
+
 Notes (from f2ban.txt)
 -----
 It seems that Fail2ban is currently not working, please login and check

--- a/files/nagios/nrpe_fail2ban.te
+++ b/files/nagios/nrpe_fail2ban.te
@@ -1,0 +1,36 @@
+
+module nrpe_fail2ban 1.0;
+
+require {
+	type admin_home_t;
+	type nrpe_t;
+	class unix_dgram_socket sendto;
+	class file execute;
+	class file getattr;
+	class file { read getattr open };
+	class file execute_no_trans;
+	type fail2ban_client_exec_t;
+	class file { ioctl getattr };
+	class file { read open };
+	class file execute_no_trans;
+	type fail2ban_var_run_t;
+	class sock_file write;
+	class file ioctl;
+	type fail2ban_t;
+	class unix_stream_socket connectto;
+}
+
+#============= nrpe_t ==============
+allow nrpe_t admin_home_t:file execute;
+allow nrpe_t self:unix_dgram_socket sendto;
+allow nrpe_t admin_home_t:file getattr;
+allow nrpe_t admin_home_t:file { read open };
+allow nrpe_t admin_home_t:file execute_no_trans;
+allow nrpe_t admin_home_t:file ioctl;
+allow nrpe_t fail2ban_client_exec_t:file getattr;
+allow nrpe_t fail2ban_client_exec_t:file execute;
+allow nrpe_t fail2ban_client_exec_t:file { read open };
+allow nrpe_t fail2ban_client_exec_t:file execute_no_trans;
+allow nrpe_t fail2ban_client_exec_t:file ioctl;
+allow nrpe_t fail2ban_var_run_t:sock_file write;
+allow nrpe_t fail2ban_t:unix_stream_socket connectto;


### PR DESCRIPTION
Hey folks,
great that you're offering a Nagios / Icinga plugin for fail2ban.

On CentOS I had some problems getting this plugin running in combination with SELinux in Enforcing mode. There was no pre-existing SELinux module for the check_fail2ban utility - so I created one. Works like a charm in my lab.
Maybe this can help somebody out there - took some time for troubleshooting and fixing.
