### PR TITLE
Drop unneeded shebangs from test scripts

### DIFF
--- a/fail2ban/tests/files/config/apache-auth/digest.py
+++ b/fail2ban/tests/files/config/apache-auth/digest.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env fail2ban-python
 import requests
 
 try:

--- a/fail2ban/tests/files/ignorecommand.py
+++ b/fail2ban/tests/files/ignorecommand.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env fail2ban-python
 import sys
 if sys.argv[1] == "10.0.0.1":
 	exit(0)


### PR DESCRIPTION
Resolves this rpmlint error:

```
fail2ban-server.noarch: E: non-executable-script /usr/lib/python3.5/site-packages/fail2ban/tests/files/ignorecommand.py 644 /usr/bin/python3.5 
fail2ban-server.noarch: E: non-executable-script /usr/lib/python3.5/site-packages/fail2ban/tests/files/config/apache-auth/digest.py 644 /usr/bin/python3.5 
```

these scripts are executed with "fail2ban-python <script>" directly so no need to shebang.  Also, they are not executable anyway (644).
