### PR TITLE
Monit config: scripting is not supported in path 

### DIFF
--- a/files/monit/fail2ban
+++ b/files/monit/fail2ban
@@ -1,7 +1,7 @@
 check process fail2ban with pidfile /var/run/fail2ban/fail2ban.pid
     group services
     start program = "/etc/init.d/fail2ban force-start"
-    stop  program = "/etc/init.d/fail2ban stop || :"
+    stop  program = "/etc/init.d/fail2ban stop"
     if failed unixsocket /var/run/fail2ban/fail2ban.sock then restart
     if 5 restarts within 5 cycles then timeout
 


### PR DESCRIPTION
> Yes, scripting is not supported in path.

https://bitbucket.org/tildeslash/monit/issues/372/webadmin-shows-only-the-first-part-of#comment-27946048