### PR TITLE
make the ipv6 host regex greedy

### DIFF
--- a/fail2ban/server/failregex.py
+++ b/fail2ban/server/failregex.py
@@ -77,7 +77,7 @@ class Regex:
 		regex = regex.replace("<F-IP4/>", r); # closed
 		r_host.append(r)
 		# separated ipv6:
-		r = r"""(?P<ip6>(?:[0-9a-fA-F]{1,4}::?|::){1,7}(?:[0-9a-fA-F]{1,4}?|(?<=:):))"""
+		r = r"""(?P<ip6>(?:[0-9a-fA-F]{1,4}::?|::){1,7}(?:[0-9a-fA-F]{1,4}|(?<=:):))"""
 		regex = regex.replace("<IP6>", r); # self closed
 		regex = regex.replace("<F-IP6/>", r); # closed
 		r_host.append(r"""\[?%s\]?""" % (r,)); # enclose ipv6 in optional [] in host-regex

--- a/fail2ban/tests/files/logs/nginx-limit-req
+++ b/fail2ban/tests/files/logs/nginx-limit-req
@@ -4,3 +4,9 @@
 
 # failJSON: { "time": "2015-10-29T19:24:05", "match": true , "host": "192.0.2.0" }
 2015/10/29 19:24:05 [error] 12684#12684: *22174 limiting requests, excess: 1.495 by zone "one", client: 192.0.2.0, server: example.com, request: "GET /index.php HTTP/1.1", host: "example.com", referrer: "https://example.com"
+
+# failJSON: { "time": "2016-09-30T08:36:06", "match": true, "host": "13.123.1.123" }
+2016/09/30 08:36:06 [error] 22923#0: *4758725916 limiting requests, excess: 15.243 by zone "one", client: 13.123.1.123, server: example.com, request: "GET / HTTP/1.1", host: "example.com"
+
+# failJSON: { "time": "2016-09-30T08:36:06", "match": true, "host": "2606:2800:220:1:248:1893:25c8:1946" }
+2016/09/30 08:36:06 [error] 22923#0: *4758725916 limiting requests, excess: 15.243 by zone "one", client: 2606:2800:220:1:248:1893:25c8:1946, server: example.com, request: "GET / HTTP/1.1", host: "example.com"


### PR DESCRIPTION
Previously the regex was lazily matching ``2606:2800:220:1:248:1893:25c8:1946``
as ``2606:2800:220:1:248:1893:25c8:1``.

Expecting unrelated test failures for [everything but Python 2.6](https://github.com/fail2ban/fail2ban/blob/a406c6eb3a20621e43e84cb644ff2c19873d629f/fail2ban/tests/action_d/test_badips.py#L27) because badips.com seems to be down.