### PR TITLE
filter.d/asterisk.conf: another part ` chan_sip.c:28468 handle_request_register:` in log prefix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,8 @@ releases.
 * Fixed test case "testSetupInstallRoot" for not default python version (also
   using direct call, out of virtualenv);
 * Fixed ambiguous wrong recognized date pattern resp. its optional parts (see gh-1512);
+* `filter.d/asterisk.conf`
+    - Fixed to match different asterisk log prefix (source file: method:)
 * `filter.d/ignorecommands/apache-fakegooglebot`
     - Fixed error within apache-fakegooglebot, that will be called 
       with wrong python version (gh-1506)

--- a/config/filter.d/asterisk.conf
+++ b/config/filter.d/asterisk.conf
@@ -16,7 +16,7 @@ __pid_re = (?:\[\d+\])
 iso8601 = \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+[+-]\d{4}
 
 # All Asterisk log messages begin like this:
-log_prefix= (?:NOTICE|SECURITY|WARNING)%(__pid_re)s:?(?:\[C-[\da-f]*\])? [^:]+:\d*( in \w+:)?
+log_prefix= (?:NOTICE|SECURITY|WARNING)%(__pid_re)s:?(?:\s+\S+\.c:\d+\s+\S+:|(?:\[C-[\da-f]*\])? [^:]+:\d*( in \w+:)?)
 
 failregex = ^%(__prefix_line)s%(log_prefix)s Registration from '[^']*' failed for '<HOST>(:\d+)?' - (Wrong password|Username/auth name mismatch|No matching peer found|Not a local domain|Device does not match ACL|Peer is not supposed to register|ACL error \(permit/deny\)|Not a local domain)$
             ^%(__prefix_line)s%(log_prefix)s Call from '[^']*' \(<HOST>:\d+\) to extension '[^']*' rejected because extension not found in context

--- a/fail2ban/tests/files/logs/asterisk
+++ b/fail2ban/tests/files/logs/asterisk
@@ -82,3 +82,7 @@ Nov 4 18:30:40 localhost asterisk[32229]: NOTICE[32257]: chan_sip.c:23417 in han
 # Failed authentication with pjsip on Asterisk 13+
 # failJSON: { "time": "2016-06-08T23:40:26", "match": true , "host": "2.3.4.5" }
 [2016-06-08 23:40:26] NOTICE[32497] res_pjsip/pjsip_distributor.c: Request from '"317" <sip:317@1.2.3.4>' failed for '2.3.4.5:5089' (callid: 206f178f-896564cb-57573f49@1.2.3.4) - No matching endpoint found
+
+
+# failJSON: { "time": "2016-08-19T11:11:26", "match": true , "host": "192.0.2.1", "desc": "Another log_prefix used" }
+[2016-08-19 11:11:26] NOTICE[12931]: chan_sip.c:28468 handle_request_register: Registration from 'sip:bob@192.0.2.1' failed for '192.0.2.1:42406' - Wrong password


### PR DESCRIPTION
Fixed match of different asterisk log prefix (source file:line method:), e.g. ` chan_sip.c:28468 handle_request_register:`

Example log line from #1519:
```
[2016-08-19 11:11:26] NOTICE[12931]: chan_sip.c:28468 handle_request_register: Registration from 'sip:bob@192.0.2.1' failed for '192.0.2.1:42406' - Wrong password
```