### PR TITLE
BF: do not rely on long relative path to upstairs config - symlink dereferenced copied during install

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -16,6 +16,8 @@ config/action.d/firewallcmd-allports.conf
 config/action.d/firewallcmd-ipset.conf
 config/action.d/firewallcmd-multiport.conf
 config/action.d/firewallcmd-new.conf
+config/action.d/firewallcmd-rich-logging.conf
+config/action.d/firewallcmd-rich-rules.conf
 config/action.d/hostsdeny.conf
 config/action.d/ipfilter.conf
 config/action.d/ipfw.conf
@@ -124,6 +126,7 @@ config/filter.d/sendmail-auth.conf
 config/filter.d/sendmail-reject.conf
 config/filter.d/sendmail-spam.conf
 config/filter.d/sieve.conf
+config/filter.d/slapd.conf
 config/filter.d/sogo-auth.conf
 config/filter.d/solid-pop3d.conf
 config/filter.d/squid.conf
@@ -205,6 +208,7 @@ fail2ban/tests/config/fail2ban.conf
 fail2ban/tests/config/filter.d/simple.conf
 fail2ban/tests/config/filter.d/test.conf
 fail2ban/tests/config/filter.d/test.local
+fail2ban/tests/config/filter.d/zzz-generic-example.conf
 fail2ban/tests/config/jail.conf
 fail2ban/tests/config/paths-common.conf
 fail2ban/tests/config/paths-debian.conf
@@ -306,6 +310,7 @@ fail2ban/tests/files/logs/sendmail-auth
 fail2ban/tests/files/logs/sendmail-reject
 fail2ban/tests/files/logs/sendmail-spam
 fail2ban/tests/files/logs/sieve
+fail2ban/tests/files/logs/slapd
 fail2ban/tests/files/logs/sogo-auth
 fail2ban/tests/files/logs/solid-pop3d
 fail2ban/tests/files/logs/squid
@@ -320,6 +325,7 @@ fail2ban/tests/files/logs/vsftpd
 fail2ban/tests/files/logs/webmin-auth
 fail2ban/tests/files/logs/wuftpd
 fail2ban/tests/files/logs/xinetd-fail
+fail2ban/tests/files/logs/zzz-generic-example
 fail2ban/tests/files/testcase01.log
 fail2ban/tests/files/testcase02.log
 fail2ban/tests/files/testcase03.log

--- a/fail2ban/tests/config/filter.d/common.conf
+++ b/fail2ban/tests/config/filter.d/common.conf
@@ -1,0 +1,1 @@
+../../../../config/filter.d/common.conf

--- a/fail2ban/tests/config/filter.d/zzz-generic-example.conf
+++ b/fail2ban/tests/config/filter.d/zzz-generic-example.conf
@@ -6,8 +6,9 @@
 [INCLUDES]
 
 # Read common prefixes. If any customizations available -- read them from
-# common.local
-before = ../../../../config/filter.d/common.conf
+# common.local.  common.conf is a symlink to the original common.conf and
+# should be copied (dereferenced) during installation
+before = common.conf
 
 [Definition]
 


### PR DESCRIPTION
I know that original idea was that the zzz is never shipped/installed.  But e.g. since I base debian packaging straight on the git repo, and it is easier to maintain a thorough MANIFEST, I have decided to just workaround by making that common.conf a symlink and then rely on it being dereferenced during installation.  It is unlikely someone would be installing fail2ban on crummy filesystem not supporting symlinks.

