### PR TITLE
Added npf.conf for the NPF packet filer, episode 2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,7 +33,9 @@ TODO: implementing of options resp. other tasks from PR #1346
     - new conditional section functionality used in config resp. includes:
       - [Init?family=inet4] - IPv4 qualified hosts only
       - [Init?family=inet6] - IPv6 qualified hosts only
-
+* New Actions:
+    - `action.d/npf.conf` for NPF, the latest packet filter for NetBSD
+    
 ### Enhancements
 * huge increasing of fail2ban performance and especially test-cases performance (see gh-1109)
 * datedetector: in-place reordering using hits and last used time: 

--- a/config/action.d/npf.conf
+++ b/config/action.d/npf.conf
@@ -1,0 +1,61 @@
+# Fail2Ban configuration file
+#
+# NetBSD npf ban/unban
+#
+# Author: Nils Ratusznik <nils@NetBSD.org>
+# Based on pf.conf action file
+#
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed once at the start of Fail2Ban.
+# Values:  CMD
+#
+# we don't enable NPF automatically, as it will be enabled elsewhere
+actionstart = 
+
+
+# Option:  actionstop
+# Notes.:  command executed once at the end of Fail2Ban
+# Values:  CMD
+#
+# we don't disable NPF automatically either
+actionstop = 
+
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+actioncheck = 
+
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    <ip>  IP address
+#          <failures>  number of failures
+#          <time>  unix timestamp of the ban time
+# Values:  CMD
+#
+actionban = /sbin/npfctl table <tablename> add <ip>
+
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    <ip>  IP address
+#          <failures>  number of failures
+#          <time>  unix timestamp of the ban time
+# Values:  CMD
+#
+# note -r option used to remove matching rule
+actionunban = /sbin/npfctl table <tablename> rem <ip>
+
+[Init]
+# Option:  tablename
+# Notes.:  The pf table name.
+# Values:  [ STRING ]
+#
+tablename = fail2ban


### PR DESCRIPTION
This new action files adds support for the NPF packet filter, available on NetBSD since version 6.0.
This pull request makes https://github.com/fail2ban/fail2ban/pull/1326 obsolete, since I updated the changelog file here.