### PR TITLE
travis: coverage python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
   # - 3.2
   - 3.3
   - 3.4
+  - 3.5
   - pypy3
 before_install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2* || $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then export F2B_PY_2=true && echo "Set F2B_PY_2"; fi


### PR DESCRIPTION
Coverage via python 3.5

BTW. I've tried to re-enable 3.2 - seems to have still the same bug:
```
  File "/home/travis/virtualenv/python3.2.6/bin/coverage", line 7, in <module>
    from coverage.cmdline import main
  File "/home/travis/virtualenv/python3.2.6/lib/python3.2/site-packages/coverage/__init__.py", line 13, in <module>
    from coverage.control import Coverage, process_startup
  File "/home/travis/virtualenv/python3.2.6/lib/python3.2/site-packages/coverage/control.py", line 15, in <module>
    from coverage.annotate import AnnotateReporter
  File "/home/travis/virtualenv/python3.2.6/lib/python3.2/site-packages/coverage/annotate.py", line 85
    dest.write(u'  ')
                   ^
SyntaxError: invalid syntax
```