### PR TITLE
Fix ambiguous wrong recognized date pattern resp. its optional parts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@ releases.
   uses "fail2ban-python" now);
 * Fixed test case "testSetupInstallRoot" for not default python version (also
   using direct call, out of virtualenv);
+* Fixed ambiguous wrong recognized date pattern resp. its optional parts (see gh-1512);
 * `filter.d/ignorecommands/apache-fakegooglebot`
     - Fixed error within apache-fakegooglebot, that will be called 
       with wrong python version (gh-1506)
@@ -33,6 +34,8 @@ releases.
 ### New Features
 
 ### Enhancements
+* DateTemplate regexp extended with the word-end boundary, additionally to 
+  word-start boundary
 * Introduces new command "fail2ban-python", as automatically created symlink to 
   python executable, where fail2ban currently installed (resp. its modules are located):
     - allows to use the same version, fail2ban currently running, e.g. in 

--- a/fail2ban/server/datetemplate.py
+++ b/fail2ban/server/datetemplate.py
@@ -64,7 +64,7 @@ class DateTemplate(object):
 	def getRegex(self):
 		return self._regex
 
-	def setRegex(self, regex, wordBegin=True):
+	def setRegex(self, regex, wordBegin=True, wordEnd=True):
 		"""Sets regex to use for searching for date in log line.
 
 		Parameters
@@ -82,8 +82,10 @@ class DateTemplate(object):
 			If regular expression fails to compile
 		"""
 		regex = regex.strip()
-		if (wordBegin and not re.search(r'^\^', regex)):
-			regex = r'\b' + regex
+		if wordBegin and not re.search(r'^\^', regex):
+			regex = r'(?=^|\b|\W)' + regex
+		if wordEnd and not re.search(r'\$$', regex):
+			regex += r'(?=\b|\W|$)'
 		self._regex = regex
 		self._cRegex = re.compile(regex, re.UNICODE | re.IGNORECASE)
 

--- a/fail2ban/server/datetemplate.py
+++ b/fail2ban/server/datetemplate.py
@@ -72,8 +72,12 @@ class DateTemplate(object):
 		regex : str
 			The regex the template will use for searching for a date.
 		wordBegin : bool
-			Defines whether the regex should be modified to search at
-			beginning of a word, by adding "\\b" to start of regex.
+			Defines whether the regex should be modified to search at beginning of a
+			word, by adding special boundary r'(?=^|\b|\W)' to start of regex.
+			Default True.
+		wordEnd : bool
+			Defines whether the regex should be modified to search at end of a word,
+			by adding special boundary r'(?=\b|\W|$)' to end of regex.
 			Default True.
 
 		Raises

--- a/fail2ban/tests/fail2banregextestcase.py
+++ b/fail2ban/tests/fail2banregextestcase.py
@@ -200,9 +200,18 @@ class Fail2banRegexTest(LogCaptureTestCase):
 			# direct specified patterns:
 			(1, ('-d', r'%H:%M:%S %d.%m.%Y$', '192.0.2.1 at 20:00:00 01.02.2003', '^<HOST>')),
 			(1, ('-d', r'\[%H:%M:%S %d.%m.%Y\]', '192.0.2.1[20:00:00 01.02.2003]', '^<HOST>$')),
+			(1, ('-d', r'\[%H:%M:%S %d.%m.%Y\]', '[20:00:00 01.02.2003]192.0.2.1', '^<HOST>$')),
 			(1, ('-d', r'\[%H:%M:%S %d.%m.%Y\]$', '192.0.2.1[20:00:00 01.02.2003]', '^<HOST>$')),
 			(1, ('-d', r'^\[%H:%M:%S %d.%m.%Y\]', '[20:00:00 01.02.2003]192.0.2.1', '^<HOST>$')),
 			(1, ('-d', r'^\[%d/%b/%Y %H:%M:%S\]', '[17/Jun/2011 17:00:45] Attempt, IP address 192.0.2.1', r'^ Attempt, IP address <HOST>$')),
+			(1, ('-d', r'\[%d/%b/%Y %H:%M:%S\]', 'Attempt [17/Jun/2011 17:00:45] IP address 192.0.2.1', r'^Attempt\s+IP address <HOST>$')),
+			(1, ('-d', r'\[%d/%b/%Y %H:%M:%S\]', 'Attempt IP address 192.0.2.1, date: [17/Jun/2011 17:00:45]', r'^Attempt IP address <HOST>, date: $')),
+			# direct specified patterns (begin/end, missed):
+			(0, ('-d', r'%H:%M:%S %d.%m.%Y', '192.0.2.1x20:00:00 01.02.2003', '^<HOST>')),
+			(0, ('-d', r'%H:%M:%S %d.%m.%Y', '20:00:00 01.02.2003x192.0.2.1', '<HOST>$')),
+			# direct specified patterns (begin/end, matched):
+			(1, ('-d', r'%H:%M:%S %d.%m.%Y', '192.0.2.1 20:00:00 01.02.2003', '^<HOST>')),
+			(1, ('-d', r'%H:%M:%S %d.%m.%Y', '20:00:00 01.02.2003 192.0.2.1', '<HOST>$')),
 		):
 			logSys.debug('== test: %r', args)
 			(opts, args, fail2banRegex) = _Fail2banRegex(*args)

--- a/fail2ban/tests/fail2banregextestcase.py
+++ b/fail2ban/tests/fail2banregextestcase.py
@@ -187,41 +187,4 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 		self.assertLogged('https://')
 
-	def testAmbiguousDatePattern(self):
-		for (matched, args) in (
-			# positive case:
-			(1, ('Test failure Jan 23 21:59:59 for 192.0.2.1', r'for <HOST>$')),
-			# ambiguous "unbound" patterns (missed):
-			(0, ('Test failure TestJan 23 21:59:59.011 2015 for 192.0.2.1', r'for <HOST>$')),
-			(0, ('Test failure Jan 23 21:59:59123456789 for 192.0.2.1', r'for <HOST>$')),
-			# ambiguous "no optional year" patterns (matched):
-			(1, ('Aug 8 11:25:50 14430f2329b8 Authentication failed from 192.0.2.1', r'from <HOST>$')),
-			(1, ('[Aug 8 11:25:50] 14430f2329b8 Authentication failed from 192.0.2.1', r'from <HOST>$')),
-			# direct specified patterns:
-			(1, ('-d', r'%H:%M:%S %d.%m.%Y$', '192.0.2.1 at 20:00:00 01.02.2003', '^<HOST>')),
-			(1, ('-d', r'\[%H:%M:%S %d.%m.%Y\]', '192.0.2.1[20:00:00 01.02.2003]', '^<HOST>$')),
-			(1, ('-d', r'\[%H:%M:%S %d.%m.%Y\]', '[20:00:00 01.02.2003]192.0.2.1', '^<HOST>$')),
-			(1, ('-d', r'\[%H:%M:%S %d.%m.%Y\]$', '192.0.2.1[20:00:00 01.02.2003]', '^<HOST>$')),
-			(1, ('-d', r'^\[%H:%M:%S %d.%m.%Y\]', '[20:00:00 01.02.2003]192.0.2.1', '^<HOST>$')),
-			(1, ('-d', r'^\[%d/%b/%Y %H:%M:%S\]', '[17/Jun/2011 17:00:45] Attempt, IP address 192.0.2.1', r'^ Attempt, IP address <HOST>$')),
-			(1, ('-d', r'\[%d/%b/%Y %H:%M:%S\]', 'Attempt [17/Jun/2011 17:00:45] IP address 192.0.2.1', r'^Attempt\s+IP address <HOST>$')),
-			(1, ('-d', r'\[%d/%b/%Y %H:%M:%S\]', 'Attempt IP address 192.0.2.1, date: [17/Jun/2011 17:00:45]', r'^Attempt IP address <HOST>, date: $')),
-			# direct specified patterns (begin/end, missed):
-			(0, ('-d', r'%H:%M:%S %d.%m.%Y', '192.0.2.1x20:00:00 01.02.2003', '^<HOST>')),
-			(0, ('-d', r'%H:%M:%S %d.%m.%Y', '20:00:00 01.02.2003x192.0.2.1', '<HOST>$')),
-			# direct specified patterns (begin/end, matched):
-			(1, ('-d', r'%H:%M:%S %d.%m.%Y', '192.0.2.1 20:00:00 01.02.2003', '^<HOST>')),
-			(1, ('-d', r'%H:%M:%S %d.%m.%Y', '20:00:00 01.02.2003 192.0.2.1', '<HOST>$')),
-		):
-			logSys.debug('== test: %r', args)
-			(opts, args, fail2banRegex) = _Fail2banRegex(*args)
-			self.assertTrue(fail2banRegex.start(opts, args))
-			matchedLog = 'Lines: 1 lines, 0 ignored, 1 matched, 0 missed'
-			missedLog = 'Lines: 1 lines, 0 ignored, 0 matched, 1 missed'
-			if matched:
-				self.assertLogged(matchedLog)
-				self.assertNotLogged(missedLog)
-			else:
-				self.assertNotLogged(matchedLog)
-				self.assertLogged(missedLog)
-			self.pruneLog()
+


### PR DESCRIPTION
amend to (long time ago fixed left word-boundary) b6bb2f88c1dbb111647269590d80d95f72c81c3e: datepattern right word-boundary - prevents confusions if end of date-pattern (e.g. optional year part) misleadingly match not date values (see gh-1507)

test cases extended to check ambiguous "unbound" patterns in log lines (match/miss resp. positive/negative cases)