### PR TITLE
fix systemd convert gh 1341

### DIFF
--- a/fail2ban/server/filtersystemd.py
+++ b/fail2ban/server/filtersystemd.py
@@ -31,7 +31,7 @@ if LooseVersion(getattr(journal, '__version__', "0")) < '204':
 	raise ImportError("Fail2Ban requires systemd >= 204")
 
 from .failmanager import FailManagerEmpty
-from .filter import JournalFilter
+from .filter import JournalFilter, Filter
 from .mytime import MyTime
 from .utils import Utils
 from ..helpers import getLogger, logging, splitwords
@@ -170,21 +170,9 @@ class FilterSystemd(JournalFilter): # pragma: systemd no cover
 	def getJournalMatch(self):
 		return self.__matches
 
-    ##
-    # Join group of log elements which may be a mix of bytes and strings
-    #
-    # @param elements list of strings and bytes
-    # @return elements joined as string
-
-	@staticmethod
-	def _joinStrAndBytes(elements):
-		strElements = []
-		for element in elements:
-			if isinstance(element, str):
-				strElements.append(element)
-			else:
-				strElements.append(str(element, errors='ignore'))
-		return " ".join(strElements)
+	def uni_decode(self, x):
+		v = Filter.uni_decode(x, self.getLogEncoding())
+		return v
 
 	##
 	# Format journal log entry into syslog style
@@ -192,50 +180,44 @@ class FilterSystemd(JournalFilter): # pragma: systemd no cover
 	# @param entry systemd journal entry dict
 	# @return format log line
 
-	@classmethod
-	def formatJournalEntry(cls, logentry):
-		logelements = [""]
-		if logentry.get('_HOSTNAME'):
-			logelements.append(logentry['_HOSTNAME'])
-		if logentry.get('SYSLOG_IDENTIFIER'):
-			logelements.append(logentry['SYSLOG_IDENTIFIER'])
-			if logentry.get('SYSLOG_PID'):
-				logelements[-1] += ("[%i]" % logentry['SYSLOG_PID'])
-			elif logentry.get('_PID'):
-				logelements[-1] += ("[%i]" % logentry['_PID'])
+	def formatJournalEntry(self, logentry):
+		# Be sure, all argument of line tuple should have the same type:
+		uni_decode = self.uni_decode
+		logelements = []
+		v = logentry.get('_HOSTNAME')
+		if v:
+			logelements.append(uni_decode(v))
+		v = logentry.get('SYSLOG_IDENTIFIER')
+		if not v:
+			v = logentry.get('_COMM')
+		if v:
+			logelements.append(uni_decode(v))
+			v = logentry.get('SYSLOG_PID')
+			if not v:
+				v = logentry.get('_PID')
+			if v:
+				logelements[-1] += ("[%i]" % v)
 			logelements[-1] += ":"
-		elif logentry.get('_COMM'):
-			logelements.append(logentry['_COMM'])
-			if logentry.get('_PID'):
-				logelements[-1] += ("[%i]" % logentry['_PID'])
-			logelements[-1] += ":"
-		if logelements[-1] == "kernel:":
-			if '_SOURCE_MONOTONIC_TIMESTAMP' in logentry:
-				monotonic = logentry.get('_SOURCE_MONOTONIC_TIMESTAMP')
-			else:
-				monotonic = logentry.get('__MONOTONIC_TIMESTAMP')[0]
-			logelements.append("[%12.6f]" % monotonic.total_seconds())
-		if isinstance(logentry.get('MESSAGE',''), list):
-			logelements.append(" ".join(logentry['MESSAGE']))
+			if logelements[-1] == "kernel:":
+				if '_SOURCE_MONOTONIC_TIMESTAMP' in logentry:
+					monotonic = logentry.get('_SOURCE_MONOTONIC_TIMESTAMP')
+				else:
+					monotonic = logentry.get('__MONOTONIC_TIMESTAMP')[0]
+				logelements.append("[%12.6f]" % monotonic.total_seconds())
+		msg = logentry.get('MESSAGE','')
+		if isinstance(msg, list):
+			logelements.append(" ".join(uni_decode(v) for v in msg))
 		else:
-			logelements.append(logentry.get('MESSAGE', ''))
+			logelements.append(uni_decode(msg))
 
-		try:
-			logline = u" ".join(logelements)
-		except UnicodeDecodeError:
-			# Python 2, so treat as string
-			logline = " ".join([str(logline) for logline in logelements])
-		except TypeError:
-			# Python 3, one or more elements bytes
-			logSys.warning("Error decoding log elements from journal: %s" %
-				repr(logelements))
-			logline =  cls._joinStrAndBytes(logelements)
+		logline = " ".join(logelements)
 
 		date = logentry.get('_SOURCE_REALTIME_TIMESTAMP',
 				logentry.get('__REALTIME_TIMESTAMP'))
 		logSys.debug("Read systemd journal entry: %r" %
 			"".join([date.isoformat(), logline]))
-		return (('', date.isoformat(), logline),
+		## use the same type for 1st argument:
+		return ((logline[:0], date.isoformat(), logline),
 			time.mktime(date.timetuple()) + date.microsecond/1.0E6)
 
 	def seekToTime(self, date):

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -275,13 +275,11 @@ class Server:
 	
 	def setLogEncoding(self, name, encoding):
 		filter_ = self.__jails[name].filter
-		if isinstance(filter_, FileFilter):
-			filter_.setLogEncoding(encoding)
+		filter_.setLogEncoding(encoding)
 	
 	def getLogEncoding(self, name):
 		filter_ = self.__jails[name].filter
-		if isinstance(filter_, FileFilter):
-			return filter_.getLogEncoding()
+		return filter_.getLogEncoding()
 	
 	def setFindTime(self, name, value):
 		self.__jails[name].filter.setFindTime(value)

--- a/fail2ban/tests/files/testcase-journal.log
+++ b/fail2ban/tests/files/testcase-journal.log
@@ -13,7 +13,7 @@ error: PAM: Authentication failure for kevin from 193.168.0.128
 error: PAM: Authentication failure for kevin from 193.168.0.128
 error: PAM: Authentication failure for kevin from 193.168.0.128
 error: PAM: Authentication failure for kevin from 193.168.0.128
-error: PAM: Authentication failure for kevin from 87.142.124.10
-error: PAM: Authentication failure for kevin from 87.142.124.10
-error: PAM: Authentication failure for kevin from 87.142.124.10
-error: PAM: Authentication failure for kevin from 87.142.124.10
+error: PAM: Authentication failure for göran from 87.142.124.10
+error: PAM: Authentication failure for göran from 87.142.124.10
+error: PAM: Authentication failure for göran from 87.142.124.10
+error: PAM: Authentication failure for göran from 87.142.124.10

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -38,7 +38,7 @@ except ImportError:
 
 from ..server.jail import Jail
 from ..server.filterpoll import FilterPoll
-from ..server.filter import Filter, FileFilter, FileContainer
+from ..server.filter import Filter, FileFilter, FileContainer, locale
 from ..server.failmanager import FailManagerEmpty
 from ..server.ipdns import DNSUtils, IPAddr
 from ..server.mytime import MyTime
@@ -229,6 +229,10 @@ def _copy_lines_between_files(in_, fout, n=None, skip=0, mode='a', terminal_line
 	return fout
 
 
+TEST_JOURNAL_FIELDS = {
+  "SYSLOG_IDENTIFIER": "fail2ban-testcases",
+	"PRIORITY": "7",
+}
 def _copy_lines_to_journal(in_, fields={},n=None, skip=0, terminal_line=""): # pragma: systemd no cover
 	"""Copy lines from one file to systemd journal
 
@@ -239,9 +243,7 @@ def _copy_lines_to_journal(in_, fields={},n=None, skip=0, terminal_line=""): # p
 	else:
 		fin = in_
 	# Required for filtering
-	fields.update({"SYSLOG_IDENTIFIER": "fail2ban-testcases",
-					"PRIORITY": "7",
-					})
+	fields.update(TEST_JOURNAL_FIELDS)
 	# Skip
 	for i in xrange(skip):
 		fin.readline()
@@ -298,6 +300,19 @@ class BasicFilter(unittest.TestCase):
 			tm = datetime.datetime.fromtimestamp(i).strftime("%Y-%m-%d %H:%M:%S")
 			if _tm(i) != tm:
 				self.assertEqual((_tm(i), i), (tm, i))
+
+	def testWrongCharInTupleLine(self):
+		## line tuple has different types (ascii after ascii / unicode):
+		for a1 in ('', u'', b''):
+			for a2 in ('2016-09-05T20:18:56', u'2016-09-05T20:18:56', b'2016-09-05T20:18:56'):
+				for a3 in (
+					'Fail for "g\xc3\xb6ran" from 192.0.2.1', 
+					u'Fail for "g\xc3\xb6ran" from 192.0.2.1',
+					b'Fail for "g\xc3\xb6ran" from 192.0.2.1'
+				):
+					# join should work if all arguments have the same type:
+					enc = locale.getpreferredencoding()
+					"".join([Filter.uni_decode(v, enc) for v in (a1, a2, a3)])
 
 
 class IgnoreIP(LogCaptureTestCase):
@@ -1123,6 +1138,33 @@ def get_monitor_failures_journal_testcase(Filter_): # pragma: systemd no cover
 				self.test_file, self.journal_fields, n=6, skip=10)
 			# we should detect the failures
 			self.assertTrue(self.isFilled(10))
+
+		def test_WrongChar(self):
+			self._initFilter()
+			self.filter.start()
+			# Now let's feed it with entries from the file
+			_copy_lines_to_journal(
+				self.test_file, self.journal_fields, skip=15, n=4)
+			self.assertTrue(self.isFilled(10))
+			self.assert_correct_ban("87.142.124.10", 4)
+			# Add direct utf, unicode, blob:
+			for l in (
+		    "error: PAM: Authentication failure for \xe4\xf6\xfc\xdf from 192.0.2.1",
+		   u"error: PAM: Authentication failure for \xe4\xf6\xfc\xdf from 192.0.2.1",
+		   b"error: PAM: Authentication failure for \xe4\xf6\xfc\xdf from 192.0.2.1".decode('utf-8', 'replace'),
+		    "error: PAM: Authentication failure for \xc3\xa4\xc3\xb6\xc3\xbc\xc3\x9f from 192.0.2.2",
+		   u"error: PAM: Authentication failure for \xc3\xa4\xc3\xb6\xc3\xbc\xc3\x9f from 192.0.2.2",
+		   b"error: PAM: Authentication failure for \xc3\xa4\xc3\xb6\xc3\xbc\xc3\x9f from 192.0.2.2".decode('utf-8', 'replace')
+			):
+				fields = self.journal_fields
+				fields.update(TEST_JOURNAL_FIELDS)
+				journal.send(MESSAGE=l, **fields)
+			self.assertTrue(self.isFilled(10))
+			endtm = MyTime.time()+10
+			while len(self.jail) != 2 and MyTime.time() < endtm:
+				time.sleep(0.10)
+			self.assertEqual(sorted([self.jail.getFailTicket().getIP(), self.jail.getFailTicket().getIP()]), 
+				["192.0.2.1", "192.0.2.2"])
 
 	MonitorJournalFailures.__name__ = "MonitorJournalFailures<%s>(%s)" \
 			  % (Filter_.__name__, testclass_name)

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -1145,6 +1145,7 @@ def get_monitor_failures_journal_testcase(Filter_): # pragma: systemd no cover
 			# Now let's feed it with entries from the file
 			_copy_lines_to_journal(
 				self.test_file, self.journal_fields, skip=15, n=4)
+			self.waitForTicks(1)
 			self.assertTrue(self.isFilled(10))
 			self.assert_correct_ban("87.142.124.10", 4)
 			# Add direct utf, unicode, blob:
@@ -1159,10 +1160,8 @@ def get_monitor_failures_journal_testcase(Filter_): # pragma: systemd no cover
 				fields = self.journal_fields
 				fields.update(TEST_JOURNAL_FIELDS)
 				journal.send(MESSAGE=l, **fields)
-			self.assertTrue(self.isFilled(10))
-			endtm = MyTime.time()+10
-			while len(self.jail) != 2 and MyTime.time() < endtm:
-				time.sleep(0.10)
+			self.waitFailTotal(6, 10)
+			self.assertTrue(Utils.wait_for(lambda: len(self.jail) == 2, 10))
 			self.assertEqual(sorted([self.jail.getFailTicket().getIP(), self.jail.getFailTicket().getIP()]), 
 				["192.0.2.1", "192.0.2.2"])
 


### PR DESCRIPTION
systemd-filter: fixed tricky bug, like `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3...: ordinal not in range(128)`

* [BF] fixed journal systemd ascii/utf-8 default converting (closes gh-1341, closes gh-1344)
* [BF+ENH] allow to set default or preferred encoding for other filters as file-filter (e. g. to decode bytes from journal)
* [performance] ignore obsolete log-lines moved before searching of matched failregex
(`if time < now - findtime`)
* extended test cases to cover such bugs...
* [+0.10] optimized test cases after merge (using 0.10-features, see e3a75b4)

To compare changes between 0.10 / 0.9:
- 0.10: https://github.com/fail2ban/fail2ban/compare/0.10...sebres:_0.10/fix-systemd-convert-gh-1341 (this PR, merged from 0.9 + small code review)
- 0.9: https://github.com/fail2ban/fail2ban/compare/master...sebres:_0.9/fix-systemd-convert-gh-1341
(fast-forward)