### PR TITLE
filter.py: easy-fix to use sha1 instead of md5 (FIPS compliant)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@ releases.
 * Fixed test case "testSetupInstallRoot" for not default python version (also
   using direct call, out of virtualenv);
 * Fixed ambiguous wrong recognized date pattern resp. its optional parts (see gh-1512);
+* FIPS compliant, use sha1 instead of md5 if it not allowed (see gh-1540)
 * `filter.d/asterisk.conf`
     - Fixed to match different asterisk log prefix (source file: method:)
 * `filter.d/ignorecommands/apache-fakegooglebot`

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -742,7 +742,12 @@ class FileFilter(Filter):
 
 try:
 	import hashlib
-	md5sum = hashlib.md5
+	try:
+		md5sum = hashlib.md5
+		# try to use it (several standards like FIPS forbid it):
+		md5sum(' ').hexdigest()
+	except: # pragma: no cover
+		md5sum = hashlib.sha1
 except ImportError: # pragma: no cover
 	# hashlib was introduced in Python 2.5.  For compatibility with those
 	# elderly Pythons, import from md5


### PR DESCRIPTION
filter.py: easy-fix to use sha1 instead of md5 if its usage prohibited by some systems following strict standards (like FIPS)

Closes gh-1540