### PR TITLE
filter.d/sshd.conf: Match 'Invalid user' with 'port \d*'

### DIFF
--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -22,7 +22,7 @@ failregex = ^%(__prefix_line)s(?:error: PAM: )?[aA]uthentication (?:failure|erro
             ^%(__prefix_line)s(?:error: PAM: )?User not known to the underlying authentication module for .* from <HOST>\s*$
             ^%(__prefix_line)sFailed \S+ for .*? from <HOST>(?: port \d*)?(?: ssh\d*)?(: (ruser .*|(\S+ ID \S+ \(serial \d+\) CA )?\S+ %(__md5hex)s(, client user ".*", client host ".*")?))?\s*$
             ^%(__prefix_line)sROOT LOGIN REFUSED.* FROM <HOST>\s*$
-            ^%(__prefix_line)s[iI](?:llegal|nvalid) user .* from <HOST>\s*$
+            ^%(__prefix_line)s[iI](?:llegal|nvalid) user .* from <HOST>(?: port \d*)?\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because not listed in AllowUsers\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because listed in DenyUsers\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because not in any group\s*$

--- a/fail2ban/tests/files/logs/sshd
+++ b/fail2ban/tests/files/logs/sshd
@@ -162,3 +162,6 @@ Apr 27 13:02:04 host sshd[29116]: Received disconnect from 1.2.3.4: 11: Normal S
 # failJSON: { "time": "2015-04-16T20:02:50", "match": true , "host": "222.186.21.217", "desc": "Authentication for user failed" }
 2015-04-16T18:02:50.321974+00:00 host sshd[2716]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=222.186.21.217  user=root
 
+# Match invalid user messages with port at the end
+# failJSON: {"time": "2004-10-15T11:35:28", "match": true , "host": "1.2.3.4", "desc": "Invalid user root" }
+Oct 15 11:35:28 somehost sshd[7024]: Invalid user root from 1.2.3.4 port 37220


### PR DESCRIPTION
On a recent Arch Linux system (OpenSSH_7.3p1), I see lines like:
`Invalid user root from 1.1.1.1 port 37216`

The existing filter.d/sshd.conf failregex doesn't match these because of the ' port 37216' at the end of the line.
