### PR TITLE
0.10 fid host ip tags

### DIFF
--- a/config/action.d/badips.py
+++ b/config/action.d/badips.py
@@ -80,14 +80,17 @@ class BadIPsAction(ActionBase):
 		If invalid `category`, `score`, `banaction` or `updateperiod`.
 	"""
 
+	TIMEOUT = 10
 	_badips = "http://www.badips.com"
 	def _Request(self, url, **argv):
 		return Request(url, headers={'User-Agent': self.agent}, **argv)
 
 	def __init__(self, jail, name, category, score=3, age="24h", key=None,
-		banaction=None, bancategory=None, bankey=None, updateperiod=900, agent="Fail2Ban"):
+		banaction=None, bancategory=None, bankey=None, updateperiod=900, agent="Fail2Ban", 
+		timeout=TIMEOUT):
 		super(BadIPsAction, self).__init__(jail, name)
 
+		self.timeout = timeout
 		self.agent = agent
 		self.category = category
 		self.score = score
@@ -119,7 +122,7 @@ class BadIPsAction(ActionBase):
 		"""
 		try:
 			response = urlopen(
-				self._Request("/".join([self._badips, "get", "categories"])), None, 3)
+				self._Request("/".join([self._badips, "get", "categories"])), timeout=self.timeout)
 		except HTTPError as response:
 			messages = json.loads(response.read().decode('utf-8'))
 			self._logSys.error(
@@ -173,7 +176,7 @@ class BadIPsAction(ActionBase):
 				urlencode({'age': age})])
 			if key:
 				url = "&".join([url, urlencode({'key': key})])
-			response = urlopen(self._Request(url))
+			response = urlopen(self._Request(url), timeout=self.timeout)
 		except HTTPError as response:
 			messages = json.loads(response.read().decode('utf-8'))
 			self._logSys.error(
@@ -358,7 +361,7 @@ class BadIPsAction(ActionBase):
 			url = "/".join([self._badips, "add", self.category, aInfo['ip']])
 			if self.key:
 				url = "?".join([url, urlencode({'key': self.key})])
-			response = urlopen(self._Request(url))
+			response = urlopen(self._Request(url), timeout=self.timeout)
 		except HTTPError as response:
 			messages = json.loads(response.read().decode('utf-8'))
 			self._logSys.error(

--- a/config/filter.d/courier-smtp.conf
+++ b/config/filter.d/courier-smtp.conf
@@ -13,7 +13,7 @@ before = common.conf
 _daemon = courieresmtpd
 
 failregex = ^%(__prefix_line)serror,relay=<HOST>,.*: 550 User (<.*> )?unknown\.?$
-            ^%(__prefix_line)serror,relay=<HOST>,msg="535 Authentication failed\.",cmd:( AUTH \S+)?( [0-9a-zA-Z\+/=]+)?$
+            ^%(__prefix_line)serror,relay=<HOST>,msg="535 Authentication failed\.",cmd:( AUTH \S+)?( [0-9a-zA-Z\+/=]+)?(?: \S+)$
 
 ignoreregex = 
 

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -94,6 +94,7 @@ backend = auto
 #        but it will be logged as a warning.
 # no:    if a hostname is encountered, will not be used for banning,
 #        but it will be logged as info.
+# raw:   use raw value (no hostname), allow use it for no-host filters/actions (example user)
 usedns = warn
 
 # "logencoding" specifies the encoding of the log files handled by the jail

--- a/fail2ban/client/fail2banregex.py
+++ b/fail2ban/client/fail2banregex.py
@@ -125,6 +125,8 @@ Report bugs to https://github.com/fail2ban/fail2ban/issues
 			   help="set custom pattern used to match date/times"),
 		Option("-e", "--encoding",
 			   help="File encoding. Default: system locale"),
+		Option("-r", "--raw", action='store_true',
+			   help="Raw hosts, don't resolve dns"),
 		Option("-L", "--maxlines", type=int, default=0,
 			   help="maxlines for multi-line regex"),
 		Option("-m", "--journalmatch",
@@ -238,6 +240,7 @@ class Fail2banRegex(object):
 			self.encoding = opts.encoding
 		else:
 			self.encoding = locale.getpreferredencoding()
+		self.raw = True if opts.raw else False
 
 	def decode_line(self, line):
 		return FileContainer.decode_line('<LOG>', self.encoding, line)
@@ -341,7 +344,7 @@ class Fail2banRegex(object):
 		orgLineBuffer = self._filter._Filter__lineBuffer
 		fullBuffer = len(orgLineBuffer) >= self._filter.getMaxLines()
 		try:
-			line, ret = self._filter.processLine(line, date, checkAllRegex=True)
+			line, ret = self._filter.processLine(line, date, checkAllRegex=True, returnRawHost=self.raw)
 			for match in ret:
 				# Append True/False flag depending if line was matched by
 				# more than one regex

--- a/fail2ban/server/failregex.py
+++ b/fail2ban/server/failregex.py
@@ -274,7 +274,7 @@ class FailRegex(Regex):
 		for grp in groups:
 			try:
 				fid = self._matchCache.group(grp)
-			except IndexError:
+			except (IndexError, KeyError):
 				continue
 			if fid is not None:
 				break

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -533,21 +533,17 @@ class Filter(JailThread):
 						# failure-id:
 						fid = fail.get('fid')
 						# ip-address or host:
-						host = fail.get('ip4')
+						host = fail.get('ip4') or fail.get('ip6')
 						if host is not None:
 							raw = True
 						else:
-							host = fail.get('ip6')
-							if host is not None:
-								raw = True
-							else:
-								host = fail.get('dns')
-								if host is None:
-									# if no failure-id also (obscure case, wrong regex), throw error inside getFailID:
-									if fid is None:
-										fid = failRegex.getFailID()
-									host = fid
-									cidr = IPAddr.CIDR_RAW
+							host = fail.get('dns')
+							if host is None:
+								# if no failure-id also (obscure case, wrong regex), throw error inside getFailID:
+								if fid is None:
+									fid = failRegex.getFailID()
+								host = fid
+								cidr = IPAddr.CIDR_RAW
 						# if raw - add single ip or failure-id,
 						# otherwise expand host to multiple ips using dns (or ignore it if not valid):
 						if raw:

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -418,6 +418,9 @@ class Filter(JailThread):
 			ip = element[1]
 			unixTime = element[2]
 			lines = element[3]
+			fail = {}
+			if len(element) > 4:
+				fail = element[4]
 			logSys.debug("Processing line with time:%s and ip:%s", 
 					unixTime, ip)
 			if unixTime < MyTime.time() - self.getFindTime():
@@ -429,7 +432,7 @@ class Filter(JailThread):
 			logSys.info(
 				"[%s] Found %s - %s", self.jail.name, ip, datetime.datetime.fromtimestamp(unixTime).strftime("%Y-%m-%d %H:%M:%S")
 			)
-			tick = FailTicket(ip, unixTime, lines)
+			tick = FailTicket(ip, unixTime, lines, data=fail)
 			self.failManager.addFailure(tick)
 
 	##
@@ -457,7 +460,12 @@ class Filter(JailThread):
 		checkAllRegex=False):
 		failList = list()
 
-		# Checks if we must ignore this line.
+		cidr = IPAddr.CIDR_UNSPEC
+		if self.__useDns == "raw":
+			returnRawHost = True
+			cidr = IPAddr.CIDR_RAW
+
+		# Checks if we mut ignore this line.
 		if self.ignoreLine([tupleLine[::2]]) is not None:
 			# The ignoreregex matched. Return.
 			logSys.log(7, "Matched ignoreregex and was \"%s\" ignored",
@@ -518,19 +526,45 @@ class Filter(JailThread):
 						 % ("\n".join(failRegex.getMatchedLines()), timeText))
 				else:
 					self.__lineBuffer = failRegex.getUnmatchedTupleLines()
+					# retrieve failure-id, host, etc from failure match:
+					raw = returnRawHost
 					try:
-						host = failRegex.getHost()
-						if returnRawHost or self.__useDns == "raw":
-							failList.append([failRegexIndex, IPAddr(host), date,
-								 failRegex.getMatchedLines()])
+						fail = failRegex.getGroups()
+						# failure-id:
+						fid = fail.get('fid')
+						# ip-address or host:
+						host = fail.get('ip4')
+						if host is not None:
+							raw = True
+						else:
+							host = fail.get('ip6')
+							if host is not None:
+								raw = True
+							else:
+								host = fail.get('dns')
+								if host is None:
+									# if no failure-id also (obscure case, wrong regex), throw error inside getFailID:
+									if fid is None:
+										fid = failRegex.getFailID()
+									host = fid
+									cidr = IPAddr.CIDR_RAW
+						# if raw - add single ip or failure-id,
+						# otherwise expand host to multiple ips using dns (or ignore it if not valid):
+						if raw:
+							ip = IPAddr(host, cidr)
+							# check host equal failure-id, if not - failure with complex id:
+							if fid is not None and fid != host:
+								ip = IPAddr(fid, IPAddr.CIDR_RAW)
+							failList.append([failRegexIndex, ip, date,
+								failRegex.getMatchedLines(), fail])
 							if not checkAllRegex:
 								break
 						else:
 							ips = DNSUtils.textToIp(host, self.__useDns)
 							if ips:
 								for ip in ips:
-									failList.append([failRegexIndex, ip, 
-										 date, failRegex.getMatchedLines()])
+									failList.append([failRegexIndex, ip, date,
+										failRegex.getMatchedLines(), fail])
 								if not checkAllRegex:
 									break
 					except RegexException, e: # pragma: no cover - unsure if reachable

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -171,7 +171,7 @@ class Filter(JailThread):
 		if isinstance(value, bool):
 			value = {True: 'yes', False: 'no'}[value]
 		value = value.lower()			  # must be a string by now
-		if not (value in ('yes', 'no', 'warn')):
+		if not (value in ('yes', 'warn', 'no', 'raw')):
 			logSys.error("Incorrect value %r specified for usedns. "
 						 "Using safe 'no'" % (value,))
 			value = 'no'
@@ -520,7 +520,7 @@ class Filter(JailThread):
 					self.__lineBuffer = failRegex.getUnmatchedTupleLines()
 					try:
 						host = failRegex.getHost()
-						if returnRawHost:
+						if returnRawHost or self.__useDns == "raw":
 							failList.append([failRegexIndex, IPAddr(host), date,
 								 failRegex.getMatchedLines()])
 							if not checkAllRegex:

--- a/fail2ban/server/ipdns.py
+++ b/fail2ban/server/ipdns.py
@@ -138,18 +138,21 @@ class IPAddr(object):
 	# todo: make configurable the expired time and max count of cache entries:
 	CACHE_OBJ = Utils.Cache(maxCount=1000, maxTime=5*60)
 
-	def __new__(cls, ipstr, cidr=-1):
+	CIDR_RAW = -2
+	CIDR_UNSPEC = -1
+
+	def __new__(cls, ipstr, cidr=CIDR_UNSPEC):
 		# check already cached as IPAddr
 		args = (ipstr, cidr)
 		ip = IPAddr.CACHE_OBJ.get(args)
 		if ip is not None:
 			return ip
 		# wrap mask to cidr (correct plen):
-		if cidr == -1:
+		if cidr == IPAddr.CIDR_UNSPEC:
 			ipstr, cidr = IPAddr.__wrap_ipstr(ipstr)
 			args = (ipstr, cidr)
 			# check cache again:
-			if cidr != -1:
+			if cidr != IPAddr.CIDR_UNSPEC:
 				ip = IPAddr.CACHE_OBJ.get(args)
 				if ip is not None:
 					return ip
@@ -166,7 +169,7 @@ class IPAddr(object):
 			ipstr = ipstr[1:-1]
 		# test mask:
 		if "/" not in ipstr:
-			return ipstr, -1
+			return ipstr, IPAddr.CIDR_UNSPEC
 		s = ipstr.split('/', 1)
 		# IP address without CIDR mask
 		if len(s) > 2:
@@ -176,7 +179,7 @@ class IPAddr(object):
 		s[1] = long(s[1])
 		return s
 		
-	def __init(self, ipstr, cidr=-1):
+	def __init(self, ipstr, cidr=CIDR_UNSPEC):
 		""" initialize IP object by converting IP address string
 			to binary to integer
 		"""
@@ -184,49 +187,48 @@ class IPAddr(object):
 		self._addr = 0
 		self._plen = 0
 		self._maskplen = None
-		self._raw = ""
+		# always save raw value (normally used if really raw or not valid only):
+		self._raw = ipstr
+		# if not raw - recognize family, set addr, etc.:
+		if cidr != IPAddr.CIDR_RAW:
+			for family in [socket.AF_INET, socket.AF_INET6]:
+				try:
+					binary = socket.inet_pton(family, ipstr)
+					self._family = family
+					break
+				except socket.error:
+					continue
 
-		for family in [socket.AF_INET, socket.AF_INET6]:
-			try:
-				binary = socket.inet_pton(family, ipstr)
-				self._family = family
-				break
-			except socket.error:
-				continue
-
-		if self._family == socket.AF_INET:
-			# convert host to network byte order
-			self._addr, = struct.unpack("!L", binary)
-			self._plen = 32
-
-			# mask out host portion if prefix length is supplied
-			if cidr is not None and cidr >= 0:
-				mask = ~(0xFFFFFFFFL >> cidr)
-				self._addr &= mask
-				self._plen = cidr
-
-		elif self._family == socket.AF_INET6:
-			# convert host to network byte order
-			hi, lo = struct.unpack("!QQ", binary)
-			self._addr = (hi << 64) | lo
-			self._plen = 128
-
-			# mask out host portion if prefix length is supplied
-			if cidr is not None and cidr >= 0:
-				mask = ~(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFL >> cidr)
-				self._addr &= mask
-				self._plen = cidr
-
-			# if IPv6 address is a IPv4-compatible, make instance a IPv4
-			elif self.isInNet(IPAddr.IP6_4COMPAT):
-				self._addr = lo & 0xFFFFFFFFL
-				self._family = socket.AF_INET
+			if self._family == socket.AF_INET:
+				# convert host to network byte order
+				self._addr, = struct.unpack("!L", binary)
 				self._plen = 32
+
+				# mask out host portion if prefix length is supplied
+				if cidr is not None and cidr >= 0:
+					mask = ~(0xFFFFFFFFL >> cidr)
+					self._addr &= mask
+					self._plen = cidr
+
+			elif self._family == socket.AF_INET6:
+				# convert host to network byte order
+				hi, lo = struct.unpack("!QQ", binary)
+				self._addr = (hi << 64) | lo
+				self._plen = 128
+
+				# mask out host portion if prefix length is supplied
+				if cidr is not None and cidr >= 0:
+					mask = ~(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFL >> cidr)
+					self._addr &= mask
+					self._plen = cidr
+
+				# if IPv6 address is a IPv4-compatible, make instance a IPv4
+				elif self.isInNet(IPAddr.IP6_4COMPAT):
+					self._addr = lo & 0xFFFFFFFFL
+					self._family = socket.AF_INET
+					self._plen = 32
 		else:
-			# string couldn't be converted neither to a IPv4 nor
-			# to a IPv6 address - retain raw input for later use
-			# (e.g. DNS resolution)
-			self._raw = ipstr
+			self._family = IPAddr.CIDR_RAW
 
 	def __repr__(self):
 		return self.ntoa
@@ -270,6 +272,8 @@ class IPAddr(object):
 		return self._family != socket.AF_UNSPEC
 
 	def __eq__(self, other):
+		if self._family == IPAddr.CIDR_RAW and not isinstance(other, IPAddr):
+			return self._raw == other
 		if not isinstance(other, IPAddr):
 			if other is None: return False
 			other = IPAddr(other)
@@ -285,6 +289,8 @@ class IPAddr(object):
 		return not (self == other)
 
 	def __lt__(self, other):
+		if self._family == IPAddr.CIDR_RAW and not isinstance(other, IPAddr):
+			return self._raw < other
 		if not isinstance(other, IPAddr):
 			if other is None: return False
 			other = IPAddr(other)

--- a/fail2ban/server/ipdns.py
+++ b/fail2ban/server/ipdns.py
@@ -85,10 +85,7 @@ class DNSUtils:
 			return v
 		# retrieve name
 		try:
-			if not isinstance(ip, IPAddr):
-				v = socket.gethostbyaddr(ip)[0]
-			else:
-				v = socket.gethostbyaddr(ip.ntoa)[0]
+			v = socket.gethostbyaddr(ip)[0]
 		except socket.error, e:
 			logSys.debug("Unable to find a name for the IP %s: %s", ip, e)
 			v = None
@@ -359,7 +356,7 @@ class IPAddr(object):
 			if not suffix:
 				suffix = "in-addr.arpa."
 		elif self.isIPv6:
-			exploded_ip = self.hexdump()
+			exploded_ip = self.hexdump
 			if not suffix:
 				suffix = "ip6.arpa."
 		else:

--- a/fail2ban/server/ticket.py
+++ b/fail2ban/server/ticket.py
@@ -36,7 +36,7 @@ logSys = getLogger(__name__)
 
 class Ticket:
 	
-	def __init__(self, ip=None, time=None, matches=None, ticket=None):
+	def __init__(self, ip=None, time=None, matches=None, data={}, ticket=None):
 		"""Ticket constructor
 
 		@param ip the IP address
@@ -50,6 +50,7 @@ class Ticket:
 		self._banTime = None;
 		self._time = time if time is not None else MyTime.time()
 		self._data = {'matches': [], 'failures': 0}
+		self._data.update(data)
 		if ticket:
 			# ticket available - copy whole information from ticket:
 			self.__dict__.update(i for i in ticket.__dict__.iteritems() if i[0] in self.__dict__)
@@ -77,6 +78,9 @@ class Ticket:
 		if isinstance(value, basestring):
 			value = IPAddr(value)
 		self.__ip = value
+	
+	def getID(self):
+		return self._data.get('fid', self.__ip)
 	
 	def getIP(self):
 		return self.__ip
@@ -164,12 +168,12 @@ class Ticket:
 
 class FailTicket(Ticket):
 
-	def __init__(self, ip=None, time=None, matches=None, ticket=None):
+	def __init__(self, ip=None, time=None, matches=None, data={}, ticket=None):
 		# this class variables:
 		self.__retry = 0
 		self.__lastReset = None
 		# create/copy using default ticket constructor:
-		Ticket.__init__(self, ip, time, matches, ticket)
+		Ticket.__init__(self, ip, time, matches, data, ticket)
 		# init:
 		if ticket is None:
 			self.__lastReset = time if time is not None else self.getTime()

--- a/fail2ban/tests/action_d/test_badips.py
+++ b/fail2ban/tests/action_d/test_badips.py
@@ -39,6 +39,7 @@ if sys.version_info >= (2,7):
 			self.jail.actions.add("badips", pythonModule, initOpts={
 				'category': "ssh",
 				'banaction': "test",
+				'timeout': (3 if unittest.F2B.fast else 30),
 				})
 			self.action = self.jail.actions["badips"]
 

--- a/fail2ban/tests/fail2banregextestcase.py
+++ b/fail2ban/tests/fail2banregextestcase.py
@@ -132,6 +132,15 @@ class Fail2banRegexTest(LogCaptureTestCase):
 		self.assertLogged('Dez 31 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 193.168.0.128')
 		self.assertLogged('Dec 31 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 87.142.124.10')
 
+	def testDirectRE_1raw(self):
+		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--print-all-matched", "--raw",
+			Fail2banRegexTest.FILENAME_01, 
+			Fail2banRegexTest.RE_00
+		)
+		self.assertTrue(fail2banRegex.start(opts, args))
+		self.assertLogged('Lines: 19 lines, 0 ignored, 16 matched, 3 missed')
+
 	def testDirectRE_2(self):
 		(opts, args, fail2banRegex) = _Fail2banRegex(
 			"--print-all-matched",

--- a/fail2ban/tests/files/logs/courier-smtp
+++ b/fail2ban/tests/files/logs/courier-smtp
@@ -10,3 +10,5 @@ Jul  6 03:42:28 whistler courieresmtpd: error,relay=::ffff:1.2.3.4,from=<>,to=<a
 Nov 21 23:16:17 server courieresmtpd: error,relay=::ffff:1.2.3.4,from=<>,to=<>: 550 User unknown.
 # failJSON: { "time": "2004-08-14T12:51:04", "match": true , "host": "1.2.3.4" }
 Aug 14 12:51:04 HOSTNAME courieresmtpd: error,relay=::ffff:1.2.3.4,from=<firozquarl@aclunc.org>,to=<BOGUSUSER@HOSTEDDOMAIN.org>: 550 User unknown.
+# failJSON: { "time": "2004-08-14T12:51:04", "match": true , "host": "1.2.3.4" }
+Aug 14 12:51:04 mail.server courieresmtpd[26762]: error,relay=::ffff:1.2.3.4,msg="535 Authentication failed.",cmd: AUTH PLAIN AAAAABBBBCCCCWxlZA== admin

--- a/fail2ban/tests/samplestestcase.py
+++ b/fail2ban/tests/samplestestcase.py
@@ -127,7 +127,7 @@ def testSampleRegexsFactory(name, basedir):
 								 (map(lambda x: x[0], ret),logFile.filename(), logFile.filelineno()))
 
 				# Verify timestamp and host as expected
-				failregex, host, fail2banTime, lines = ret[0]
+				failregex, host, fail2banTime, lines, fail = ret[0]
 				self.assertEqual(host, faildata.get("host", None))
 
 				t = faildata.get("time", None)

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -1026,28 +1026,6 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 				logSys.debug(l)
 		return True
 
-	def test_IPAddr(self):
-		self.assertTrue(IPAddr('192.0.2.1').isIPv4)
-		self.assertTrue(IPAddr('2001:DB8::').isIPv6)
-
-	def test_IPAddr_Raw(self):
-		# raw string:
-		r = IPAddr('xxx', IPAddr.CIDR_RAW)
-		self.assertFalse(r.isIPv4)
-		self.assertFalse(r.isIPv6)
-		self.assertTrue(r.isValid)
-		self.assertEqual(r, 'xxx')
-		self.assertEqual('xxx', str(r))
-		self.assertNotEqual(r, IPAddr('xxx'))
-		# raw (not IP, for example host:port as string):
-		r = IPAddr('1:2', IPAddr.CIDR_RAW)
-		self.assertFalse(r.isIPv4)
-		self.assertFalse(r.isIPv6)
-		self.assertTrue(r.isValid)
-		self.assertEqual(r, '1:2')
-		self.assertEqual('1:2', str(r))
-		self.assertNotEqual(r, IPAddr('1:2'))
-
 	def _testExecActions(self, server):
 		jails = server._Server__jails
 		for jail in jails:

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -933,6 +933,14 @@ class RegexTests(unittest.TestCase):
 
 	def testHost(self):
 		self.assertRaises(RegexException, FailRegex, '')
+		self.assertRaises(RegexException, FailRegex, '^test no group$')
+		self.assertTrue(FailRegex('^test <HOST> group$'))
+		self.assertTrue(FailRegex('^test <IP4> group$'))
+		self.assertTrue(FailRegex('^test <IP6> group$'))
+		self.assertTrue(FailRegex('^test <DNS> group$'))
+		self.assertTrue(FailRegex('^test id group: ip:port = <F-ID><IP4>(?::<F-PORT/>)?</F-ID>$'))
+		self.assertTrue(FailRegex('^test id group: user:\(<F-ID>[^\)]+</F-ID>\)$'))
+		self.assertTrue(FailRegex('^test id group: anything = <F-ID/>$'))
 		# Testing obscure case when host group might be missing in the matched pattern,
 		# e.g. if we made it optional.
 		fr = FailRegex('%%<HOST>?')
@@ -940,6 +948,30 @@ class RegexTests(unittest.TestCase):
 		fr.search([('%%',"","")])
 		self.assertTrue(fr.hasMatched())
 		self.assertRaises(RegexException, fr.getHost)
+		# The same as above but using separated IPv4/IPv6 expressions
+		fr = FailRegex('%%inet(?:=<F-IP4/>|inet6=<F-IP6/>)?')
+		self.assertFalse(fr.hasMatched())
+		fr.search([('%%inet=test',"","")])
+		self.assertTrue(fr.hasMatched())
+		self.assertRaises(RegexException, fr.getHost)
+		# Success case: using separated IPv4/IPv6 expressions (no HOST)
+		fr = FailRegex('%%(?:inet(?:=<IP4>|6=<IP6>)?|dns=<DNS>?)')
+		self.assertFalse(fr.hasMatched())
+		fr.search([('%%inet=192.0.2.1',"","")])
+		self.assertTrue(fr.hasMatched())
+		self.assertEqual(fr.getHost(), '192.0.2.1')
+		fr.search([('%%inet6=2001:DB8::',"","")])
+		self.assertTrue(fr.hasMatched())
+		self.assertEqual(fr.getHost(), '2001:DB8::')
+		fr.search([('%%dns=example.com',"","")])
+		self.assertTrue(fr.hasMatched())
+		self.assertEqual(fr.getHost(), 'example.com')
+		# Success case: using user as failure-id
+		fr = FailRegex('^test id group: user:\(<F-ID>[^\)]+</F-ID>\)$')
+		self.assertFalse(fr.hasMatched())
+		fr.search([('test id group: user:(test login name)',"","")])
+		self.assertTrue(fr.hasMatched())
+		self.assertEqual(fr.getFailID(), 'test login name')
 
 
 class _BadThread(JailThread):
@@ -997,6 +1029,24 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 	def test_IPAddr(self):
 		self.assertTrue(IPAddr('192.0.2.1').isIPv4)
 		self.assertTrue(IPAddr('2001:DB8::').isIPv6)
+
+	def test_IPAddr_Raw(self):
+		# raw string:
+		r = IPAddr('xxx', IPAddr.CIDR_RAW)
+		self.assertFalse(r.isIPv4)
+		self.assertFalse(r.isIPv6)
+		self.assertTrue(r.isValid)
+		self.assertEqual(r, 'xxx')
+		self.assertEqual('xxx', str(r))
+		self.assertNotEqual(r, IPAddr('xxx'))
+		# raw (not IP, for example host:port as string):
+		r = IPAddr('1:2', IPAddr.CIDR_RAW)
+		self.assertFalse(r.isIPv4)
+		self.assertFalse(r.isIPv6)
+		self.assertTrue(r.isValid)
+		self.assertEqual(r, '1:2')
+		self.assertEqual('1:2', str(r))
+		self.assertNotEqual(r, IPAddr('1:2'))
 
 	def _testExecActions(self, server):
 		jails = server._Server__jails


### PR DESCRIPTION
Here is a continuation of #1454, resp. extended version of it for 0.10 branch:
Pros:
- possibility to differentiate between failure ID and failure IP on tag levels;
- possibility to define a start/end tag for each group (failure id, ip4, ip6, host, etc.);
- possibility to define different `failregex` for IPv4, IPv6 and for both (included dns host match);
- more precise regular expressions for IPv4 and IPv6 (and host) - separated now;

New tags:
- `<HOST>` - used new separated groups for `ip4`, `ip6`, `dns`;
- `<IP4>` (+ alias `<F-IP4/>`) - matches IPv4 only;
- `<IP6>` (+ alias `<F-IP6/>`) - matches IPv6 only;
- `<DNS>` (+ alias `<F-DNS/>`) - matches host name (usedns should be enabled);
- `<F-ID/>` - Failure ID, typically not IP-address (for example user name);
- `<F-PORT/>` - port, will be wrapped into the group "port";

New start/end tags to use it together around any free configurable own regexp:
- `<F-IP4>...</F-IP4>` - regexp between tags matches IPv4 only;
- `<F-IP6>...</F-IP6>` - regexp between tags matches IPv6 only;
- `<F-DNS>...</F-DNS>` - regexp between tags matches host name (usedns should be enabled);
- `<F-ID>...</F-ID>` - regexp between tags corresponds to failure ID (for example user name);
- `<F-PORT>...</F-PORT>` - regexp between tags corresponds to port, will be wrapped into the group "port";

Planned (TODO):
- additionally to the "solution" from #1454 a new substitution tags `<fid>`, `<ip4>`, `<ip6>`, `<port>`, `<dns>` should be used in addition to tag `<ip>` in action definitions.