### PR TITLE
Accept no space after "failed:"

### DIFF
--- a/config/filter.d/postfix-sasl.conf
+++ b/config/filter.d/postfix-sasl.conf
@@ -9,7 +9,7 @@ before = common.conf
 
 _daemon = postfix(-\w+)?/(?:submission/|smtps/)?smtp[ds]
 
-failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL ((?i)LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/:]*={0,2})?\s*$
+failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL ((?i)LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(:[ A-Za-z0-9+/:]*={0,2})?\s*$
 
 ignoreregex = authentication failed: Connection lost to authentication server$
 

--- a/fail2ban/tests/files/logs/postfix-sasl
+++ b/fail2ban/tests/files/logs/postfix-sasl
@@ -27,6 +27,6 @@ Jan 29 08:11:45 mail postfix-incoming/smtpd[10752]: warning: unknown[1.1.1.1]: S
 # failJSON: { "time": "2005-04-12T02:24:11", "match": true , "host": "62.138.2.143" }
 Apr 12 02:24:11 xxx postfix/smtps/smtpd[42]: warning: astra4139.startdedicated.de[62.138.2.143]: SASL LOGIN authentication failed: UGFzc3dvcmQ6
 
-# failJSON: { "time": "2016-08-08T19:50:00", "match": true , "host": "98.191.84.74" }
+# failJSON: { "time": "2005-08-03T13:30:49", "match": true , "host": "98.191.84.74" }
 Aug 3 15:30:49 ksusha postfix/smtpd[17041]: warning: mail.foldsandwalker.com[98.191.84.74]: SASL Plain authentication failed:
 

--- a/fail2ban/tests/files/logs/postfix-sasl
+++ b/fail2ban/tests/files/logs/postfix-sasl
@@ -27,6 +27,6 @@ Jan 29 08:11:45 mail postfix-incoming/smtpd[10752]: warning: unknown[1.1.1.1]: S
 # failJSON: { "time": "2005-04-12T02:24:11", "match": true , "host": "62.138.2.143" }
 Apr 12 02:24:11 xxx postfix/smtps/smtpd[42]: warning: astra4139.startdedicated.de[62.138.2.143]: SASL LOGIN authentication failed: UGFzc3dvcmQ6
 
-# failJSON: { "time": "2005-08-03T11:30:49", "match": true , "host": "98.191.84.74" }
+# failJSON: { "time": "2005-08-03T15:30:49", "match": true , "host": "98.191.84.74" }
 Aug 3 15:30:49 ksusha postfix/smtpd[17041]: warning: mail.foldsandwalker.com[98.191.84.74]: SASL Plain authentication failed:
 

--- a/fail2ban/tests/files/logs/postfix-sasl
+++ b/fail2ban/tests/files/logs/postfix-sasl
@@ -26,3 +26,7 @@ Jan 29 08:11:45 mail postfix-incoming/smtpd[10752]: warning: unknown[1.1.1.1]: S
 
 # failJSON: { "time": "2005-04-12T02:24:11", "match": true , "host": "62.138.2.143" }
 Apr 12 02:24:11 xxx postfix/smtps/smtpd[42]: warning: astra4139.startdedicated.de[62.138.2.143]: SASL LOGIN authentication failed: UGFzc3dvcmQ6
+
+# failJSON: { "time": "2016-08-08T19:50:00", "match": true , "host": "98.191.84.74" }
+Aug 3 15:30:49 ksusha postfix/smtpd[17041]: warning: mail.foldsandwalker.com[98.191.84.74]: SASL Plain authentication failed:
+

--- a/fail2ban/tests/files/logs/postfix-sasl
+++ b/fail2ban/tests/files/logs/postfix-sasl
@@ -27,6 +27,6 @@ Jan 29 08:11:45 mail postfix-incoming/smtpd[10752]: warning: unknown[1.1.1.1]: S
 # failJSON: { "time": "2005-04-12T02:24:11", "match": true , "host": "62.138.2.143" }
 Apr 12 02:24:11 xxx postfix/smtps/smtpd[42]: warning: astra4139.startdedicated.de[62.138.2.143]: SASL LOGIN authentication failed: UGFzc3dvcmQ6
 
-# failJSON: { "time": "2005-08-03T13:30:49", "match": true , "host": "98.191.84.74" }
+# failJSON: { "time": "2005-08-03T11:30:49", "match": true , "host": "98.191.84.74" }
 Aug 3 15:30:49 ksusha postfix/smtpd[17041]: warning: mail.foldsandwalker.com[98.191.84.74]: SASL Plain authentication failed:
 


### PR DESCRIPTION
- [X] I hope this is the right branch; I fixed it for 0.10, however, the same issue is present in master - so I will submit two pull requests, to master as well
- [X] No unit test required, as similar conditions do not get tested
- [X] Issue #1497 is resolved
- [X] current tests run, no problems
- [X] PR is only removing 1 space
- [X] No stylistic change
- [X] Added test line to postfix-sasl test

fix issue #1497