### PR TITLE
fixed a bug in action ufw when using app with space

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -77,6 +77,7 @@ Lars Kneschke
 Lee Clemens
 leftyfb (Mike Rushton)
 M. Maraun
+Magnus Appelquist
 Manuel Arostegui Ramirez
 Marcel Dopita
 Mark Edgington

--- a/config/action.d/ufw.conf
+++ b/config/action.d/ufw.conf
@@ -13,11 +13,11 @@ actionstop =
 
 actioncheck = 
 
-actionban = [ -n "<application>" ] && app="app <application>"
-            ufw insert <insertpos> <blocktype> from <ip> to <destination> $app
+actionban = [ -n "<application>" ] && app="app '<application>'"
+            eval ufw insert <insertpos> <blocktype> from <ip> to <destination> $app
 
-actionunban = [ -n "<application>" ] && app="app <application>"
-              ufw delete <blocktype> from <ip> to <destination> $app
+actionunban = [ -n "<application>" ] && app="app '<application>'"
+              eval ufw delete <blocktype> from <ip> to <destination> $app
 
 [Init]
 # Option: insertpos
@@ -40,3 +40,4 @@ application =
 # 
 # Author: Guilhem Lettron
 # Enhancements: Daniel Black
+# Enhancements: Magnus Appelquist


### PR DESCRIPTION
I was trying to use UFW app "Apache Full", which is installed default in Ubuntu. I've added this in the jail:

ufw[application=Apache Full]

Due to the space in the application argument "Apache Full", the action failed. It does not matter if you escape quotes or space. I even tried double escaping. The only way I could get it to work was to evaluate $app before bash is executing it.

Perhaps there is another way of getting this to work, but in that case it would be great with an example in the action.
