### PR TITLE
filter.d/sshd.conf: Match 'Invalid user' with 'port \d*'

### DIFF
--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -22,7 +22,7 @@ failregex = ^%(__prefix_line)s(?:error: PAM: )?[aA]uthentication (?:failure|erro
             ^%(__prefix_line)s(?:error: PAM: )?User not known to the underlying authentication module for .* from <HOST>\s*$
             ^%(__prefix_line)sFailed \S+ for .*? from <HOST>(?: port \d*)?(?: ssh\d*)?(: (ruser .*|(\S+ ID \S+ \(serial \d+\) CA )?\S+ %(__md5hex)s(, client user ".*", client host ".*")?))?\s*$
             ^%(__prefix_line)sROOT LOGIN REFUSED.* FROM <HOST>\s*$
-            ^%(__prefix_line)s[iI](?:llegal|nvalid) user .* from <HOST>\s*$
+            ^%(__prefix_line)s[iI](?:llegal|nvalid) user .* from <HOST>(?: port \d*)?\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because not listed in AllowUsers\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because listed in DenyUsers\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because not in any group\s*$


### PR DESCRIPTION
On a recent Arch Linux system (OpenSSH_7.3p1), I see lines like:
`Invalid user root from 1.1.1.1 port 37216`

The existing filter.d/sshd.conf failregex doesn't match these because of the ' port 37216' at the end of the line.