### PR TITLE
Fix ASSP filter to work with both ASSP V1 and V2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,8 @@ new features (e.g. IPv6 support), please consider 0.10 branch and its
 releases.
 
 ### Fixes
+* `filter.d/assp.conf`
+    - Extended failregex and test cases to handle ASSP V1 and V2 (gh-1494)
 * `filter.d/monit.conf`
     - Extended failregex with new monit "access denied" version (gh-1355)
     - failregex of previous monit version merged as single expression

--- a/config/filter.d/assp.conf
+++ b/config/filter.d/assp.conf
@@ -1,5 +1,5 @@
-# Fail2Ban filter for Anti-Spam SMTP Proxy Server (ASSP) Version 2.5.1 (or later)
-# 
+# Fail2Ban filter for Anti-Spam SMTP Proxy Server (ASSP)
+#    Filter works in theory for both ASSP V1 and V2. Recommended ASSP is V2.5.1 or later.
 #    Homepage:    http://sourceforge.net/projects/assp/
 #    ProjectSite: http://sourceforge.net/projects/assp/?source=directory
 #
@@ -7,14 +7,23 @@
 
 [Definition] 
 
-failregex = ^\s*(?:[m0-9\-]+\s+)*(?:\[\S+\]\s+)*<HOST> (?:\<\S+@\S+\.\S+\> )*(?:to: \S+@\S+\.\S+ )*relay attempt blocked for(?: \(parsing\))*: \S+$
-            ^\s*(?:[m0-9\-]+\s+)*(?:\[\S+\]\s+)*<HOST> \[SMTP Error\] 535 5\.7\.8 Error: authentication failed:\s+(?:\S+|Connection lost to authentication server|Invalid authentication mechanism|Invalid base64 data in continued response)*$
+__assp_actions = (?:dropping|refusing)
+
+failregex = ^(:? \[SSL-out\])? <HOST> max sender authentication errors \(\d{,3}\) exceeded -- %(__assp_actions)s connection - after reply: \d{3} \d{1}\.\d{1}.\d{1} Error: authentication failed: \w+;$
+			^(?: \[SSL-out\])? <HOST> SSL negotiation with client failed: SSL accept attempt failed with unknown error.*:unknown protocol;$
+			^ Blocking <HOST> - too much AUTH errors \(\d{,3}\);$
+			^\s*(?:[m0-9\-]+\s+)*(?:\[\S+\]\s+)*<HOST> (?:\<\S+@\S+\.\S+\> )*(?:to: \S+@\S+\.\S+ )*relay attempt blocked for(?: \(parsing\))*: \S+$
+			^\s*(?:[m0-9\-]+\s+)*(?:\[\S+\]\s+)*<HOST> \[SMTP Error\] 535 5\.7\.8 Error: authentication failed:\s+(?:\S+|Connection lost to authentication server|Invalid authentication mechanism|Invalid base64 data in continued response)*$
 
 ignoreregex = 
 
 # DEV Notes:
+# V1 Examples matches:
+#   Apr-27-13 02:33:09 Blocking 217.194.197.97 - too much AUTH errors (41);
+#   Dec-29-12 17:10:31 [SSL-out] 200.247.87.82 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
+#   Dec-30-12 04:01:47 [SSL-out] 81.82.232.66 max sender authentication errors (5) exceeded 
 #
-# Examples matches:
+# V2 Examples matches:
 #   Jul-29-16 16:49:52 m1-25391-06124 [Worker_1] [TLS-out] [RelayAttempt] 0.0.0.0 <user@example.com> to: user@example.org relay attempt blocked for: someone@example.org
 #   Jul-30-16 16:59:42 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6
 #   Jul-30-16 00:15:36 m1-52131-09651 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6
@@ -28,4 +37,4 @@ ignoreregex =
 
 #
 # Author: Enrico Labedzki (enrico.labedzki@deiwos.de)
-# Updated: Robert Hardy (rhardy@webcon.ca)
+# V2 Filters: Robert Hardy (rhardy@webcon.ca)

--- a/config/filter.d/assp.conf
+++ b/config/filter.d/assp.conf
@@ -7,18 +7,25 @@
 
 [Definition] 
 
-failregex = <HOST> \<\S+@\S+\.\S+\> to: \S+@\S+\.\S+ relay attempt blocked for: \S+$
-            <HOST> \[SMTP Error\] 535 5\.7\.8 Error: authentication failed.*$
+failregex = ^\s*(?:[m0-9\-]+\s+)*(?:\[\S+\]\s+)*<HOST> (?:\<\S+@\S+\.\S+\> )*(?:to: \S+@\S+\.\S+ )*relay attempt blocked for(?: \(parsing\))*: \S+$
+            ^\s*(?:[m0-9\-]+\s+)*(?:\[\S+\]\s+)*<HOST> \[SMTP Error\] 535 5\.7\.8 Error: authentication failed:\s+(?:\S+|Connection lost to authentication server|Invalid authentication mechanism|Invalid base64 data in continued response)*$
 
 ignoreregex = 
 
 # DEV Notes:
 #
-# Examples:
-#               Jul-29-16 16:49:52 m1-25391-06124 [Worker_1] [TLS-out] [RelayAttempt] 0.0.0.0 <user@example.com> to: user@example.org relay attempt blocked for: someone@example.org
-#               Jul-30-16 16:59:42 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6
-#               Jul-30-16 00:15:36 m1-52131-09651 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6
-#               Jul-31-16 06:45:59 [Worker_1] [TLS-in] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed:
+# Examples matches:
+#   Jul-29-16 16:49:52 m1-25391-06124 [Worker_1] [TLS-out] [RelayAttempt] 0.0.0.0 <user@example.com> to: user@example.org relay attempt blocked for: someone@example.org
+#   Jul-30-16 16:59:42 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6
+#   Jul-30-16 00:15:36 m1-52131-09651 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6
+#   Jul-31-16 06:45:59 [Worker_1] [TLS-in] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed:
+#   Jan-05-16 08:38:49 m1-01129-09140 [Worker_1] [TLS-in] [TLS-out] [RelayAttempt] 0.0.0.0 <user@example.com> relay attempt blocked for (parsing): <user2@example>
+#   Jun-12-16 16:43:37 m1-64217-12013 [Worker_1] [TLS-in] [TLS-out] [RelayAttempt] 0.0.0.0 <user@example.com> to: user2@example.com relay attempt blocked for (parsing): <a.notheruser69@example.c>
+#   Jan-22-16 22:25:51 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: Invalid authentication mechanism
+#   Mar-19-16 13:42:20 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: Invalid base64 data in continued response
+#   Jul-18-16 16:54:21 [Worker_2] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: Connection lost to authentication server
+#   Jul-18-16 17:14:23 m1-76453-02949 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: Connection lost to authentication server
+
 #
 # Author: Enrico Labedzki (enrico.labedzki@deiwos.de)
 # Updated: Robert Hardy (rhardy@webcon.ca)

--- a/config/filter.d/assp.conf
+++ b/config/filter.d/assp.conf
@@ -1,11 +1,14 @@
 # Fail2Ban filter for Anti-Spam SMTP Proxy Server (ASSP)
 #    Filter works in theory for both ASSP V1 and V2. Recommended ASSP is V2.5.1 or later.
+#    Support for ASSP V1 ended in 2014 so if you are still running ASSP V1 an immediate upgrade is recommended.
+#
 #    Homepage:    http://sourceforge.net/projects/assp/
 #    ProjectSite: http://sourceforge.net/projects/assp/?source=directory
 #
 #
 
 [Definition] 
+# Note: First three failregex matches below are for ASSP V1 with the remaining being designed for V2. Deleting the V1 regex is recommended but I left it in for compatibilty reasons.
 
 __assp_actions = (?:dropping|refusing)
 

--- a/config/filter.d/assp.conf
+++ b/config/filter.d/assp.conf
@@ -1,24 +1,24 @@
-# Fail2Ban filter for Anti-Spam SMTP Proxy Server also known as ASSP
+# Fail2Ban filter for Anti-Spam SMTP Proxy Server (ASSP) Version 2.5.1 (or later)
 # 
-#    Honmepage:   http://www.magicvillage.de/~Fritz_Borgstedt/assp/0003D91C-8000001C/
-#    ProjektSite: http://sourceforge.net/projects/assp/?source=directory
+#    Homepage:    http://sourceforge.net/projects/assp/
+#    ProjectSite: http://sourceforge.net/projects/assp/?source=directory
 #
 #
 
 [Definition] 
 
-__assp_actions = (?:dropping|refusing)
-
-failregex = ^(:? \[SSL-out\])? <HOST> max sender authentication errors \(\d{,3}\) exceeded -- %(__assp_actions)s connection - after reply: \d{3} \d{1}\.\d{1}.\d{1} Error: authentication failed: \w+;$
-			^(?: \[SSL-out\])? <HOST> SSL negotiation with client failed: SSL accept attempt failed with unknown error.*:unknown protocol;$
-			^ Blocking <HOST> - too much AUTH errors \(\d{,3}\);$
+failregex = <HOST> \<\S+@\S+\.\S+\> to: \S+@\S+\.\S+ relay attempt blocked for: \S+$
+            <HOST> \[SMTP Error\] 535 5\.7\.8 Error: authentication failed.*$
 
 ignoreregex = 
 
 # DEV Notes:
 #
-# Examples: Apr-27-13 02:33:09 Blocking 217.194.197.97 - too much AUTH errors (41);
-#           Dec-29-12 17:10:31 [SSL-out] 200.247.87.82 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
-#           Dec-30-12 04:01:47 [SSL-out] 81.82.232.66 max sender authentication errors (5) exceeded 
+# Examples:
+#               Jul-29-16 16:49:52 m1-25391-06124 [Worker_1] [TLS-out] [RelayAttempt] 0.0.0.0 <user@example.com> to: user@example.org relay attempt blocked for: someone@example.org
+#               Jul-30-16 16:59:42 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6
+#               Jul-30-16 00:15:36 m1-52131-09651 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6
+#               Jul-31-16 06:45:59 [Worker_1] [TLS-in] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed:
 #
 # Author: Enrico Labedzki (enrico.labedzki@deiwos.de)
+# Updated: Robert Hardy (rhardy@webcon.ca)

--- a/fail2ban/tests/files/logs/assp
+++ b/fail2ban/tests/files/logs/assp
@@ -1,3 +1,27 @@
+# failJSON: { "time": "2013-04-07T07:08:36", "match": true , "host": "68.171.223.68" }
+Apr-07-13 07:08:36 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
+# failJSON: { "time": "2013-04-07T07:08:36", "match": true , "host": "68.171.223.68" }
+Apr-07-13 07:08:36 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
+# failJSON: { "time": "2013-04-07T07:10:37", "match": true , "host": "68.171.223.68" }
+Apr-07-13 07:10:37 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
+# failJSON: { "time": "2013-04-07T07:12:37", "match": true , "host": "68.171.223.68" }
+Apr-07-13 07:12:37 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
+# failJSON: { "time": "2013-04-07T07:14:36", "match": true , "host": "68.171.223.68" }
+Apr-07-13 07:14:36 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
+# failJSON: { "time": "2013-04-27T02:25:09", "match": true , "host": "217.194.197.97" }
+Apr-27-13 02:25:09 Blocking 217.194.197.97 - too much AUTH errors (8);
+# failJSON: { "time": "2013-04-27T02:25:09", "match": true , "host": "217.194.197.97" }
+Apr-27-13 02:25:09 Blocking 217.194.197.97 - too much AUTH errors (9);
+# failJSON: { "time": "2013-04-27T02:25:09", "match": true , "host": "217.194.197.97" }
+Apr-27-13 02:25:09 Blocking 217.194.197.97 - too much AUTH errors (10);
+# failJSON: { "time": "2013-04-27T02:25:10", "match": true , "host": "217.194.197.97" }
+Apr-27-13 02:25:10 [SSL-out] 217.194.197.97 max sender authentication errors (5) exceeded -- dropping connection - after reply: 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6;
+# failJSON: { "time": "2013-04-27T02:25:10", "match": true , "host": "217.194.197.97" }
+Apr-27-13 02:25:10 [SSL-out] 217.194.197.97 max sender authentication errors (5) exceeded -- dropping connection - after reply: 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6;
+# failJSON: { "time": "2013-04-27T02:25:10", "match": true , "host": "217.194.197.97" }
+Apr-27-13 02:25:10 [SSL-out] 217.194.197.97 max sender authentication errors (5) exceeded -- dropping connection - after reply: 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6;
+# failJSON: { "time": "2013-04-27T02:25:11", "match": true , "host": "217.194.197.97" }
+Apr-27-13 02:25:11 [SSL-out] 217.194.197.97 max sender authentication errors (5) exceeded -- dropping connection - after reply: 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6;
 # failJSON: { "time": "2016-07-29T16:49:52", "match": true , "host": "0.0.0.0" }
 Jul-29-16 16:49:52 m1-25391-06124 [Worker_1] [TLS-out] [RelayAttempt] 0.0.0.0 <user@example.com> to: user@example.org relay attempt blocked for: someone@example.org
 # failJSON: { "time": "2016-07-30T17:07:25", "match": true , "host": "0.0.0.0" }

--- a/fail2ban/tests/files/logs/assp
+++ b/fail2ban/tests/files/logs/assp
@@ -5,4 +5,16 @@ Jul-30-16 17:07:25 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: au
 # failJSON: { "time": "2016-07-30T17:11:05", "match": true , "host": "0.0.0.0" }
 Jul-30-16 17:11:05 m1-13060-05386 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6
 # failJSON: { "time": "2016-07-31T06:45:59", "match": true , "host": "0.0.0.0" }
-Jul-31-16 06:45:59 [Worker_1] [TLS-in] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed:
+Jul-31-16 06:45:59 [Worker_1] [TLS-in] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: 
+# failJSON: { "time": "2016-01-05T08:38:49", "match": true , "host": "0.0.0.0" }
+Jan-05-16 08:38:49 m1-01129-09140 [Worker_1] [TLS-in] [TLS-out] [RelayAttempt] 0.0.0.0 <user@example.com> relay attempt blocked for (parsing): <user2@example>
+# failJSON: { "time": "2016-06-12T16:43:37", "match": true , "host": "0.0.0.0" }
+Jun-12-16 16:43:37 m1-64217-12013 [Worker_1] [TLS-in] [TLS-out] [RelayAttempt] 0.0.0.0 <user@example.com> to: user2@example.com relay attempt blocked for (parsing): <a.notheruser69@example.c>
+# failJSON: { "time": "2016-01-22T22:25:51", "match": true , "host": "0.0.0.0" }
+Jan-22-16 22:25:51 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: Invalid authentication mechanism
+# failJSON: { "time": "2016-03-19T13:42:20", "match": true , "host": "0.0.0.0" }
+Mar-19-16 13:42:20 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: Invalid base64 data in continued response
+# failJSON: { "time": "2016-07-18T16:54:21", "match": true , "host": "0.0.0.0" }
+Jul-18-16 16:54:21 [Worker_2] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: Connection lost to authentication server
+# failJSON: { "time": "2016-07-18T17:14:23", "match": true , "host": "0.0.0.0" }
+Jul-18-16 17:14:23 m1-76453-02949 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: Connection lost to authentication server

--- a/fail2ban/tests/files/logs/assp
+++ b/fail2ban/tests/files/logs/assp
@@ -1,25 +1,8 @@
-# failJSON: { "time": "2013-04-07T07:08:36", "match": true , "host": "68.171.223.68" }
-Apr-07-13 07:08:36 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
-# failJSON: { "time": "2013-04-07T07:08:36", "match": true , "host": "68.171.223.68" }
-Apr-07-13 07:08:36 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
-# failJSON: { "time": "2013-04-07T07:10:37", "match": true , "host": "68.171.223.68" }
-Apr-07-13 07:10:37 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
-# failJSON: { "time": "2013-04-07T07:12:37", "match": true , "host": "68.171.223.68" }
-Apr-07-13 07:12:37 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
-# failJSON: { "time": "2013-04-07T07:14:36", "match": true , "host": "68.171.223.68" }
-Apr-07-13 07:14:36 [SSL-out] 68.171.223.68 SSL negotiation with client failed: SSL accept attempt failed with unknown errorerror:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol;
-# failJSON: { "time": "2013-04-27T02:25:09", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:09 Blocking 217.194.197.97 - too much AUTH errors (8);
-# failJSON: { "time": "2013-04-27T02:25:09", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:09 Blocking 217.194.197.97 - too much AUTH errors (9);
-# failJSON: { "time": "2013-04-27T02:25:09", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:09 Blocking 217.194.197.97 - too much AUTH errors (10);
-# failJSON: { "time": "2013-04-27T02:25:10", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:10 [SSL-out] 217.194.197.97 max sender authentication errors (5) exceeded -- dropping connection - after reply: 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6;
-# failJSON: { "time": "2013-04-27T02:25:10", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:10 [SSL-out] 217.194.197.97 max sender authentication errors (5) exceeded -- dropping connection - after reply: 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6;
-# failJSON: { "time": "2013-04-27T02:25:10", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:10 [SSL-out] 217.194.197.97 max sender authentication errors (5) exceeded -- dropping connection - after reply: 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6;
-# failJSON: { "time": "2013-04-27T02:25:11", "match": true , "host": "217.194.197.97" }
-Apr-27-13 02:25:11 [SSL-out] 217.194.197.97 max sender authentication errors (5) exceeded -- dropping connection - after reply: 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6;
-
+# failJSON: { "time": "2016-07-29T16:49:52", "match": true , "host": "0.0.0.0" }
+Jul-29-16 16:49:52 m1-25391-06124 [Worker_1] [TLS-out] [RelayAttempt] 0.0.0.0 <user@example.com> to: user@example.org relay attempt blocked for: someone@example.org
+# failJSON: { "time": "2016-07-30T17:07:25", "match": true , "host": "0.0.0.0" }
+Jul-30-16 17:07:25 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6
+# failJSON: { "time": "2016-07-30T17:11:05", "match": true , "host": "0.0.0.0" }
+Jul-30-16 17:11:05 m1-13060-05386 [Worker_1] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed: UGFzc3dvcmQ6
+# failJSON: { "time": "2016-07-31T06:45:59", "match": true , "host": "0.0.0.0" }
+Jul-31-16 06:45:59 [Worker_1] [TLS-in] [TLS-out] 0.0.0.0 [SMTP Error] 535 5.7.8 Error: authentication failed:


### PR DESCRIPTION
ASSP V1 development stopped at the end of 2014 and it is now deprecated.
All users were urged to upgrade to ASSP V2 which is still actively
developed. For some reason fail2ban 0.9.5 (and trunk) still have code
which only understands ASSP V1 logs. This means the filter ignores brute
force attacks against ASSP.