### PR TITLE
Additional sshd-ddos failregex check

### DIFF
--- a/config/filter.d/sshd-ddos.conf
+++ b/config/filter.d/sshd-ddos.conf
@@ -19,6 +19,7 @@ before = common.conf
 _daemon = sshd
 
 failregex = ^%(__prefix_line)sDid not receive identification string from <HOST>\s*$
+            ^%(__prefix_line)sConnection closed by <HOST> port \d+ \[preauth\]$
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/sshd-ddos
+++ b/fail2ban/tests/files/logs/sshd-ddos
@@ -1,3 +1,4 @@
 # http://forums.powervps.com/showthread.php?t=1667
 # failJSON: { "time": "2005-06-07T01:10:56", "match": true , "host": "69.61.56.114" }
 Jun 7 01:10:56 host sshd[5937]: Did not receive identification string from 69.61.56.114
+Oct  7 20:12:48 host sshd[15868]: Connection closed by 120.26.109.89 port 53202 [preauth]


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:
- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
    against 0.9.x series, choose `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
    within `fail2ban/tests/files/logs/X` file

Added a 2nd line to check for failregex in sshd-ddos.conf as this was a line I was seeing in my own server's /var/log/auth.log file very often from unexpected hosts, perhaps trying to probe for SSH access. Typically this line `Connection closed by <HOST> port \d+ \[preauth\]` is seen many times after seeing the `Did not receive identification string from <HOST>` only once, from what I've seen.

Added relevant log example in appropriate tests/files/logs file.
