### PR TITLE
[gh-67] no-host ban

### DIFF
--- a/config/jail.conf
+++ b/config/jail.conf
@@ -94,6 +94,7 @@ backend = auto
 #        but it will be logged as a warning.
 # no:    if a hostname is encountered, will not be used for banning,
 #        but it will be logged as info.
+# raw:   use raw value (no hostname), allow use it for no-host filters/actions (example user)
 usedns = warn
 
 # "logencoding" specifies the encoding of the log files handled by the jail

--- a/fail2ban/client/fail2banregex.py
+++ b/fail2ban/client/fail2banregex.py
@@ -126,6 +126,8 @@ Report bugs to https://github.com/fail2ban/fail2ban/issues
 			   help="set custom pattern used to match date/times"),
 		Option("-e", "--encoding",
 			   help="File encoding. Default: system locale"),
+		Option("-r", "--raw", action='store_true',
+			   help="Raw hosts, don't resolve dns"),
 		Option("-L", "--maxlines", type=int, default=0,
 			   help="maxlines for multi-line regex"),
 		Option("-m", "--journalmatch",
@@ -239,6 +241,7 @@ class Fail2banRegex(object):
 			self.encoding = opts.encoding
 		else:
 			self.encoding = locale.getpreferredencoding()
+		self.raw = True if opts.raw else False
 
 	def decode_line(self, line):
 		return FileContainer.decode_line('<LOG>', self.encoding, line)
@@ -335,7 +338,7 @@ class Fail2banRegex(object):
 		orgLineBuffer = self._filter._Filter__lineBuffer
 		fullBuffer = len(orgLineBuffer) >= self._filter.getMaxLines()
 		try:
-			line, ret = self._filter.processLine(line, date, checkAllRegex=True)
+			line, ret = self._filter.processLine(line, date, checkAllRegex=True, returnRawHost=self.raw)
 			for match in ret:
 				# Append True/False flag depending if line was matched by
 				# more than one regex

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -523,7 +523,7 @@ class Filter(JailThread):
 					self.__lineBuffer = failRegex.getUnmatchedTupleLines()
 					try:
 						host = failRegex.getHost()
-						if returnRawHost:
+						if returnRawHost or self.__useDns not in ("yes", "warn"):
 							failList.append([failRegexIndex, host, date,
 								 failRegex.getMatchedLines()])
 							if not checkAllRegex:

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -523,7 +523,7 @@ class Filter(JailThread):
 					self.__lineBuffer = failRegex.getUnmatchedTupleLines()
 					try:
 						host = failRegex.getHost()
-						if returnRawHost or self.__useDns not in ("yes", "warn"):
+						if returnRawHost or self.__useDns == "raw":
 							failList.append([failRegexIndex, host, date,
 								 failRegex.getMatchedLines()])
 							if not checkAllRegex:

--- a/fail2ban/tests/fail2banregextestcase.py
+++ b/fail2ban/tests/fail2banregextestcase.py
@@ -132,6 +132,15 @@ class Fail2banRegexTest(LogCaptureTestCase):
 		self.assertLogged('Dez 31 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 193.168.0.128')
 		self.assertLogged('Dec 31 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 87.142.124.10')
 
+	def testDirectRE_1raw(self):
+		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--print-all-matched", "--raw",
+			Fail2banRegexTest.FILENAME_01, 
+			Fail2banRegexTest.RE_00
+		)
+		self.assertTrue(fail2banRegex.start(opts, args))
+		self.assertLogged('Lines: 19 lines, 0 ignored, 16 matched, 3 missed')
+
 	def testDirectRE_2(self):
 		(opts, args, fail2banRegex) = _Fail2banRegex(
 			"--print-all-matched",


### PR DESCRIPTION
Partially closes gh-67:
- there is any unique ban identifier available (ban-id)
- this ban-id (user, ip:port pair, something else) stand together and can be retrieved with exact one group

Example for test jail to ban users, config `jail.local`:
```bash
[test]
# don't use dns, because host group is not hostname (and not resolvable ip):
usedns = raw
ignoreip =
ignorecommand =
# if used some filter:
#filter = no-host-filter[HOST=(?P<host>\S+)]
#
# if used failregex:
filter =
failregex = ^\s*(?:\S+\s+)?(?:[^:]+:auth\[\d+\]:\s+)?pam_unix(?:\(\S+\))?:?\s+authentication failure; login=(?P<host>\S+)
# action that bans users
banaction = test-ban-user[name=%(__name__)s]
#
logpath  = %(syslog_authpriv)s
enabled = true
```
Action config file `action.d/test-ban-user.conf`:
```bash
[Definition]
actionstart = 
actionstop =
actioncheck =
actionban = echo 'ban f2b-<name> --user <ip>'
actionunban = echo 'unban f2b-<name> --user <ip>'
```

To test, the user "xxx" will be banned, just execute:
```bash
logger -t 'test:auth' -i -p auth.info "pam_unix(test:auth): authentication failure; login=xxx"
logger -t 'test:auth' -i -p auth.info "pam_unix(test:auth): authentication failure; login=xxx"
logger -t 'test:auth' -i -p auth.info "pam_unix(test:auth): authentication failure; login=xxx"
```

To test regular expression, use new option `--raw` or `-r`, to prevent dns resolving errors:
```bash
fail2ban-regex --raw /var/log/auth.log '^\s*(?:\S+\s+)?(?:[^:]+:auth\[\d+\]:\s+)?pam_unix(?:\(\S+\))?:?\s+authentication failure; login=(?P<host>\S+)'
```