### PR TITLE
 0.10/datedetector grave fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,15 @@ TODO: implementing of options resp. other tasks from PR #1346
 
 ### Fixes
 * [Grave] memory leak's fixed (gh-1277, gh-1234)
+* [Grave] Misleading date patterns defined more precisely (using extended syntax
+  `%Ex[mdHMS]` for exact two-digit match or e. g. `%ExY` as more precise year 
+  pattern, within same century of last year and the next 3 years)
+* [Grave] extends date detector template with distance (position of match in 
+  log-line), to prevent grave collision using (re)ordered template list (e.g.
+  find-spot of wrong date-match inside foreign input, misleading date patterns
+  by ambiguous formats, etc.)
+* Distance collision check always prefers template with shortest distance
+  (left for right) if date pattern is not anchored
 * Tricky bug fix: last position of log file will be never retrieved (gh-795),
   because of CASCADE all log entries will be deleted from logs table together with jail, 
   if used "INSERT OR REPLACE" statement
@@ -28,6 +37,11 @@ TODO: implementing of options resp. other tasks from PR #1346
 * Pyinotify-backend: stability fix for sporadically errors in multi-threaded
   environment (without lock)
 * Fixed sporadically error in testCymruInfoNxdomain, because of unsorted values
+* Fixed UTC/GMT named time zone, using `%Z` and `%z` patterns 
+  (special case with 0 zone offset, see gh-1575)
+* `filter.d/freeswitch.conf`
+    - Optional prefixes (server, daemon, dual time) if systemd daemon logs used (gh-1548)
+    - User part rewritten to accept IPv6 resp. domain after "@" (gh-1548)
 
 ### New Features
 * IPv6 support:
@@ -118,6 +132,22 @@ fail2ban-client set loglevel INFO
   - new replacement for `<ADDR>` in opposition to `<HOST>`, for separate
     usage of 2 address groups only (regardless of `usedns`), `ip4` and `ip6`
     together, without host (dns)
+* More precise date template handling (WARNING: theoretically possible incompatibilities):
+  - datedetector rewritten more strict as earlier;
+  - default templates can be specified exacter using prefix/suffix syntax (via `datepattern`);
+  - more as one date pattern can be specified using option `datepattern` now 
+    (new-line separated);
+  - some default options like `datepattern` can be specified directly in 
+    section `[Definition]`, that avoids contrary usage of unnecessarily `[Init]`
+    section, because of performance (each extra section costs time);
+  - option `datepattern` can be specified in jail also (e. g. jails without filters 
+    or custom log-format, new-line separated for multiple patterns);
+  - if first unnamed group specified in pattern, only this will be cut out from
+    search log-line (e. g.: `^date:[({DATE})]` will cut out only datetime match 
+    pattern, and leaves `date:[] ...` for searching in filter);
+  - faster match and fewer searching of appropriate templates
+    (DateDetector.matchTime calls rarer DateTemplate.matchDate now);
+  - several standard filters extended with exact prefixed or anchored date templates;
 * fail2ban-testcases:
   - `assertLogged` extended with parameter wait (to wait up to specified timeout,
     before we throw assert exception) + test cases rewritten using that

--- a/config/filter.d/3proxy.conf
+++ b/config/filter.d/3proxy.conf
@@ -9,6 +9,8 @@ failregex = ^\s[+-]\d{4} \S+ \d{3}0[1-9] \S+ <HOST>:\d+ [\d.]+:\d+ \d+ \d+ \d+\s
 
 ignoreregex = 
 
+datepattern = {^LN-BEG}
+
 # DEV Notes:
 # http://www.3proxy.ru/howtoe.asp#ERRORS indicates that 01-09 are
 # all authentication problems (%E field)

--- a/config/filter.d/apache-badbots.conf
+++ b/config/filter.d/apache-badbots.conf
@@ -14,6 +14,9 @@ failregex = ^<HOST> -.*"(GET|POST|HEAD).*HTTP.*"(?:%(badbots)s|%(badbotscustom)s
 
 ignoreregex =
 
+datepattern = ^[^\[]*\[({DATE})
+              {^LN-BEG}
+
 # DEV Notes:
 # List of bad bots fetched from http://www.user-agents.org
 # Generated on Thu Nov  7 14:23:35 PST 2013 by files/gen_badbots.

--- a/config/filter.d/apache-common.conf
+++ b/config/filter.d/apache-common.conf
@@ -10,6 +10,8 @@ after = apache-common.local
 
 _apache_error_client = \[\] \[(:?error|\S+:\S+)\]( \[pid \d+(:\S+ \d+)?\])? \[client <HOST>(:\d{1,5})?\]
 
+datepattern = {^LN-BEG}
+
 # Common prefix for [error] apache messages which also would include <HOST>
 # Depending on the version it could be
 # 2.2: [Sat Jun 01 11:23:08 2013] [error] [client 1.2.3.4]

--- a/config/filter.d/apache-fakegooglebot.conf
+++ b/config/filter.d/apache-fakegooglebot.conf
@@ -6,6 +6,8 @@ failregex = ^<HOST> .*Googlebot.*$
 
 ignoreregex =
 
+datepattern = ^[^\[]*\[({DATE})
+              {^LN-BEG}
 
 # DEV Notes:
 #

--- a/config/filter.d/apache-pass.conf
+++ b/config/filter.d/apache-pass.conf
@@ -9,6 +9,9 @@ failregex = ^<HOST> - \w+ \[\] "GET <knocking_url> HTTP/1\.[01]" 200 \d+ ".*" "[
 
 ignoreregex =
 
+datepattern = ^[^\[]*\[({DATE})
+              {^LN-BEG}
+
 [Init]
 
 knocking_url = /knocking/

--- a/config/filter.d/apache-pass.conf
+++ b/config/filter.d/apache-pass.conf
@@ -3,10 +3,6 @@
 #
 # The knocking request must have a referer.
 
-[INCLUDES]
-
-before = apache-common.conf
-
 [Definition]
 
 failregex = ^<HOST> - \w+ \[\] "GET <knocking_url> HTTP/1\.[01]" 200 \d+ ".*" "[^-].*"$

--- a/config/filter.d/assp.conf
+++ b/config/filter.d/assp.conf
@@ -20,6 +20,8 @@ failregex = ^(:? \[SSL-out\])? <HOST> max sender authentication errors \(\d{,3}\
 
 ignoreregex = 
 
+datepattern = {^LN-BEG}
+
 # DEV Notes:
 # V1 Examples matches:
 #   Apr-27-13 02:33:09 Blocking 217.194.197.97 - too much AUTH errors (41);

--- a/config/filter.d/assp.conf
+++ b/config/filter.d/assp.conf
@@ -20,7 +20,8 @@ failregex = ^(:? \[SSL-out\])? <HOST> max sender authentication errors \(\d{,3}\
 
 ignoreregex = 
 
-datepattern = {^LN-BEG}
+datepattern = {^LN-BEG}%%b-%%d-%%Exy %%H:%%M:%%S
+              {^LN-BEG}
 
 # DEV Notes:
 # V1 Examples matches:

--- a/config/filter.d/asterisk.conf
+++ b/config/filter.d/asterisk.conf
@@ -31,6 +31,7 @@ failregex = ^%(__prefix_line)s%(log_prefix)s Registration from '[^']*' failed fo
 
 ignoreregex =
 
+datepattern = {^LN-BEG}
 
 # Author: Xavier Devlamynck / Daniel Black
 #

--- a/config/filter.d/common.conf
+++ b/config/filter.d/common.conf
@@ -61,4 +61,7 @@ __prefix_line = %(__date_ambit)s?\s*(?:%(__bsd_syslog_verbose)s\s+)?(?:%(__hostn
 # pam_ldap
 __pam_auth = pam_unix
 
+# standardly all formats using prefix have line-begin anchored date:
+datepattern = {^LN-BEG}
+
 # Author: Yaroslav Halchenko

--- a/config/filter.d/counter-strike.conf
+++ b/config/filter.d/counter-strike.conf
@@ -8,8 +8,6 @@ failregex = ^: Bad Rcon: "rcon \d+ "\S+"  sv_contact ".*?"" from "<HOST>:\d+"$
 
 ignoreregex =
 
-[Init]
-
 datepattern = ^L %%d/%%m/%%Y - %%H:%%M:%%S
 
 

--- a/config/filter.d/courier-auth.conf
+++ b/config/filter.d/courier-auth.conf
@@ -15,5 +15,7 @@ failregex = ^%(__prefix_line)sLOGIN FAILED, user=.*, ip=\[<HOST>\]$
 
 ignoreregex = 
 
+datepattern = {^LN-BEG}
+
 # Author: Christoph Haas
 # Modified by: Cyril Jaquier

--- a/config/filter.d/directadmin.conf
+++ b/config/filter.d/directadmin.conf
@@ -13,7 +13,6 @@ failregex = ^: \'<HOST>\' \d{1,3} failed login attempt(s)?. \s*
 
 ignoreregex = 
 
-[Init]
 datepattern = ^%%Y:%%m:%%d-%%H:%%M:%%S
 
 #

--- a/config/filter.d/dovecot.conf
+++ b/config/filter.d/dovecot.conf
@@ -17,9 +17,10 @@ failregex = ^%(__prefix_line)s(%(__pam_auth)s(\(dovecot:auth\))?:)?\s+authentica
 
 ignoreregex = 
 
-[Init]
-
 journalmatch = _SYSTEMD_UNIT=dovecot.service
+
+datepattern = {^LN-BEG}TAI64N
+              {^LN-BEG}
 
 # DEV Notes:
 # * the first regex is essentially a copy of pam-generic.conf

--- a/config/filter.d/ejabberd-auth.conf
+++ b/config/filter.d/ejabberd-auth.conf
@@ -34,4 +34,7 @@ maxlines = 2
 #
 journalmatch = 
 
-datepattern = ^(?:=[^=]+={3,} )?({DATE})
+#datepattern = ^(?:=[^=]+={3,} )?({DATE})
+# explicit time format using prefix =...==== and no date in second string begins with I(...)... 
+datepattern = ^(?:=[^=]+={3,} )?(%%ExY(?P<_sep>[-/.])%%m(?P=_sep)%%d[T ]%%H:%%M:%%S(?:[.,]%%f)?(?:\s*%%z)?)
+              ^I\(()**

--- a/config/filter.d/ejabberd-auth.conf
+++ b/config/filter.d/ejabberd-auth.conf
@@ -25,8 +25,6 @@ failregex = ^=INFO REPORT====  ===\nI\(<0\.\d+\.0>:ejabberd_c2s:\d+\) : \([^)]+\
 #
 ignoreregex = 
 
-[Init]
-
 # "maxlines" is number of log lines to buffer for multi-line regex searches
 maxlines = 2
 
@@ -35,3 +33,5 @@ maxlines = 2
 # Values:  TEXT
 #
 journalmatch = 
+
+datepattern = ^(?:=[^=]+={3,} )?({DATE})

--- a/config/filter.d/freeswitch.conf
+++ b/config/filter.d/freeswitch.conf
@@ -26,6 +26,8 @@ failregex = %(_pref_line)s \[WARNING\] sofia_reg\.c:\d+ SIP auth (failure|challe
 
 ignoreregex =
 
+datepattern = {^LN-BEG}
+
 # Author: Rupa SChomaker, soapee01, Daniel Black
 # https://freeswitch.org/confluence/display/FREESWITCH/Fail2Ban
 # Thanks to Jim on mailing list of samples and guidance

--- a/config/filter.d/freeswitch.conf
+++ b/config/filter.d/freeswitch.conf
@@ -8,10 +8,21 @@
 # IP addresses on your LAN.
 #
 
+[INCLUDES]
+
+# Read common prefixes. If any customizations available -- read them from
+# common.local
+before = common.conf
+
 [Definition]
 
-failregex = ^\.\d+ \[WARNING\] sofia_reg\.c:\d+ SIP auth (failure|challenge) \((REGISTER|INVITE)\) on sofia profile \'[^']+\' for \[.*\] from ip <HOST>$
-            ^\.\d+ \[WARNING\] sofia_reg\.c:\d+ Can't find user \[\d+@\d+\.\d+\.\d+\.\d+\] from <HOST>$
+_daemon = freeswitch
+
+# Prefix contains common prefix line (server, daemon, etc.) and 2 datetimes if used systemd backend
+_pref_line = ^%(__prefix_line)s(?:\d+-\d+-\d+ \d+:\d+:\d+\.\d+)?
+
+failregex = %(_pref_line)s \[WARNING\] sofia_reg\.c:\d+ SIP auth (failure|challenge) \((REGISTER|INVITE)\) on sofia profile \'[^']+\' for \[[^\]]*\] from ip <HOST>$
+            %(_pref_line)s \[WARNING\] sofia_reg\.c:\d+ Can't find user \[[^@]+@[^\]]+\] from <HOST>$
 
 ignoreregex =
 

--- a/config/filter.d/guacamole.conf
+++ b/config/filter.d/guacamole.conf
@@ -17,6 +17,9 @@ failregex = ^.*\nWARNING: Authentication attempt from <HOST> for user "[^"]*" fa
 #
 ignoreregex = 
 
-[Init]
 # "maxlines" is number of log lines to buffer for multi-line regex searches
 maxlines = 2
+
+datepattern = ^%%b %%d, %%ExY %%I:%%M:%%S %%p
+              ^WARNING:()**
+              {^LN-BEG}

--- a/config/filter.d/kerio.conf
+++ b/config/filter.d/kerio.conf
@@ -9,8 +9,6 @@ failregex = ^ SMTP Spam attack detected from <HOST>,
 
 ignoreregex =
 
-[Init]
-
 datepattern = ^\[%%d/%%b/%%Y %%H:%%M:%%S\]
 
 # DEV NOTES:

--- a/config/filter.d/monit.conf
+++ b/config/filter.d/monit.conf
@@ -13,7 +13,7 @@ before = common.conf
 _daemon = monit
 
 # Regexp for previous (accessing monit httpd) and new (access denied) versions
-failregex = ^\[[A-Z]+\s+\]\s*error\s*:\s*Warning:\s+Client '<HOST>' supplied (?:unknown user '[^']+'|wrong password for user '[^']*') accessing monit httpd$
+failregex = ^\[\s*\]\s*error\s*:\s*Warning:\s+Client '<HOST>' supplied (?:unknown user '[^']+'|wrong password for user '[^']*') accessing monit httpd$
             ^%(__prefix_line)s\w+: access denied -- client <HOST>: (?:unknown user '[^']+'|wrong password for user '[^']*'|empty password)$
 
 # Ignore login with empty user (first connect, no user specified)

--- a/config/filter.d/murmur.conf
+++ b/config/filter.d/murmur.conf
@@ -15,13 +15,14 @@ _daemon = murmurd
 #      variable in your server config file (murmur.ini / mumble-server.ini).
 _usernameregex = [^>]+
 
-_prefix = <W>[\n\s]*(\.\d{3})?\s+\d+ => <\d+:%(_usernameregex)s\(-1\)> Rejected connection from <HOST>:\d+:
+_prefix = \s+\d+ => <\d+:%(_usernameregex)s\(-1\)> Rejected connection from <HOST>:\d+:
 
 failregex = ^%(_prefix)s Invalid server password$
             ^%(_prefix)s Wrong certificate or password for existing user$
 
 ignoreregex =
 
+datepattern = ^<W>{DATE}
 
 # DEV Notes:
 #

--- a/config/filter.d/nginx-botsearch.conf
+++ b/config/filter.d/nginx-botsearch.conf
@@ -13,6 +13,9 @@ failregex = ^<HOST> \- \S+ \[\] \"(GET|POST|HEAD) \/<block> \S+\" 404 .+$
 
 ignoreregex = 
 
+datepattern = {^LN-BEG}%%ExY(?P<_sep>[-/.])%%m(?P=_sep)%%d[T ]%%H:%%M:%%S(?:[.,]%%f)?(?:\s*%%z)?
+              ^[^\[]*\[({DATE})
+              {^LN-BEG}
 
 # DEV Notes:
 # Based on apache-botsearch filter

--- a/config/filter.d/nginx-http-auth.conf
+++ b/config/filter.d/nginx-http-auth.conf
@@ -8,6 +8,8 @@ failregex = ^ \[error\] \d+#\d+: \*\d+ user "\S+":? (password mismatch|was not f
 
 ignoreregex = 
 
+datepattern = {^LN-BEG}
+
 # DEV NOTES:
 # Based on samples in https://github.com/fail2ban/fail2ban/pull/43/files
 # Extensive search of all nginx auth failures not done yet.

--- a/config/filter.d/nginx-limit-req.conf
+++ b/config/filter.d/nginx-limit-req.conf
@@ -43,3 +43,4 @@ failregex = ^\s*\[error\] \d+#\d+: \*\d+ limiting requests, excess: [\d\.]+ by z
 
 ignoreregex = 
 
+datepattern = {^LN-BEG}

--- a/config/filter.d/nsd.conf
+++ b/config/filter.d/nsd.conf
@@ -26,3 +26,6 @@ failregex =  ^%(__prefix_line)sinfo: ratelimit block .* query <HOST> TYPE255$
              ^%(__prefix_line)sinfo: .* <HOST> refused, no acl matches\.$
 
 ignoreregex =
+
+datepattern = {^LN-BEG}Epoch
+              {^LN-BEG}

--- a/config/filter.d/openhab.conf
+++ b/config/filter.d/openhab.conf
@@ -9,7 +9,6 @@
 [Definition] 
 failregex = ^<HOST>\s+-\s+-\s+\[\]\s+"[A-Z]+ .*" 401 \d+\s*$
 
-[Init]
 datepattern = %%d/%%b[^/]*/%%Y:%%H:%%M:%%S %%z
 
 

--- a/config/filter.d/oracleims.conf
+++ b/config/filter.d/oracleims.conf
@@ -52,10 +52,12 @@ before = common.conf
 # Note that you MUST have LOG_FORMAT=4 for this to work!
 #
 
-failregex = ^.*tr="[A-Z]+\|[0-9.]+\|\d+\|<HOST>\|\d+" ap="[^"]*" mi="Bad password" us="[^"]*" di="535 5.7.8 Bad username or password( \(Authentication failed\))?\."/>$
+failregex = tr="[A-Z]+\|[0-9.]+\|\d+\|<HOST>\|\d+" ap="[^"]*" mi="Bad password" us="[^"]*" di="535 5.7.8 Bad username or password( \(Authentication failed\))?\."/>$
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.
 # Values:  TEXT
 #
 ignoreregex =
+
+datepattern = ^<co ts="{DATE}"\s+

--- a/config/filter.d/php-url-fopen.conf
+++ b/config/filter.d/php-url-fopen.conf
@@ -18,3 +18,6 @@ ignoreregex =
 # http://blogs.buanzo.com.ar/2009/04/fail2ban-filter-for-php-injection-attacks.html#comment-1489
 #
 # Author: Arturo 'Buanzo' Busleiman <buanzo@buanzo.com.ar>
+
+datepattern = ^[^\[]*\[({DATE})
+              {^LN-BEG}

--- a/config/filter.d/portsentry.conf
+++ b/config/filter.d/portsentry.conf
@@ -8,5 +8,8 @@ failregex = \/<HOST> Port\: [0-9]+ (TCP|UDP) Blocked$
 
 ignoreregex =
 
+datepattern = {^LN-BEG}Epoch
+              {^LN-BEG}
+
 # Author: Pacop <pacoparu@gmail.com>
 

--- a/config/filter.d/selinux-common.conf
+++ b/config/filter.d/selinux-common.conf
@@ -18,4 +18,6 @@ failregex = ^type=%(_type)s msg=audit\(:\d+\): (user )?pid=\d+ uid=%(_uid)s auid
 
 ignoreregex =
 
+datepattern = EPOCH
+
 # Author: Daniel Black

--- a/config/filter.d/sogo-auth.conf
+++ b/config/filter.d/sogo-auth.conf
@@ -6,7 +6,9 @@
 
 failregex = ^ sogod \[\d+\]: SOGoRootPage Login from '<HOST>' for user '.*' might not have worked( - password policy: \d*  grace: -?\d*  expire: -?\d*  bound: -?\d*)?\s*$
 
-ignoreregex = 
+ignoreregex = "^<ADDR>"
+
+datepattern = {^LN-BEG}
 
 # 
 # DEV Notes:

--- a/config/filter.d/sogo-auth.conf
+++ b/config/filter.d/sogo-auth.conf
@@ -8,7 +8,10 @@ failregex = ^ sogod \[\d+\]: SOGoRootPage Login from '<HOST>' for user '.*' migh
 
 ignoreregex = "^<ADDR>"
 
-datepattern = {^LN-BEG}
+datepattern = {^LN-BEG}%%ExY(?P<_sep>[-/.])%%m(?P=_sep)%%d[T ]%%H:%%M:%%S(?:[.,]%%f)?(?:\s*%%z)?
+              {^LN-BEG}(?:%%a )?%%b %%d %%H:%%M:%%S(?:\.%%f)?(?: %%ExY)?
+              ^[^\[]*\[({DATE})
+              {^LN-BEG}
 
 # 
 # DEV Notes:

--- a/config/filter.d/squid.conf
+++ b/config/filter.d/squid.conf
@@ -9,5 +9,8 @@ failregex = ^\s+\d\s<HOST>\s+[A-Z_]+_DENIED/403 .*$
 
 ignoreregex =
 
+datepattern = {^LN-BEG}Epoch
+              {^LN-BEG}
+
 # Author: Daniel Black
 

--- a/config/filter.d/squirrelmail.conf
+++ b/config/filter.d/squirrelmail.conf
@@ -5,8 +5,6 @@ failregex = ^ \[LOGIN_ERROR\].*from <HOST>: Unknown user or password incorrect\.
 
 ignoreregex =
 
-[Init]
-
 datepattern = ^%%m/%%d/%%Y %%H:%%M:%%S
 
 # DEV NOTES:

--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -38,12 +38,12 @@ failregex = ^%(__prefix_line)s(?:error: PAM: )?[aA]uthentication (?:failure|erro
 
 ignoreregex = 
 
-[Init]
-
 # "maxlines" is number of log lines to buffer for multi-line regex searches
 maxlines = 10
 
 journalmatch = _SYSTEMD_UNIT=sshd.service + _COMM=sshd
+
+datepattern = {^LN-BEG}
 
 # DEV Notes:
 #

--- a/config/filter.d/tine20.conf
+++ b/config/filter.d/tine20.conf
@@ -10,6 +10,9 @@ failregex =  ^[\da-f]{5,} [\da-f]{5,} (-- none --|.*?)( \d+(\.\d+)?(h|m|s|ms)){0
 
 ignoreregex = 
 
+datepattern = ^[^-]+ -- [^-]+ -- - ({DATE})
+              {^LN-BEG}
+
 # Author: Mika (mkl) from Tine20.org forum: https://www.tine20.org/forum/viewtopic.php?f=2&t=15688&p=54766
 # Editor: Daniel Black
 # Advisor: Lars Kneschke

--- a/fail2ban/client/fail2banregex.py
+++ b/fail2ban/client/fail2banregex.py
@@ -474,8 +474,9 @@ class Fail2banRegex(object):
 				if self._verbose or template.hits:
 					out.append("[%d] %s" % (template.hits, template.name))
 					if self._verbose_date:
-						out.append("    # weight: %3s, pattern: %s" % (
-							template.weight, getattr(template, 'pattern', ''),))
+						out.append("    # weight: %.3f (%.3f), pattern: %s" % (
+							template.weight, template.template.weight,
+							getattr(template, 'pattern', ''),))
 						out.append("    # regex:   %s" % (getattr(template, 'regex', ''),))
 			pprint_list(out, "[# of hits] date format")
 

--- a/fail2ban/client/fail2banregex.py
+++ b/fail2ban/client/fail2banregex.py
@@ -122,15 +122,15 @@ Report bugs to https://github.com/fail2ban/fail2ban/issues
 	p.add_options([
 		Option("-d", "--datepattern",
 			   help="set custom pattern used to match date/times"),
-		Option("-e", "--encoding",
+		Option("-e", "--encoding", default=PREFER_ENC,
 			   help="File encoding. Default: system locale"),
-		Option("-r", "--raw", action='store_true',
+		Option("-r", "--raw", action='store_true', default=False,
 			   help="Raw hosts, don't resolve dns"),
 		Option("--usedns", action='store', default=None,
 			   help="DNS specified replacement of tags <HOST> in regexp "
 			        "('yes' - matches all form of hosts, 'no' - IP addresses only)"),
 		Option("-L", "--maxlines", type=int, default=0,
-			   help="maxlines for multi-line regex"),
+			   help="maxlines for multi-line regex."),
 		Option("-m", "--journalmatch",
 			   help="journalctl style matches overriding filter file. "
 			   "\"systemd-journal\" only"),
@@ -143,6 +143,8 @@ Report bugs to https://github.com/fail2ban/fail2ban/issues
 			   help="Increase verbosity"),
 		Option("--verbosity", action="store", dest="verbose", type=int,
 			   help="Set numerical level of verbosity (0..4)"),
+		Option("--verbose-date", "--VD", action='store_true',
+			   help="Verbose date patterns/regex in output"),
 		Option("-D", "--debuggex", action='store_true',
 			   help="Produce debuggex.com urls for debugging there"),
 		Option("--print-no-missed", action='store_true',
@@ -215,14 +217,8 @@ class LineStats(object):
 class Fail2banRegex(object):
 
 	def __init__(self, opts):
-		self._verbose = opts.verbose
-		self._debuggex = opts.debuggex
-		self._maxlines = 20
-		self._print_no_missed = opts.print_no_missed
-		self._print_no_ignored = opts.print_no_ignored
-		self._print_all_matched = opts.print_all_matched
-		self._print_all_missed = opts.print_all_missed
-		self._print_all_ignored = opts.print_all_ignored
+		# set local protected memebers from given options:
+		self.__dict__.update(dict(('_'+o,v) for o,v in opts.__dict__.iteritems()))
 		self._maxlines_set = False		  # so we allow to override maxlines in cmdline
 		self._datepattern_set = False
 		self._journalmatch = None
@@ -236,23 +232,20 @@ class Fail2banRegex(object):
 
 		if opts.maxlines:
 			self.setMaxLines(opts.maxlines)
+		else:
+			self._maxlines = 20
 		if opts.journalmatch is not None:
 			self.setJournalMatch(opts.journalmatch.split())
 		if opts.datepattern:
 			self.setDatePattern(opts.datepattern)
-		if opts.encoding:
-			self.encoding = opts.encoding
-		else:
-			self.encoding = PREFER_ENC
-		self.raw = True if opts.raw else False
 		if opts.usedns:
 			self._filter.setUseDns(opts.usedns)
 
 	def decode_line(self, line):
-		return FileContainer.decode_line('<LOG>', self.encoding, line)
+		return FileContainer.decode_line('<LOG>', self._encoding, line)
 
 	def encode_line(self, line):
-		return line.encode(self.encoding, 'ignore')
+		return line.encode(self._encoding, 'ignore')
 
 	def setDatePattern(self, pattern):
 		if not self._datepattern_set:
@@ -350,7 +343,7 @@ class Fail2banRegex(object):
 		orgLineBuffer = self._filter._Filter__lineBuffer
 		fullBuffer = len(orgLineBuffer) >= self._filter.getMaxLines()
 		try:
-			line, ret = self._filter.processLine(line, date, checkAllRegex=True, returnRawHost=self.raw)
+			line, ret = self._filter.processLine(line, date, checkAllRegex=True, returnRawHost=self._raw)
 			for match in ret:
 				# Append True/False flag depending if line was matched by
 				# more than one regex
@@ -479,8 +472,11 @@ class Fail2banRegex(object):
 			out = []
 			for template in self._filter.dateDetector.templates:
 				if self._verbose or template.hits:
-					out.append("[%d] %s" % (
-						template.hits, template.name))
+					out.append("[%d] %s" % (template.hits, template.name))
+					if self._verbose_date:
+						out.append("    # weight: %3s, pattern: %s" % (
+							template.weight, getattr(template, 'pattern', ''),))
+						out.append("    # regex:   %s" % (getattr(template, 'regex', ''),))
 			pprint_list(out, "[# of hits] date format")
 
 		output( "\nLines: %s" % self._line_stats, )
@@ -518,7 +514,7 @@ class Fail2banRegex(object):
 			try:
 				hdlr = open(cmd_log, 'rb')
 				output( "Use         log file : %s" % cmd_log )
-				output( "Use         encoding : %s" % self.encoding )
+				output( "Use         encoding : %s" % self._encoding )
 				test_lines = self.file_lines_gen(hdlr)
 			except IOError as e:
 				output( e )

--- a/fail2ban/client/filterreader.py
+++ b/fail2ban/client/filterreader.py
@@ -40,6 +40,9 @@ class FilterReader(DefinitionInitConfigReader):
 	_configOpts = {
 		"ignoreregex": ["string", None],
 		"failregex": ["string", ""],
+		"maxlines": ["int", None],
+		"datepattern": ["string", None],
+		"journalmatch": ["string", None],
 	}
 
 	def setFile(self, fileName):
@@ -74,16 +77,16 @@ class FilterReader(DefinitionInitConfigReader):
 					stream.append(["multi-set", self._jailName, "add" + opt, multi])
 				elif len(multi):
 					stream.append(["set", self._jailName, "add" + opt, multi[0]])
-		if self._initOpts:
-			if 'maxlines' in self._initOpts:
+			elif opt == 'maxlines':
 				# We warn when multiline regex is used without maxlines > 1
 				# therefore keep sure we set this option first.
-				stream.insert(0, ["set", self._jailName, "maxlines", self._initOpts["maxlines"]])
-			if 'datepattern' in self._initOpts:
-				stream.append(["set", self._jailName, "datepattern", self._initOpts["datepattern"]])
+				stream.insert(0, ["set", self._jailName, "maxlines", value])
+			elif opt == 'datepattern':
+				stream.append(["set", self._jailName, "datepattern", value])
 			# Do not send a command if the match is empty.
-			if self._initOpts.get("journalmatch", '') != '':
-				for match in self._initOpts["journalmatch"].split("\n"):
+			elif opt == 'journalmatch':
+				for match in value.split("\n"):
+					if match == '': continue
 					stream.append(
 						["set", self._jailName, "addjournalmatch"] +
                         shlex.split(match))

--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -112,6 +112,7 @@ class JailReader(ConfigReader):
 				["string", "ignorecommand", None],
 				["string", "ignoreip", None],
 				["string", "filter", ""],
+				["string", "datepattern", None],
 				["string", "action", ""]]
 
 		# Before interpolation (substitution) add static options always available as default:
@@ -195,6 +196,8 @@ class JailReader(ConfigReader):
 		 """
 
 		stream = []
+		if self.__filter:
+			stream.extend(self.__filter.convert())
 		for opt, value in self.__opts.iteritems():
 			if opt == "logpath" and	\
 					not self.__opts.get('backend', None).startswith("systemd"):
@@ -216,17 +219,9 @@ class JailReader(ConfigReader):
 				stream.append(["set", self.__name, "logencoding", value])
 			elif opt == "backend":
 				backend = value
-			elif opt == "maxretry":
-				stream.append(["set", self.__name, "maxretry", value])
 			elif opt == "ignoreip":
 				for ip in splitwords(value):
 					stream.append(["set", self.__name, "addignoreip", ip])
-			elif opt == "findtime":
-				stream.append(["set", self.__name, "findtime", value])
-			elif opt == "bantime":
-				stream.append(["set", self.__name, "bantime", value])
-			elif opt == "usedns":
-				stream.append(["set", self.__name, "usedns", value])
 			elif opt in ("failregex", "ignoreregex"):
 				multi = []
 				for regex in value.split('\n'):
@@ -237,10 +232,8 @@ class JailReader(ConfigReader):
 					stream.append(["multi-set", self.__name, "add" + opt, multi])
 				elif len(multi):
 					stream.append(["set", self.__name, "add" + opt, multi[0]])
-			elif opt == "ignorecommand":
-				stream.append(["set", self.__name, "ignorecommand", value])
-		if self.__filter:
-			stream.extend(self.__filter.convert())
+			elif opt not in ('action', 'filter', 'enabled'):
+				stream.append(["set", self.__name, opt, value])
 		for action in self.__actions:
 			if isinstance(action, (ConfigReaderUnshared, ConfigReader)):
 				stream.extend(action.convert())

--- a/fail2ban/server/datedetector.py
+++ b/fail2ban/server/datedetector.py
@@ -326,8 +326,8 @@ class DateDetector(object):
 			if template.flags & (DateTemplate.LINE_BEGIN|DateTemplate.LINE_END):
 				if logSys.getEffectiveLevel() <= logLevel-1: # pragma: no cover - very-heavy debug
 					logSys.log(logLevel-1, "  try to match last anchored template #%02i ...", i)
-					match = template.matchDate(line)
-					ignoreBySearch = i
+				match = template.matchDate(line)
+				ignoreBySearch = i
 			else:
 				distance, endpos = self.__lastPos[0], self.__lastEndPos[0]
 				if logSys.getEffectiveLevel() <= logLevel-1:
@@ -357,7 +357,6 @@ class DateDetector(object):
 				logSys.log(logLevel, "  ** last pattern not found - pattern change, search ...")
 		# search template and better match:
 		if not match:
-			self.__lastTemplIdx = 0x7fffffff
 			logSys.log(logLevel, " search template (%i) ...", len(self.__templates))
 			found = None, 0x7fffffff, 0x7fffffff, -1
 			i = 0
@@ -414,7 +413,7 @@ class DateDetector(object):
 			self.__lastPos = distance, line[distance-1:distance]
 			self.__lastEndPos = endpos, line[endpos:endpos+1]
 			# if not first - try to reorder current template (bubble up), they will be not sorted anymore:
-			if i:
+			if i and i != self.__lastTemplIdx:
 				i = self._reorderTemplate(i)
 			self.__lastTemplIdx = i
 			# return tuple with match and template reference used for parsing:

--- a/fail2ban/server/datedetector.py
+++ b/fail2ban/server/datedetector.py
@@ -88,14 +88,9 @@ class DateDetectorCache(object):
 		# simple date: 2005/01/23 21:59:59 
 		# custom for syslog-ng 2006.12.21 06:43:20
 		self._cacheTemplate("%ExY(?P<_sep>[-/.])%m(?P=_sep)%d[T ]%H:%M:%S(?:[.,]%f)?(?:\s*%z)?")
-		# 20050123T215959, 20050123 215959
-		self._cacheTemplate("%ExY%Exm%Exd[T ]%ExH%ExM%ExS(?:[.,]%f)?(?:\s*%z)?")
 		# asctime with optional day, subsecond and/or year:
 		# Sun Jan 23 21:59:59.011 2005 
-		# prefixed with optional time zone (monit):
-		# PDT Apr 16 21:05:29
 		self._cacheTemplate("(?:%z )?(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?")
-		self._cacheTemplate("(?:%Z )?(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?")
 		# asctime with optional day, subsecond and/or year coming after day
 		# http://bugs.debian.org/798923
 		# Sun Jan 23 2005 21:59:59.011
@@ -132,6 +127,12 @@ class DateDetectorCache(object):
 		self._cacheTemplate("%b %d, %ExY %I:%M:%S %p")
 		# ASSP: Apr-27-13 02:33:06
 		self._cacheTemplate("%b-%d-%Exy %H:%M:%S", lineBeginOnly=True)
+		# 20050123T215959, 20050123 215959
+		self._cacheTemplate("%ExY%Exm%Exd[T ]%ExH%ExM%ExS(?:[.,]%f)?(?:\s*%z)?")
+		# prefixed with optional named time zone (monit):
+		# PDT Apr 16 21:05:29
+		self._cacheTemplate("(?:%Z )?(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?")
+		#
 		self.__templates = self.__tmpcache[0] + self.__tmpcache[1]
 		del self.__tmpcache
 
@@ -212,7 +213,9 @@ class DateDetector(object):
 	def addDefaultTemplate(self, filterTemplate=None, preMatch=None):
 		"""Add Fail2Ban's default set of date templates.
 		"""
-		for template in DateDetector._defCache.templates:
+		for template in sorted(DateDetector._defCache.templates,
+			lambda a,b: b.hits - a.hits
+		):
 			# filter if specified:
 			if filterTemplate is not None and not filterTemplate(template): continue
 			# if exact pattern available - create copy of template, contains replaced {DATE} with default regex:

--- a/fail2ban/server/datedetector.py
+++ b/fail2ban/server/datedetector.py
@@ -254,27 +254,32 @@ class DateDetector(object):
 		if i < len(self.__templates):
 			ddtempl = self.__templates[i]
 			template = ddtempl.template
-			distance, endpos = self.__lastPos[0], self.__lastEndPos[0]
-			if logSys.getEffectiveLevel() <= logLevel-1:
-				logSys.log(logLevel-1, "  try to match last template #%02i (from %r to %r): ...%r==%r %s %r==%r...",
-					i, distance, endpos, 
-					line[distance-1:distance], self.__lastPos[1],
-					line[distance:endpos],
-					line[endpos:endpos+1], self.__lastEndPos[1])
-			# check same boundaries left/right, otherwise possible collision/pattern switch:
-			if (line[distance-1:distance] == self.__lastPos[1] and 
-					line[endpos:endpos+1] == self.__lastEndPos[1]
-			):
-				match = template.matchDate(line, distance, endpos)
-				if match:
-					distance = match.start()
-					endpos = match.end()
-					# if different position, possible collision/pattern switch:
-					if distance == self.__lastPos[0] and endpos == self.__lastEndPos[0]:
-						logSys.log(logLevel, "  matched last time template #%02i", i)
-					else:
-						logSys.log(logLevel, "  ** last pattern collision - pattern change, search ...")
-						match = None
+			if template.flags & DateTemplate.LINE_BEGIN:
+				if logSys.getEffectiveLevel() <= logLevel-1:
+					logSys.log(logLevel-1, "  try to match last anchored template #%02i ...", i)
+					match = template.matchDate(line)
+			else:
+				distance, endpos = self.__lastPos[0], self.__lastEndPos[0]
+				if logSys.getEffectiveLevel() <= logLevel-1:
+					logSys.log(logLevel-1, "  try to match last template #%02i (from %r to %r): ...%r==%r %s %r==%r...",
+						i, distance, endpos, 
+						line[distance-1:distance], self.__lastPos[1],
+						line[distance:endpos],
+						line[endpos:endpos+1], self.__lastEndPos[1])
+				# check same boundaries left/right, otherwise possible collision/pattern switch:
+				if (line[distance-1:distance] == self.__lastPos[1] and 
+						line[endpos:endpos+1] == self.__lastEndPos[1]
+				):
+					match = template.matchDate(line, distance, endpos)
+			if match:
+				distance = match.start()
+				endpos = match.end()
+				# if different position, possible collision/pattern switch:
+				if distance == self.__lastPos[0] and endpos == self.__lastEndPos[0]:
+					logSys.log(logLevel, "  matched last time template #%02i", i)
+				else:
+					logSys.log(logLevel, "  ** last pattern collision - pattern change, search ...")
+					match = None
 		# search template and better match:
 		if not match:
 			self.__lastTemplIdx = 0x7fffffff

--- a/fail2ban/server/datedetector.py
+++ b/fail2ban/server/datedetector.py
@@ -359,7 +359,7 @@ class DateDetector(object):
 		if not match:
 			self.__lastTemplIdx = 0x7fffffff
 			logSys.log(logLevel, " search template (%i) ...", len(self.__templates))
-			found = None, 0x7fffffff, -1
+			found = None, 0x7fffffff, 0x7fffffff, -1
 			i = 0
 			for ddtempl in self.__templates:
 				if logSys.getEffectiveLevel() <= logLevel-1:

--- a/fail2ban/server/datedetector.py
+++ b/fail2ban/server/datedetector.py
@@ -60,16 +60,15 @@ class DateDetectorCache(object):
 			# exact given template with word benin-end boundary:
 			template = DatePatternRegex(template)
 		# additional template, that prefers datetime at start of a line (safety+performance feature):
-		template2 = copy.copy(template)
-		if hasattr(template, 'pattern'):
-			regex = template.pattern
-			wordEnd = True
-		else:
-			regex = template.regex
-			wordEnd = False
-		template2.setRegex(regex, wordBegin='start', wordEnd=wordEnd)
-		if template2.name != template.name:
-			self.__templates.append(template2)
+		if 0 and hasattr(template, 'regex'):
+			template2 = copy.copy(template)
+			regex = getattr(template, 'pattern', template.regex)
+			template2.setRegex(regex, wordBegin='start', wordEnd=True)
+			if template2.name != template.name:
+				# increase weight of such templates, because they should be always
+				# preferred in template sorting process (bubble up):
+				template2.weight = 100
+				self.__templates.append(template2)
 		# add template:
 		self.__templates.append(template)
 
@@ -80,35 +79,35 @@ class DateDetectorCache(object):
 		# 2005-01-23T21:59:59.981746, 2005-01-23 21:59:59
 		# simple date: 2005/01/23 21:59:59 
 		# custom for syslog-ng 2006.12.21 06:43:20
-		self._cacheTemplate("%Y(?P<_sep>[-/.])%m(?P=_sep)%d[T ]%H:%M:%S(?:[.,]%f)?(?:\s*%z)?")
+		self._cacheTemplate("%ExY(?P<_sep>[-/.])%m(?P=_sep)%d[T ]%H:%M:%S(?:[.,]%f)?(?:\s*%z)?")
 		# 20050123T215959, 20050123 215959
-		self._cacheTemplate("%Y%Em%Ed[T ]%EH%EM%ES(?:[.,]%f)?(?:\s*%z)?")
+		self._cacheTemplate("%ExY%Exm%Exd[T ]%ExH%ExM%ExS(?:[.,]%f)?(?:\s*%z)?")
 		# asctime with optional day, subsecond and/or year:
 		# Sun Jan 23 21:59:59.011 2005 
 		# prefixed with optional time zone (monit):
 		# PDT Apr 16 21:05:29
-		self._cacheTemplate("(?:%z )?(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %Y)?")
+		self._cacheTemplate("(?:%z )?(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?")
 		# asctime with optional day, subsecond and/or year coming after day
 		# http://bugs.debian.org/798923
 		# Sun Jan 23 2005 21:59:59.011
-		self._cacheTemplate("(?:%a )?%b %d %Y %H:%M:%S(?:\.%f)?")
+		self._cacheTemplate("(?:%a )?%b %d %ExY %H:%M:%S(?:\.%f)?")
 		# simple date too (from x11vnc): 23/01/2005 21:59:59 
 		# and with optional year given by 2 digits: 23/01/05 21:59:59 
 		# (See http://bugs.debian.org/537610)
 		# 17-07-2008 17:23:25
-		self._cacheTemplate("%d(?P<_sep>[-/])%m(?P=_sep)(?:%Y|%y) %H:%M:%S")
+		self._cacheTemplate("%d(?P<_sep>[-/])%m(?P=_sep)(?:%ExY|%Exy) %H:%M:%S")
 		# Apache format optional time zone:
 		# [31/Oct/2006:09:22:55 -0000]
 		# 26-Jul-2007 15:20:52
 		# named 26-Jul-2007 15:20:52.252
 		# roundcube 26-Jul-2007 15:20:52 +0200
-		self._cacheTemplate("%d(?P<_sep>[-/])%b(?P=_sep)%Y[ :]?%H:%M:%S(?:\.%f)?(?: %z)?")
+		self._cacheTemplate("%d(?P<_sep>[-/])%b(?P=_sep)%ExY[ :]?%H:%M:%S(?:\.%f)?(?: %z)?")
 		# CPanel 05/20/2008:01:57:39
-		self._cacheTemplate("%m/%d/%Y:%H:%M:%S")
+		self._cacheTemplate("%m/%d/%ExY:%H:%M:%S")
 		# 01-27-2012 16:22:44.252
 		# subseconds explicit to avoid possible %m<->%d confusion
-		# with previous ("%d-%m-%Y %H:%M:%S" by "%d(?P<_sep>[-/])%m(?P=_sep)(?:%Y|%y) %H:%M:%S")
-		self._cacheTemplate("%m-%d-%Y %H:%M:%S(?:\.%f)?")
+		# with previous ("%d-%m-%ExY %H:%M:%S" by "%d(?P<_sep>[-/])%m(?P=_sep)(?:%ExY|%Exy) %H:%M:%S")
+		self._cacheTemplate("%m-%d-%ExY %H:%M:%S(?:\.%f)?")
 		# TAI64N
 		self._cacheTemplate(DateTai64n())
 		# Epoch
@@ -116,13 +115,13 @@ class DateDetectorCache(object):
 		# Only time information in the log
 		self._cacheTemplate("^%H:%M:%S")
 		# <09/16/08@05:03:30>
-		self._cacheTemplate("^<%m/%d/%y@%H:%M:%S>")
+		self._cacheTemplate("^<%m/%d/%Exy@%H:%M:%S>")
 		# MySQL: 130322 11:46:11
-		self._cacheTemplate("%y%Em%Ed  ?%H:%M:%S")
+		self._cacheTemplate("%Exy%Exm%Exd  ?%H:%M:%S")
 		# Apache Tomcat
-		self._cacheTemplate("%b %d, %Y %I:%M:%S %p")
+		self._cacheTemplate("%b %d, %ExY %I:%M:%S %p")
 		# ASSP: Apr-27-13 02:33:06
-		self._cacheTemplate("^%b-%d-%y %H:%M:%S")
+		self._cacheTemplate("^%b-%d-%Exy %H:%M:%S")
 
 
 class DateDetectorTemplate(object):
@@ -218,14 +217,14 @@ class DateDetector(object):
 		"""
 		i = 0
 		with self.__lock:
-			for ddtemplate in self.__templates:
-				template = ddtemplate.template
+			for ddtempl in self.__templates:
+				template = ddtempl.template
 				match = template.matchDate(line)
-				if not match is None:
+				if match is not None:
 					if logSys.getEffectiveLevel() <= logLevel:
 						logSys.log(logLevel, "Matched time template %s", template.name)
-					ddtemplate.hits += 1
-					ddtemplate.lastUsed = time.time()
+					ddtempl.hits += 1
+					ddtempl.lastUsed = time.time()
 					# if not first - try to reorder current template (bubble up), they will be not sorted anymore:
 					if i:
 						self._reorderTemplate(i)
@@ -254,32 +253,21 @@ class DateDetector(object):
 			The Unix timestamp returned from the first successfully matched
 			template or None if not found.
 		"""
-		if timeMatch:
-			template = timeMatch[1]
-			if template is not None:
-				try:
-					date = template.getDate(line, timeMatch[0])
-					if date is not None:
-						if logSys.getEffectiveLevel() <= logLevel:
-							logSys.log(logLevel, "Got time %f for %r using template %s",
-								date[0], date[1].group(), template.name)
-						return date
-				except ValueError:
-					return None
-		with self.__lock:
-			for ddtemplate in self.__templates:
-				template = ddtemplate.template
-				try:
-					date = template.getDate(line)
-					if date is None:
-						continue
+		# search match for all specified templates:
+		if timeMatch is None:
+			timeMatch = self.matchTime(line)
+		# convert:
+		template = timeMatch[1]
+		if template is not None:
+			try:
+				date = template.getDate(line, timeMatch[0])
+				if date is not None:
 					if logSys.getEffectiveLevel() <= logLevel:
-						logSys.log(logLevel, "Got time %f for %r using template %s", 
+						logSys.log(logLevel, "Got time %f for %r using template %s",
 							date[0], date[1].group(), template.name)
 					return date
-				except ValueError: # pragma: no cover
-					pass
-			return None
+			except ValueError:
+				return None
 
 	def _reorderTemplate(self, num):
 		"""Reorder template (bubble up) in template list if hits grows enough.
@@ -291,16 +279,16 @@ class DateDetector(object):
 		"""
 		if num:
 			templates = self.__templates
-			template = templates[num]
+			ddtempl = templates[num]
 		  ## current hits and time the template was long unused:
-			untime = template.lastUsed - self.__unusedTime
-			hits = template.hits
+			untime = ddtempl.lastUsed - self.__unusedTime
+			hits = ddtempl.hits * ddtempl.template.weight
 			## try to move faster (first 2 if it still unused, or half of part to current template position):
-			phits = 0
 			for pos in (0, 1, num // 2):
 				phits = templates[pos].hits
-				if not phits:
+				if not phits: # if we've found an unused
 					break
+			phits *= templates[pos].template.weight
 			## don't move too often (multiline logs resp. log's with different date patterns),
 			## if template not used too long, replace it also :
 			if not phits or hits > phits + 5 or templates[pos].lastUsed < untime:
@@ -308,8 +296,9 @@ class DateDetector(object):
 				if hits <= phits and templates[pos].lastUsed > untime:
 					pos = num-1
 					## if still smaller and template at position used, don't move:
-					if hits < templates[pos].hits and templates[pos].lastUsed > untime:
+					phits = templates[pos].hits * templates[pos].template.weight
+					if hits < phits and templates[pos].lastUsed > untime:
 						return
-				templates[pos], templates[num] = template, templates[pos]
+				templates[pos], templates[num] = ddtempl, templates[pos]
 
 

--- a/fail2ban/server/datetemplate.py
+++ b/fail2ban/server/datetemplate.py
@@ -65,6 +65,7 @@ class DateTemplate(object):
 		self.name = ""
 		self.weight = 1.0
 		self.flags = 0
+		self.hits = 0
 		self._regex = ""
 		self._cRegex = None
 
@@ -133,6 +134,8 @@ class DateTemplate(object):
 		if not self._cRegex:
 			self._compileRegex()
 		dateMatch = self._cRegex.search(line, *args); # pos, endpos
+		if dateMatch:
+			self.hits += 1
 		return dateMatch
 
 	@abstractmethod

--- a/fail2ban/server/datetemplate.py
+++ b/fail2ban/server/datetemplate.py
@@ -50,7 +50,7 @@ class DateTemplate(object):
 
 	def __init__(self):
 		self.name = ""
-		self.weight = 1
+		self.weight = 1.0
 		self._regex = ""
 		self._cRegex = None
 
@@ -232,11 +232,7 @@ class DatePatternRegex(DateTemplate):
 		if not dateMatch:
 			dateMatch = self.matchDate(line)
 		if dateMatch:
-			groupdict = dict(
-				(key, value)
-				for key, value in dateMatch.groupdict().iteritems()
-				if value is not None)
-			return reGroupDictStrptime(groupdict), dateMatch
+			return reGroupDictStrptime(dateMatch.groupdict()), dateMatch
 
 
 class DateTai64n(DateTemplate):

--- a/fail2ban/server/datetemplate.py
+++ b/fail2ban/server/datetemplate.py
@@ -219,7 +219,6 @@ class DateEpoch(DateTemplate):
 		if dateMatch:
 			# extract part of format which represents seconds since epoch
 			return (float(dateMatch.group(1)), dateMatch)
-		return None
 
 
 class DatePatternRegex(DateTemplate):
@@ -338,4 +337,3 @@ class DateTai64n(DateTemplate):
 			seconds_since_epoch = value[2:17]
 			# convert seconds from HEX into local time stamp
 			return (int(seconds_since_epoch, 16), dateMatch)
-		return None

--- a/fail2ban/server/datetemplate.py
+++ b/fail2ban/server/datetemplate.py
@@ -115,15 +115,14 @@ class DateTemplate(object):
 			self.flags |= DateTemplate.WORD_BEGIN if wordBegin != 'start' else DateTemplate.LINE_BEGIN
 			if wordBegin != 'start':
 				regex = r'(?:^|\b|\W)' + regex
-				self.name = '{*WD-BEG}' + self.name
 			else:
 				regex = r"^(?:\W{0,2})?" + regex
-				self.name = '{^LN-BEG}' + self.name
+				if not self.name.startswith('{^LN-BEG}'):
+					self.name = '{^LN-BEG}' + self.name
 		# if word end boundary:
 		if boundEnd:
 			self.flags |= DateTemplate.WORD_END
 			regex += r'(?=\b|\W|$)'
-			self.name += '{*WD-END}'
 		if RE_LINE_BOUND_BEG.search(regex): self.flags |= DateTemplate.LINE_BEGIN
 		if RE_LINE_BOUND_END.search(regex): self.flags |= DateTemplate.LINE_END
 		# remove possible special pattern "**" in front and end of regex:

--- a/fail2ban/server/mytime.py
+++ b/fail2ban/server/mytime.py
@@ -41,6 +41,21 @@ class MyTime:
 	"""
 
 	myTime = None
+	alternateNowTime = None
+	alternateNow = None
+
+	@staticmethod
+	def setAlternateNow(t):
+		"""Set current time.
+
+		Use None in order to always get the real current time.
+
+		@param t the time to set or None
+		"""
+
+		MyTime.alternateNowTime = t
+		MyTime.alternateNow = \
+			datetime.datetime.fromtimestamp(t) if t is not None else None
 
 	@staticmethod
 	def setTime(t):
@@ -84,8 +99,9 @@ class MyTime:
 		"""
 		if MyTime.myTime is None:
 			return datetime.datetime.now()
-		else:
-			return datetime.datetime.fromtimestamp(MyTime.myTime)
+		if MyTime.myTime == MyTime.alternateNowTime:
+			return MyTime.alternateNow
+		return datetime.datetime.fromtimestamp(MyTime.myTime)
 
 	@staticmethod
 	def localtime(x=None):

--- a/fail2ban/server/strptime.py
+++ b/fail2ban/server/strptime.py
@@ -26,7 +26,23 @@ from .mytime import MyTime
 
 locale_time = LocaleTime()
 timeRE = TimeRE()
+#todo: implement literal time zone support like CET, PST, PDT, etc (via pytz):
+#timeRE['z'] = r"%s?(?P<z>Z|[+-]\d{2}(?::?[0-5]\d)?|[A-Z]{3})?" % timeRE['Z']
 timeRE['z'] = r"(?P<z>Z|[+-]\d{2}(?::?[0-5]\d)?)"
+
+# Extend build-in TimeRE with some exact (two-digit) patterns:
+timeRE['Ed'] = r"(?P<d>3[0-1]|[1-2]\d|0[1-9])"
+timeRE['Em'] = r"(?P<m>1[0-2]|0[1-9])"
+timeRE['EH'] = r"(?P<H>2[0-3]|[0-1]\d)"
+timeRE['EM'] = r"(?P<M>[0-5]\d)"
+timeRE['ES'] = r"(?P<S>6[0-1]|[0-5]\d)"
+
+def getTimePatternRE():
+	keys = timeRE.keys()
+	return (r"%%(%%|%s|[%s])" % (
+		"|".join([k for k in keys if len(k) > 1]),
+		"".join([k for k in keys if len(k) == 1]),
+	))
 
 
 def reGroupDictStrptime(found_dict):

--- a/fail2ban/server/strptime.py
+++ b/fail2ban/server/strptime.py
@@ -40,6 +40,7 @@ def _getYearCentRE(cent=(0,3), distance=3, now=(MyTime.now(), MyTime.alternateNo
 
 #todo: implement literal time zone support like CET, PST, PDT, etc (via pytz):
 #timeRE['z'] = r"%s?(?P<z>Z|[+-]\d{2}(?::?[0-5]\d)?|[A-Z]{3})?" % timeRE['Z']
+timeRE['Z'] = r"(?P<Z>[A-Z]{3,5})"
 timeRE['z'] = r"(?P<z>Z|[+-]\d{2}(?::?[0-5]\d)?)"
 
 # Extend build-in TimeRE with some exact patterns

--- a/fail2ban/server/strptime.py
+++ b/fail2ban/server/strptime.py
@@ -55,8 +55,6 @@ timeRE['ExS'] = r"(?P<S>6[0-1]|[0-5]\d)"
 # respect possible run in the test-cases (alternate date used there):
 timeRE['ExY'] = r"(?P<Y>%s\d)" % _getYearCentRE(cent=(0,3), distance=3)
 timeRE['Exy'] = r"(?P<y>%s\d)" % _getYearCentRE(cent=(2,3), distance=3)
-# Special pattern "start of the line", analogous to `wordBegin='start'` of default templates:
-timeRE['ExLB'] = r"(?:^|(?<=^\W)|(?<=^\W{2}))"
 
 def getTimePatternRE():
 	keys = timeRE.keys()
@@ -70,7 +68,6 @@ def getTimePatternRE():
 		'M': "Minute", 'p': "AMPM", 'S': "Second", 'U': "Yearweek",
 		'w': "Weekday", 'W': "Yearweek", 'y': 'Year2', 'Y': "Year", '%': "%",
 		'z': "Zone offset", 'f': "Microseconds", 'Z': "Zone name",
-		'ExLB': '{^LN-BEG}',
 	}
 	for key in set(keys) - set(names): # may not have them all...
 		if key.startswith('Ex'):

--- a/fail2ban/server/strptime.py
+++ b/fail2ban/server/strptime.py
@@ -41,7 +41,7 @@ def _getYearCentRE(cent=(0,3), distance=3, now=(MyTime.now(), MyTime.alternateNo
 #todo: implement literal time zone support like CET, PST, PDT, etc (via pytz):
 #timeRE['z'] = r"%s?(?P<z>Z|[+-]\d{2}(?::?[0-5]\d)?|[A-Z]{3})?" % timeRE['Z']
 timeRE['Z'] = r"(?P<Z>[A-Z]{3,5})"
-timeRE['z'] = r"(?P<z>Z|[+-]\d{2}(?::?[0-5]\d)?)"
+timeRE['z'] = r"(?P<z>Z|UTC|GMT|[+-]\d{2}(?::?[0-5]\d)?)"
 
 # Extend build-in TimeRE with some exact patterns
 # exact two-digit patterns:
@@ -183,7 +183,7 @@ def reGroupDictStrptime(found_dict, msec=False):
 				week_of_year_start = 0
 		elif key == 'z':
 			z = val
-			if z == "Z":
+			if z in ("Z", "UTC", "GMT"):
 				tzoffset = 0
 			else:
 				tzoffset = int(z[1:3]) * 60 # Hours...
@@ -191,6 +191,10 @@ def reGroupDictStrptime(found_dict, msec=False):
 					tzoffset += int(z[-2:]) # ...and minutes
 				if z.startswith("-"):
 					tzoffset = -tzoffset
+		elif key == 'Z':
+			z = val
+			if z in ("UTC", "GMT"):
+				tzoffset = 0
 
 	# Fail2Ban will assume it's this year
 	assume_year = False

--- a/fail2ban/server/transmitter.py
+++ b/fail2ban/server/transmitter.py
@@ -303,7 +303,7 @@ class Transmitter:
 					actionvalue = command[4]
 					setattr(action, actionkey, actionvalue)
 					return getattr(action, actionkey)
-		raise Exception("Invalid command (no set action or not yet implemented)")
+		raise Exception("Invalid command %r (no set action or not yet implemented)" % (command[1],))
 	
 	def __commandGet(self, command):
 		name = command[0]

--- a/fail2ban/tests/action_d/test_badips.py
+++ b/fail2ban/tests/action_d/test_badips.py
@@ -32,6 +32,7 @@ if sys.version_info >= (2,7): # pragma: no cover - may be unavailable
 		
 		def setUp(self):
 			"""Call before every test case."""
+			super(BadIPsActionTest, self).setUp()
 			unittest.F2B.SkipIfNoNetwork()
 
 			self.jail = DummyJail()

--- a/fail2ban/tests/action_d/test_smtp.py
+++ b/fail2ban/tests/action_d/test_smtp.py
@@ -45,6 +45,7 @@ class SMTPActionTest(unittest.TestCase):
 
 	def setUp(self):
 		"""Call before every test case."""
+		super(SMTPActionTest, self).setUp()
 		self.jail = DummyJail()
 		pythonModule = os.path.join(CONFIG_DIR, "action.d", "smtp.py")
 		pythonModuleName = os.path.basename(pythonModule.rstrip(".py"))

--- a/fail2ban/tests/banmanagertestcase.py
+++ b/fail2ban/tests/banmanagertestcase.py
@@ -32,6 +32,7 @@ from ..server.ticket import BanTicket
 class AddFailure(unittest.TestCase):
 	def setUp(self):
 		"""Call before every test case."""
+		super(AddFailure, self).setUp()
 		self.__ticket = BanTicket('193.168.0.128', 1167605999.0)
 		self.__banManager = BanManager()
 
@@ -134,6 +135,7 @@ class AddFailure(unittest.TestCase):
 class StatusExtendedCymruInfo(unittest.TestCase):
 	def setUp(self):
 		"""Call before every test case."""
+		super(StatusExtendedCymruInfo, self).setUp()
 		unittest.F2B.SkipIfNoNetwork()
 		self.__ban_ip = "93.184.216.34"
 		self.__asn = "15133"

--- a/fail2ban/tests/clientbeautifiertestcase.py
+++ b/fail2ban/tests/clientbeautifiertestcase.py
@@ -32,6 +32,7 @@ class BeautifierTest(unittest.TestCase):
 
 	def setUp(self):
 		""" Call before every test case """
+		super(BeautifierTest, self).setUp()
 		self.b = Beautifier()
 
 	def tearDown(self):

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -55,6 +55,7 @@ class ConfigReaderTest(unittest.TestCase):
 
 	def setUp(self):
 		"""Call before every test case."""
+		super(ConfigReaderTest, self).setUp()
 		self.d = tempfile.mkdtemp(prefix="f2b-temp")
 		self.c = ConfigReaderUnshared(basedir=self.d)
 

--- a/fail2ban/tests/config/filter.d/zzz-generic-example.conf
+++ b/fail2ban/tests/config/filter.d/zzz-generic-example.conf
@@ -20,3 +20,8 @@ failregex = ^%(__prefix_line)sF2B: failure from <HOST>$
 # just to test multiple ignoreregex:
 ignoreregex = ^%(__prefix_line)sF2B: error from 192.0.2.251$
               ^%(__prefix_line)sF2B: error from 192.0.2.252$
+
+# specify only exact date patterns, +1 with %%Y to test usage of last known date by wrong dates like 0000-00-00...
+datepattern = {^LN-BEG}%%ExY(?P<_sep>[-/.])%%m(?P=_sep)%%d[T ]%%H:%%M:%%S(?:[.,]%%f)?(?:\s*%%z)?
+              {^LN-BEG}(?:%%a )?%%b %%d %%H:%%M:%%S(?:\.%%f)?(?: %%ExY)?
+              {^LN-BEG}%%Y(?P<_sep>[-/.])%%m(?P=_sep)%%d[T ]%%H:%%M:%%S(?:[.,]%%f)?(?:\s*%%z)?

--- a/fail2ban/tests/datedetectortestcase.py
+++ b/fail2ban/tests/datedetectortestcase.py
@@ -378,6 +378,11 @@ class CustomDateFormatsTest(unittest.TestCase):
 			("20031230010203",  "{^LN-BEG}%ExY%Exm%Exd%ExH%ExM%ExS**", "#2003123001020320030101000000"),
 			("20031230010203",  "{^LN-BEG}%ExY%Exm%Exd%ExH%ExM%ExS**", "##2003123001020320030101000000"),
 			("20031230010203",  "{^LN-BEG}%ExY%Exm%Exd%ExH%ExM%ExS",   "[20031230010203]20030101000000"),
+			# UTC/GMT time zone offset (with %z and %Z):
+			(1072746123.0 - 3600, "{^LN-BEG}%ExY-%Exm-%Exd %ExH:%ExM:%ExS(?: %z)?", "[2003-12-30 01:02:03] server ..."),
+			(1072746123.0 - 3600, "{^LN-BEG}%ExY-%Exm-%Exd %ExH:%ExM:%ExS(?: %Z)?", "[2003-12-30 01:02:03] server ..."),
+			(1072746123.0,        "{^LN-BEG}%ExY-%Exm-%Exd %ExH:%ExM:%ExS(?: %z)?", "[2003-12-30 01:02:03 UTC] server ..."),
+			(1072746123.0,        "{^LN-BEG}%ExY-%Exm-%Exd %ExH:%ExM:%ExS(?: %Z)?", "[2003-12-30 01:02:03 UTC] server ..."),
 		):
 			logSys.debug('== test: %r', (matched, dp, line))
 			if dp is None:
@@ -388,7 +393,10 @@ class CustomDateFormatsTest(unittest.TestCase):
 			date = dd.getTime(line)
 			if matched:
 				self.assertTrue(date)
-				self.assertEqual(matched, date[1].group(1))
+				if isinstance(matched, basestring):
+					self.assertEqual(matched, date[1].group(1))
+				else:
+					self.assertEqual(matched, date[0])
 			else:
 				self.assertEqual(date, None)
 

--- a/fail2ban/tests/datedetectortestcase.py
+++ b/fail2ban/tests/datedetectortestcase.py
@@ -250,12 +250,12 @@ class DateDetectorTest(LogCaptureTestCase):
 			("030324  0:04:00",            "server mysqld[1000]: 030324  0:04:00 [Warning] Access denied ..."
 																				" foreign-input just some free text 2003-03-07 17:05:01 test", 10),
 			# distance collision detection (first date should be found):
-			("Sep 16 21:30:26",            "server mysqld[1020]: Sep 16 21:30:26 server mysqld: 030916 21:30:26 [Warning] Access denied", 10),
+			("Sep 16 21:30:26",            "server mysqld[1020]: Sep 16 21:30:26 server mysqld: 030916 21:30:26 [Warning] Access denied", 15),
 			# just to test sorting:
 			("2005-10-07 06:09:42",        "server mysqld[5906]: 2005-10-07 06:09:42 5907 [Warning] Access denied", 20),
 			("2005-10-08T15:26:18.237955", "server mysqld[5906]: 2005-10-08T15:26:18.237955 6 [Note] Access denied", 20),
 			# date format changed again:
-			("051009 10:05:30",            "server mysqld[1000]: 051009 10:05:30 [Warning] Access denied ...", 20),
+			("051009 10:05:30",            "server mysqld[1000]: 051009 10:05:30 [Warning] Access denied ...", 50),
 		):
 			logSys.debug('== test: %r', (debit, line, cnt))
 			for i in range(cnt):

--- a/fail2ban/tests/datedetectortestcase.py
+++ b/fail2ban/tests/datedetectortestcase.py
@@ -30,7 +30,7 @@ import datetime
 
 from ..server.datedetector import DateDetector
 from ..server import datedetector
-from ..server.datetemplate import DateTemplate
+from ..server.datetemplate import DatePatternRegex, DateTemplate
 from .utils import setUpMyTime, tearDownMyTime, LogCaptureTestCase
 from ..helpers import getLogger
 
@@ -89,6 +89,10 @@ class DateDetectorTest(LogCaptureTestCase):
 		"""
 		dateUnix = 1106513999.0
 
+		# anchored - matching expression (pattern) is anchored
+		# bound - pattern can be tested using word boundary (e.g. False if contains in front some optional part)
+		# sdate - date string used in test log-line
+		# rdate - if specified, the result match, which differs from sdate
 		for anchored, bound, sdate, rdate in (
 			(False, True,  "Jan 23 21:59:59", None),
 			(False, False, "Sun Jan 23 21:59:59 2005", None),
@@ -113,15 +117,15 @@ class DateDetectorTest(LogCaptureTestCase):
 			(False, True,  "2005-01-23T20:59:59.252Z", None), #ISO 8601 (UTC)
 			(False, True,  "2005-01-23T15:59:59-05:00", None), #ISO 8601 with TZ
 			(False, True,  "2005-01-23 21:59:59", None), #ISO 8601 no TZ, assume local
-			(False, True,  "20050123T215959", None),   #Short ISO
-			(False, True,  "20050123 215959", None),   #Short ISO
+			(False, True,  "20050123T215959", None),   #Short ISO with T
+			(False, True,  "20050123 215959", None),   #Short ISO with space
 			(True,  True,  "<01/23/05@21:59:59>", None),
 			(False, True,  "050123 21:59:59", None), # MySQL
 			(True,  True,  "Jan-23-05 21:59:59", None), # ASSP like
 			(False, True,  "Jan 23, 2005 9:59:59 PM", None), # Apache Tomcat
 			(True,  True,  "1106513999", None), # Regular epoch
 			(True,  True,  "1106513999.000", None), # Regular epoch with millisec
-			(True,  True,  "[1106513999.000]", "1106513999.000"), # epoch squared
+			(True,  True,  "[1106513999.000]", "1106513999.000"), # epoch squared (brackets are not in match)
 			(False, True,  "audit(1106513999.000:987)", "1106513999.000"), # SELinux
 		):
 			logSys.debug('== test %r', (anchored, bound, sdate))
@@ -193,6 +197,141 @@ class DateDetectorTest(LogCaptureTestCase):
 			self.assertEqual(t.getRegex(), '^a{3,5}b?c*$')
 			self.assertRaises(Exception, t.getDate, '')
 			self.assertEqual(t.matchDate('aaaac').group(), 'aaaac')
+
+
+iso8601 = DatePatternRegex("%Y-%m-%d[T ]%H:%M:%S(?:\.%f)?%z")
+
+class CustomDateFormatsTest(unittest.TestCase):
+
+	def testIso8601(self):
+		date = datetime.datetime.utcfromtimestamp(
+			iso8601.getDate("2007-01-25T12:00:00Z")[0])
+		self.assertEqual(
+			date,
+			datetime.datetime(2007, 1, 25, 12, 0))
+		self.assertRaises(TypeError, iso8601.getDate, None)
+		self.assertRaises(TypeError, iso8601.getDate, date)
+
+		self.assertEqual(iso8601.getDate(""), None)
+		self.assertEqual(iso8601.getDate("Z"), None)
+
+		self.assertEqual(iso8601.getDate("2007-01-01T120:00:00Z"), None)
+		self.assertEqual(iso8601.getDate("2007-13-01T12:00:00Z"), None)
+		date = datetime.datetime.utcfromtimestamp(
+			iso8601.getDate("2007-01-25T12:00:00+0400")[0])
+		self.assertEqual(
+			date,
+			datetime.datetime(2007, 1, 25, 8, 0))
+		date = datetime.datetime.utcfromtimestamp(
+			iso8601.getDate("2007-01-25T12:00:00+04:00")[0])
+		self.assertEqual(
+			date,
+			datetime.datetime(2007, 1, 25, 8, 0))
+		date = datetime.datetime.utcfromtimestamp(
+			iso8601.getDate("2007-01-25T12:00:00-0400")[0])
+		self.assertEqual(
+			date,
+			datetime.datetime(2007, 1, 25, 16, 0))
+		date = datetime.datetime.utcfromtimestamp(
+			iso8601.getDate("2007-01-25T12:00:00-04")[0])
+		self.assertEqual(
+			date,
+			datetime.datetime(2007, 1, 25, 16, 0))
+
+	def testAmbiguousDatePattern(self):
+		defDD = DateDetector()
+		defDD.addDefaultTemplate()
+		for (matched, dp, line) in (
+			# positive case:
+			('Jan 23 21:59:59',   None, 'Test failure Jan 23 21:59:59 for 192.0.2.1'),
+			# ambiguous "unbound" patterns (missed):
+			(False,               None, 'Test failure TestJan 23 21:59:59.011 2015 for 192.0.2.1'),
+			(False,               None, 'Test failure Jan 23 21:59:59123456789 for 192.0.2.1'),
+			# ambiguous "no optional year" patterns (matched):
+			('Aug 8 11:25:50',      None, 'Aug 8 11:25:50 20030f2329b8 Authentication failed from 192.0.2.1'),
+			('Aug 8 11:25:50',      None, '[Aug 8 11:25:50] 20030f2329b8 Authentication failed from 192.0.2.1'),
+			('Aug 8 11:25:50 2014', None, 'Aug 8 11:25:50 2014 20030f2329b8 Authentication failed from 192.0.2.1'),
+			# direct specified patterns:
+			('20:00:00 01.02.2003',    r'%H:%M:%S %d.%m.%Y$', '192.0.2.1 at 20:00:00 01.02.2003'),
+			('[20:00:00 01.02.2003]',  r'\[%H:%M:%S %d.%m.%Y\]', '192.0.2.1[20:00:00 01.02.2003]'),
+			('[20:00:00 01.02.2003]',  r'\[%H:%M:%S %d.%m.%Y\]', '[20:00:00 01.02.2003]192.0.2.1'),
+			('[20:00:00 01.02.2003]',  r'\[%H:%M:%S %d.%m.%Y\]$', '192.0.2.1[20:00:00 01.02.2003]'),
+			('[20:00:00 01.02.2003]',  r'^\[%H:%M:%S %d.%m.%Y\]', '[20:00:00 01.02.2003]192.0.2.1'),
+			('[17/Jun/2011 17:00:45]', r'^\[%d/%b/%Y %H:%M:%S\]', '[17/Jun/2011 17:00:45] Attempt, IP address 192.0.2.1'),
+			('[17/Jun/2011 17:00:45]', r'\[%d/%b/%Y %H:%M:%S\]', 'Attempt [17/Jun/2011 17:00:45] IP address 192.0.2.1'),
+			('[17/Jun/2011 17:00:45]', r'\[%d/%b/%Y %H:%M:%S\]', 'Attempt IP address 192.0.2.1, date: [17/Jun/2011 17:00:45]'),
+			# direct specified patterns (begin/end, missed):
+			(False,                 r'%H:%M:%S %d.%m.%Y', '192.0.2.1x20:00:00 01.02.2003'),
+			(False,                 r'%H:%M:%S %d.%m.%Y', '20:00:00 01.02.2003x192.0.2.1'),
+			# direct specified unbound patterns (no begin/end boundary):
+			('20:00:00 01.02.2003', r'**%H:%M:%S %d.%m.%Y**', '192.0.2.1x20:00:00 01.02.2003'),
+			('20:00:00 01.02.2003', r'**%H:%M:%S %d.%m.%Y**', '20:00:00 01.02.2003x192.0.2.1'),
+			# pattern enclosed with stars (in comparison to example above):
+			('*20:00:00 01.02.2003*', r'\**%H:%M:%S %d.%m.%Y\**', 'test*20:00:00 01.02.2003*test'),
+			# direct specified patterns (begin/end, matched):
+			('20:00:00 01.02.2003', r'%H:%M:%S %d.%m.%Y', '192.0.2.1 20:00:00 01.02.2003'),
+			('20:00:00 01.02.2003', r'%H:%M:%S %d.%m.%Y', '20:00:00 01.02.2003 192.0.2.1'),
+			# wrong year in 1st date, so failed by convert using not precise year (filter used last known date),
+			# in the 2nd and 3th tests (with precise year) it should find correct the 2nd date:
+			(None,                  r'%Y-%Exm-%Exd %ExH:%ExM:%ExS',   "0000-12-30 00:00:00 - 2003-12-30 00:00:00"),
+			('2003-12-30 00:00:00', r'%ExY-%Exm-%Exd %ExH:%ExM:%ExS', "0000-12-30 00:00:00 - 2003-12-30 00:00:00"),
+			('2003-12-30 00:00:00', None,                             "0000-12-30 00:00:00 - 2003-12-30 00:00:00"),
+			# wrong date recognized short month/day (unbounded date pattern without separator between parts),
+			# in the 2nd and 3th tests (with precise month and day) it should find correct the 2nd date:
+			('200333 010203',   r'%Y%m%d %H%M%S',             "text:200333 010203 | date:20031230 010203"),
+			('20031230 010203', r'%ExY%Exm%Exd %ExH%ExM%ExS', "text:200333 010203 | date:20031230 010203"),
+			('20031230 010203', None,                         "text:200333 010203 | date:20031230 010203"),
+			# Explicit bound in start of the line using %ExLB key,
+			# (negative) in the 1st case without line begin boundary - wrong date may be found,
+			# (positive) in the 2nd case with line begin boundary - unexpected date / log line (not found)
+			# (positive) and in 3th case with line begin boundary - find the correct date
+			("20030101 000000", "%ExY%Exm%Exd %ExH%ExM%ExS",      "00001230 010203 - 20030101 000000"),
+			(None,              "%ExLB%ExY%Exm%Exd %ExH%ExM%ExS", "00001230 010203 - 20030101 000000"),
+			("20031230 010203", "%ExLB%ExY%Exm%Exd %ExH%ExM%ExS", "20031230 010203 - 20030101 000000"),
+			# Explicit bound in start of the line using %ExLB key, 
+			# up to 2 non-alphanumeric chars front, ** - no word boundary on the right
+			("20031230010203",  "%ExLB%ExY%Exm%Exd%ExH%ExM%ExS**", "2003123001020320030101000000"),
+			("20031230010203",  "%ExLB%ExY%Exm%Exd%ExH%ExM%ExS**", "#2003123001020320030101000000"),
+			("20031230010203",  "%ExLB%ExY%Exm%Exd%ExH%ExM%ExS**", "##2003123001020320030101000000"),
+			("20031230010203",  "%ExLB%ExY%Exm%Exd%ExH%ExM%ExS",   "[20031230010203]20030101000000"),
+		):
+			logSys.debug('== test: %r', (matched, dp, line))
+			if dp is None:
+				dd = defDD
+			else:
+				dp = DatePatternRegex(dp)
+				dd = DateDetector()
+				dd.appendTemplate(dp)
+			date = dd.getTime(line)
+			if matched:
+				self.assertTrue(date)
+				self.assertEqual(matched, date[1].group())
+			else:
+				self.assertEqual(date, None)
+
+	# def testAmbiguousUsingOrderedTemplates(self):
+	# 	defDD = DateDetector()
+	# 	defDD.addDefaultTemplate()
+	# 	for (matched, dp, line) in (
+	# 		# wrong date recognized short month/day (unbounded date pattern without separator),
+	# 		# in the 2nd and 3th tests (with precise month and day) it should find correct the 2nd date:
+	# 		('200333 010203',   r'%Y%m%d %H%M%S',             "text:200333 010203 | date:20031230 010203"),
+	# 		('20031230 010203', r'%ExY%Exm%Exd %ExH%ExM%ExS', "text:200333 010203 | date:20031230 010203"),
+	# 		('20031230 010203', None,                         "text:200333 010203 | date:20031230 010203"),
+	# 	):
+	# 		logSys.debug('== test: %r', (matched, dp, line))
+	# 		if dp is None:
+	# 			dd = defDD
+	# 		else:
+	# 			dp = DatePatternRegex(dp)
+	# 			dd = DateDetector()
+	# 			dd.appendTemplate(dp)
+	# 		date = dd.getTime(line)
+	# 		if matched:
+	# 			self.assertTrue(date)
+	# 			self.assertEqual(matched, date[1].group())
+	# 		else:
+	# 			self.assertEqual(date, None)
 
 
 #	def testDefaultTempate(self):

--- a/fail2ban/tests/datedetectortestcase.py
+++ b/fail2ban/tests/datedetectortestcase.py
@@ -202,6 +202,9 @@ class DateDetectorTest(LogCaptureTestCase):
 		dd = DateDetector()
 		dd.addDefaultTemplate()
 		for (debit, line, cnt) in (
+			# shortest distance to datetime should win:
+			("030324  0:03:59",            "some free text 030324  0:03:59 -- 2003-03-07 17:05:01 ...", 1),
+			# some free text with datetime:
 			("2003-03-07 17:05:01",        "some free text 2003-03-07 17:05:01 test ...", 15),
 			# distance collision detection (date from foreign input should not be found):
 			("030324  0:04:00",            "server mysqld[1000]: 030324  0:04:00 [Warning] Access denied ..."

--- a/fail2ban/tests/fail2banclienttestcase.py
+++ b/fail2ban/tests/fail2banclienttestcase.py
@@ -743,6 +743,7 @@ class Fail2banServerTest(Fail2banClientServerBase):
 				"maxretry = 3",
 				"findtime = 10m",
 				"failregex = ^\s*failure (401|403) from <HOST>",
+				"datepattern = {^LN-BEG}EPOCH",
 				"",
 				"[test-jail1]", "backend = " + backend, "filter =", 
 				"action = ",

--- a/fail2ban/tests/fail2banclienttestcase.py
+++ b/fail2ban/tests/fail2banclienttestcase.py
@@ -138,8 +138,8 @@ def _start_params(tmp, use_stock=False, logtarget="/dev/null", db=":memory:"):
 			"""Filters list of 'files' to contain only directories (under dir)"""
 			return [f for f in files if isdir(pjoin(dir, f))]
 		shutil.copytree(STOCK_CONF_DIR, cfg, ignore=ig_dirs)
-		os.symlink(pjoin(STOCK_CONF_DIR, "action.d"), pjoin(cfg, "action.d"))
-		os.symlink(pjoin(STOCK_CONF_DIR, "filter.d"), pjoin(cfg, "filter.d"))
+		os.symlink(os.path.abspath(pjoin(STOCK_CONF_DIR, "action.d")), pjoin(cfg, "action.d"))
+		os.symlink(os.path.abspath(pjoin(STOCK_CONF_DIR, "filter.d")), pjoin(cfg, "filter.d"))
 		# replace fail2ban params (database with memory):
 		r = re.compile(r'^dbfile\s*=')
 		for line in fileinput.input(pjoin(cfg, "fail2ban.conf"), inplace=True):
@@ -424,7 +424,7 @@ class Fail2banClientTest(Fail2banClientServerBase):
 		self.execSuccess(startparams, "-vvd")
 		self.assertLogged("Loading files")
 		self.assertLogged("logtarget")
-
+		
 	@with_tmpdir
 	@with_kill_srv
 	def testClientStartBackgroundInside(self, tmp):

--- a/fail2ban/tests/fail2banregextestcase.py
+++ b/fail2ban/tests/fail2banregextestcase.py
@@ -101,6 +101,7 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 	def testWrongIngnoreRE(self):
 		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--datepattern", "{^LN-BEG}EPOCH",
 			"test", r".*? from <HOST>$", r".**"
 		)
 		self.assertFalse(fail2banRegex.start(opts, args))
@@ -108,6 +109,7 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 	def testDirectFound(self):
 		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--datepattern", "^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?",
 			"--print-all-matched", "--print-no-missed",
 			"Dec 31 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 192.0.2.0",
 			r"Authentication failure for .*? from <HOST>$"
@@ -136,6 +138,7 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 	def testDirectRE_1(self):
 		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--datepattern", "^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?",
 			"--print-all-matched",
 			Fail2banRegexTest.FILENAME_01, 
 			Fail2banRegexTest.RE_00
@@ -151,6 +154,7 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 	def testDirectRE_1raw(self):
 		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--datepattern", "^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?",
 			"--print-all-matched", "--raw",
 			Fail2banRegexTest.FILENAME_01, 
 			Fail2banRegexTest.RE_00
@@ -160,6 +164,7 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 	def testDirectRE_1raw_noDns(self):
 		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--datepattern", "^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?",
 			"--print-all-matched", "--raw", "--usedns=no",
 			Fail2banRegexTest.FILENAME_01, 
 			Fail2banRegexTest.RE_00
@@ -169,6 +174,7 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 	def testDirectRE_2(self):
 		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--datepattern", "^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?",
 			"--print-all-matched",
 			Fail2banRegexTest.FILENAME_02, 
 			Fail2banRegexTest.RE_00
@@ -178,6 +184,7 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 	def testVerbose(self):
 		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--datepattern", "^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?",
 			"--verbose", "--verbose-date", "--print-no-missed",
 			Fail2banRegexTest.FILENAME_02, 
 			Fail2banRegexTest.RE_00
@@ -190,6 +197,7 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 	def testWronChar(self):
 		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--datepattern", "^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?",
 			Fail2banRegexTest.FILENAME_WRONGCHAR, Fail2banRegexTest.FILTER_SSHD
 		)
 		self.assertTrue(fail2banRegex.start(opts, args))
@@ -203,6 +211,7 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 	def testWronCharDebuggex(self):
 		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"--datepattern", "^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?",
 			"--debuggex", "--print-all-matched",
 			Fail2banRegexTest.FILENAME_WRONGCHAR, Fail2banRegexTest.FILTER_SSHD
 		)

--- a/fail2ban/tests/fail2banregextestcase.py
+++ b/fail2ban/tests/fail2banregextestcase.py
@@ -178,7 +178,7 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 	def testVerbose(self):
 		(opts, args, fail2banRegex) = _Fail2banRegex(
-			"--verbose", "--print-no-missed",
+			"--verbose", "--verbose-date", "--print-no-missed",
 			Fail2banRegexTest.FILENAME_02, 
 			Fail2banRegexTest.RE_00
 		)

--- a/fail2ban/tests/failmanagertestcase.py
+++ b/fail2ban/tests/failmanagertestcase.py
@@ -36,6 +36,7 @@ class AddFailure(unittest.TestCase):
 
 	def setUp(self):
 		"""Call before every test case."""
+		super(AddFailure, self).setUp()
 		self.__items = None
 		self.__failManager = FailManager()
 

--- a/fail2ban/tests/files/filter.d/testcase01.conf
+++ b/fail2ban/tests/files/filter.d/testcase01.conf
@@ -33,7 +33,6 @@ failregex = ^%(__prefix_line)s(?:error: PAM: )?Authentication failure for .* fro
 #
 ignoreregex = ^.+ john from host 192.168.1.1\s*$
 
-[Init]
 # "maxlines" is number of log lines to buffer for multi-line regex searches
 maxlines = 1
 

--- a/fail2ban/tests/files/logs/freeswitch
+++ b/fail2ban/tests/files/logs/freeswitch
@@ -9,3 +9,8 @@
 2013-12-31 17:39:54.767815 [WARNING] sofia_reg.c:2531 Can't find user [1001@192.168.2.51] from 5.11.47.236
 # failJSON: { "time": "2013-12-31T17:39:54", "match": true, "host": "185.24.234.141" }
 2013-12-31 17:39:54.767815 [WARNING] sofia_reg.c:2531 Can't find user [100@192.168.2.51] from 185.24.234.141
+
+# failJSON: { "time": "2016-09-25T18:57:58", "match": true, "host": "192.0.2.1", "desc": "Systemd dual time with prefix - 1st expr" }
+2016-09-25T18:57:58.150982 www.srv.tld freeswitch[122921]: 2016-09-25 18:57:58.150982 [WARNING] sofia_reg.c:2889 Can't find user [201@::1] from 192.0.2.1
+# failJSON: { "time": "2016-09-25T18:57:58", "match": true, "host": "192.0.2.2", "desc": "Systemd dual time with prefix - 2nd expr" }
+2016-09-25T18:57:58.150982 www.srv.tld freeswitch[122921]: 2016-09-25 18:57:58.150982 [WARNING] sofia_reg.c:1720 SIP auth failure (INVITE) on sofia profile 'sipinterface_1' for [9810972597751739@::1] from ip 192.0.2.2

--- a/fail2ban/tests/files/logs/zzz-generic-example
+++ b/fail2ban/tests/files/logs/zzz-generic-example
@@ -46,6 +46,14 @@ Jun 22 20:37:04 server test-demo[402]: writeToStorage plist={
 # failJSON: { "time": "2005-06-22T20:37:04", "match": true , "host": "192.0.2.2" }
 0000-12-30 00:00:00 server test-demo[47831]:  F2B: failure from 192.0.2.2
 
+# -- test no zone and UTC/GMT named zone "2005-06-21T14:55:10 UTC" == "2005-06-21T16:55:10 CEST" (diff +2h in CEST):
+# failJSON: { "time": "2005-06-21T16:55:09", "match": true , "host": "192.0.2.09" }
+2005-06-21 16:55:09 machine test-demo(pam_unix)[13709] F2B: error from 192.0.2.09
+# failJSON: { "time": "2005-06-21T16:55:10", "match": true , "host": "192.0.2.10" }
+2005-06-21 14:55:10 UTC machine test-demo(pam_unix)[13709] F2B: error from 192.0.2.10
+# failJSON: { "time": "2005-06-21T16:55:11", "match": true , "host": "192.0.2.11" }
+2005-06-21 14:55:11 GMT machine test-demo(pam_unix)[13709] F2B: error from 192.0.2.11
+
 # failJSON: { "time": "2005-06-21T16:56:02", "match": true , "host": "192.0.2.250" }
 [Jun 21 16:56:02] machine test-demo(pam_unix)[13709] F2B: error from 192.0.2.250
 # failJSON: { "match": false, "desc": "test 1st ignoreregex" }

--- a/fail2ban/tests/files/logs/zzz-generic-example
+++ b/fail2ban/tests/files/logs/zzz-generic-example
@@ -30,8 +30,8 @@ Jun 21 16:55:02   <auth.info> machine kernel: [  970.699396] @vserver_demo test-
 # failJSON: { "time": "2005-06-21T16:55:03", "match": true , "host": "192.0.2.3" }
 [Jun 21 16:55:03] <auth.info> machine kernel: [  970.699396] @vserver_demo test-demo(pam_unix)[13709] [ID 255 test] F2B: failure from 192.0.2.3
 
-# -- wrong time direct in journal-line (using precise year pattern):
-# failJSON: { "match": false}
+# -- wrong time direct in journal-line (used last known date):
+# failJSON: { "time": "2005-06-21T16:55:03", "match": true , "host": "192.0.2.1" }
 0000-12-30 00:00:00 server test-demo[47831]:  F2B: failure from 192.0.2.1
 # -- wrong time after newline in message (plist without escaped newlines):
 # failJSON: { "match": false }
@@ -42,8 +42,8 @@ Jun 22 20:37:04 server test-demo[402]: writeToStorage plist={
              applicationDate = "0000-12-30 00:00:00 +0000";
 # failJSON: { "match": false }
 }
-# -- wrong time direct in journal-line (using precise year pattern):
-# failJSON: { "match": false}
+# -- wrong time direct in journal-line (used last known date):
+# failJSON: { "time": "2005-06-22T20:37:04", "match": true , "host": "192.0.2.2" }
 0000-12-30 00:00:00 server test-demo[47831]:  F2B: failure from 192.0.2.2
 
 # failJSON: { "time": "2005-06-21T16:56:02", "match": true , "host": "192.0.2.250" }

--- a/fail2ban/tests/files/logs/zzz-generic-example
+++ b/fail2ban/tests/files/logs/zzz-generic-example
@@ -30,8 +30,8 @@ Jun 21 16:55:02   <auth.info> machine kernel: [  970.699396] @vserver_demo test-
 # failJSON: { "time": "2005-06-21T16:55:03", "match": true , "host": "192.0.2.3" }
 [Jun 21 16:55:03] <auth.info> machine kernel: [  970.699396] @vserver_demo test-demo(pam_unix)[13709] [ID 255 test] F2B: failure from 192.0.2.3
 
-# -- wrong time direct in journal-line (used last known date):
-# failJSON: { "time": "2005-06-21T16:55:03", "match": true , "host": "192.0.2.1" }
+# -- wrong time direct in journal-line (using precise year pattern):
+# failJSON: { "match": false}
 0000-12-30 00:00:00 server test-demo[47831]:  F2B: failure from 192.0.2.1
 # -- wrong time after newline in message (plist without escaped newlines):
 # failJSON: { "match": false }
@@ -42,8 +42,8 @@ Jun 22 20:37:04 server test-demo[402]: writeToStorage plist={
              applicationDate = "0000-12-30 00:00:00 +0000";
 # failJSON: { "match": false }
 }
-# -- wrong time direct in journal-line (used last known date):
-# failJSON: { "time": "2005-06-22T20:37:04", "match": true , "host": "192.0.2.2" }
+# -- wrong time direct in journal-line (using precise year pattern):
+# failJSON: { "match": false}
 0000-12-30 00:00:00 server test-demo[47831]:  F2B: failure from 192.0.2.2
 
 # failJSON: { "time": "2005-06-21T16:56:02", "match": true , "host": "192.0.2.250" }

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -270,6 +270,7 @@ def _copy_lines_to_journal(in_, fields={},n=None, skip=0, terminal_line=""): # p
 class BasicFilter(unittest.TestCase):
 
 	def setUp(self):
+		super(BasicFilter, self).setUp()
 		self.filter = Filter('name')
 
 	def testGetSetUseDNS(self):
@@ -363,6 +364,7 @@ class IgnoreIP(LogCaptureTestCase):
 		setUpMyTime()
 		self.filter.addIgnoreIP('192.168.1.0/25')
 		self.filter.addFailRegex('<HOST>')
+		self.filter.setDatePattern('{^LN-BEG}EPOCH')
 		self.filter.processLineAndAdd('1387203300.222 192.168.1.32')
 		self.assertLogged('Ignore 192.168.1.32')
 		tearDownMyTime()
@@ -461,6 +463,7 @@ class LogFileFilterPoll(unittest.TestCase):
 
 	def setUp(self):
 		"""Call before every test case."""
+		super(LogFileFilterPoll, self).setUp()
 		self.filter = FilterPoll(DummyJail())
 		self.filter.addLogPath(LogFileFilterPoll.FILENAME)
 
@@ -653,6 +656,8 @@ class LogFileMonitor(LogCaptureTestCase):
 		self.assertLogged('Unable to open %s' % self.name)
 
 	def testErrorProcessLine(self):
+		# speedup search using exact date pattern:
+		self.filter.setDatePattern('^%ExY-%Exm-%Exd %ExH:%ExM:%ExS')
 		self.filter.sleeptime /= 1000.0
 		## produce error with not callable processLine:
 		_org_processLine = self.filter.processLine
@@ -715,6 +720,8 @@ class LogFileMonitor(LogCaptureTestCase):
 		pass
 
 	def testNewChangeViaGetFailures_simple(self):
+		# speedup search using exact date pattern:
+		self.filter.setDatePattern('^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?')
 		# suck in lines from this sample log file
 		self.filter.getFailures(self.name)
 		self.assertRaises(FailManagerEmpty, self.filter.failManager.toBan)
@@ -730,6 +737,8 @@ class LogFileMonitor(LogCaptureTestCase):
 		_assert_correct_last_attempt(self, self.filter, GetFailures.FAILURES_01)
 
 	def testNewChangeViaGetFailures_rewrite(self):
+		# speedup search using exact date pattern:
+		self.filter.setDatePattern('^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?')
 		#
 		# if we rewrite the file at once
 		self.file.close()
@@ -748,6 +757,8 @@ class LogFileMonitor(LogCaptureTestCase):
 		_assert_correct_last_attempt(self, self.filter, GetFailures.FAILURES_01)
 
 	def testNewChangeViaGetFailures_move(self):
+		# speedup search using exact date pattern:
+		self.filter.setDatePattern('^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?')
 		#
 		# if we move file into a new location while it has been open already
 		self.file.close()
@@ -769,6 +780,7 @@ class CommonMonitorTestCase(unittest.TestCase):
 
 	def setUp(self):
 		"""Call before every test case."""
+		super(CommonMonitorTestCase, self).setUp()
 		self._failTotal = 0
 
 	def waitFailTotal(self, count, delay=1.):
@@ -819,6 +831,8 @@ def get_monitor_failures_testcase(Filter_):
 			self.jail = DummyJail()
 			self.filter = Filter_(self.jail)
 			self.filter.addLogPath(self.name, autoSeek=False)
+			# speedup search using exact date pattern:
+			self.filter.setDatePattern('^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?')
 			self.filter.active = True
 			self.filter.addFailRegex("(?:(?:Authentication failure|Failed [-/\w+]+) for(?: [iI](?:llegal|nvalid) user)?|[Ii](?:llegal|nvalid) user|ROOT LOGIN REFUSED) .*(?: from|FROM) <HOST>")
 			self.filter.start()
@@ -1223,6 +1237,8 @@ class GetFailures(LogCaptureTestCase):
 		self.jail = DummyJail()
 		self.filter = FileFilter(self.jail)
 		self.filter.active = True
+		# speedup search using exact date pattern:
+		self.filter.setDatePattern('^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?')
 		# TODO Test this
 		#self.filter.setTimeRegex("\S{3}\s{1,2}\d{1,2} \d{2}:\d{2}:\d{2}")
 		#self.filter.setTimePattern("%b %d %H:%M:%S")
@@ -1329,6 +1345,11 @@ class GetFailures(LogCaptureTestCase):
 		output = (('212.41.96.186', 4, 1124013600.0),
 				  ('212.41.96.185', 2, 1124013598.0))
 
+		# speedup search using exact date pattern:
+		self.filter.setDatePattern(('^%ExY(?P<_sep>[-/.])%m(?P=_sep)%d[T ]%H:%M:%S(?:[.,]%f)?(?:\s*%z)?',
+			'^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?',
+			'^EPOCH'
+		))
 		self.filter.setMaxRetry(2)
 		self.filter.addLogPath(GetFailures.FILENAME_04, autoSeek=0)
 		self.filter.addFailRegex("Invalid user .* <HOST>")
@@ -1358,6 +1379,8 @@ class GetFailures(LogCaptureTestCase):
 				if enc is not None:
 					self.tearDown();self.setUp();
 					self.filter.setLogEncoding(enc);
+				# speedup search using exact date pattern:
+				self.filter.setDatePattern('^%ExY-%Exm-%Exd %ExH:%ExM:%ExS')
 				self.assertNotLogged('Error decoding line');
 				self.filter.addLogPath(fname)
 				self.filter.addFailRegex(failregex)
@@ -1533,6 +1556,7 @@ class DNSUtilsNetworkTests(unittest.TestCase):
 
 	def setUp(self):
 		"""Call before every test case."""
+		super(DNSUtilsNetworkTests, self).setUp()
 		unittest.F2B.SkipIfNoNetwork()
 
 	def test_IPAddr(self):

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -476,6 +476,8 @@ class LogFileFilterPoll(unittest.TestCase):
 		self.assertFalse(self.filter.isModified(LogFileFilterPoll.FILENAME))
 
 	def testSeekToTimeSmallFile(self):
+		# speedup search using exact date pattern:
+		self.filter.setDatePattern('^%ExY-%Exm-%Exd %ExH:%ExM:%ExS')
 		fname = tempfile.mktemp(prefix='tmp_fail2ban', suffix='.log')
 		time = 1417512352
 		f = open(fname, 'w')
@@ -560,6 +562,8 @@ class LogFileFilterPoll(unittest.TestCase):
 			_killfile(f, fname)
 
 	def testSeekToTimeLargeFile(self):
+		# speedup search using exact date pattern:
+		self.filter.setDatePattern('^%ExY-%Exm-%Exd %ExH:%ExM:%ExS')
 		fname = tempfile.mktemp(prefix='tmp_fail2ban', suffix='.log')
 		time = 1417512352
 		f = open(fname, 'w')

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -283,10 +283,10 @@ class BasicFilter(unittest.TestCase):
 	def testGetSetDatePattern(self):
 		self.assertEqual(self.filter.getDatePattern(),
 			(None, "Default Detectors"))
-		self.filter.setDatePattern("^%Y-%m-%d-%H%M%S.%f %z")
+		self.filter.setDatePattern("^%Y-%m-%d-%H%M%S.%f %z **")
 		self.assertEqual(self.filter.getDatePattern(),
-			("^%Y-%m-%d-%H%M%S.%f %z",
-			"^Year-Month-Day-24hourMinuteSecond.Microseconds Zone offset"))
+			("^%Y-%m-%d-%H%M%S.%f %z **",
+			"^Year-Month-Day-24hourMinuteSecond.Microseconds Zone offset **"))
 
 	def testAssertWrongTime(self):
 		self.assertRaises(AssertionError, 

--- a/fail2ban/tests/misctestcase.py
+++ b/fail2ban/tests/misctestcase.py
@@ -23,13 +23,11 @@ __license__ = "GPL"
 
 import logging
 import os
-import re
 import sys
 import unittest
 import tempfile
 import shutil
 import fnmatch
-import datetime
 from glob import glob
 from StringIO import StringIO
 
@@ -37,8 +35,6 @@ from utils import LogCaptureTestCase, logSys as DefLogSys
 
 from ..helpers import formatExceptionInfo, mbasename, TraceBack, FormatterWithTraceBack, getLogger, uni_decode
 from ..helpers import splitwords
-from ..server.datedetector import DateDetector
-from ..server.datetemplate import DatePatternRegex
 from ..server.mytime import MyTime
 
 
@@ -318,91 +314,6 @@ class TestsUtilsTest(LogCaptureTestCase):
 		else: # pragma: no cover
 			# wrong logging syntax will throw an error directly:
 			self.assertRaisesRegexp(Exception, 'not all arguments converted', lambda: logSys.debug('test', 1, 2, 3))
-
-
-iso8601 = DatePatternRegex("%Y-%m-%d[T ]%H:%M:%S(?:\.%f)?%z")
-
-
-class CustomDateFormatsTest(unittest.TestCase):
-
-	def testIso8601(self):
-		date = datetime.datetime.utcfromtimestamp(
-			iso8601.getDate("2007-01-25T12:00:00Z")[0])
-		self.assertEqual(
-			date,
-			datetime.datetime(2007, 1, 25, 12, 0))
-		self.assertRaises(TypeError, iso8601.getDate, None)
-		self.assertRaises(TypeError, iso8601.getDate, date)
-
-		self.assertEqual(iso8601.getDate(""), None)
-		self.assertEqual(iso8601.getDate("Z"), None)
-
-		self.assertEqual(iso8601.getDate("2007-01-01T120:00:00Z"), None)
-		self.assertEqual(iso8601.getDate("2007-13-01T12:00:00Z"), None)
-		date = datetime.datetime.utcfromtimestamp(
-			iso8601.getDate("2007-01-25T12:00:00+0400")[0])
-		self.assertEqual(
-			date,
-			datetime.datetime(2007, 1, 25, 8, 0))
-		date = datetime.datetime.utcfromtimestamp(
-			iso8601.getDate("2007-01-25T12:00:00+04:00")[0])
-		self.assertEqual(
-			date,
-			datetime.datetime(2007, 1, 25, 8, 0))
-		date = datetime.datetime.utcfromtimestamp(
-			iso8601.getDate("2007-01-25T12:00:00-0400")[0])
-		self.assertEqual(
-			date,
-			datetime.datetime(2007, 1, 25, 16, 0))
-		date = datetime.datetime.utcfromtimestamp(
-			iso8601.getDate("2007-01-25T12:00:00-04")[0])
-		self.assertEqual(
-			date,
-			datetime.datetime(2007, 1, 25, 16, 0))
-
-	def testAmbiguousDatePattern(self):
-		defDD = DateDetector()
-		defDD.addDefaultTemplate()
-		logSys = DefLogSys
-		for (matched, dp, line) in (
-			# positive case:
-			('Jan 23 21:59:59',   None, 'Test failure Jan 23 21:59:59 for 192.0.2.1'),
-			# ambiguous "unbound" patterns (missed):
-			(False,               None, 'Test failure TestJan 23 21:59:59.011 2015 for 192.0.2.1'),
-			(False,               None, 'Test failure Jan 23 21:59:59123456789 for 192.0.2.1'),
-			# ambiguous "no optional year" patterns (matched):
-			('Aug 8 11:25:50',      None, 'Aug 8 11:25:50 14430f2329b8 Authentication failed from 192.0.2.1'),
-			('Aug 8 11:25:50',      None, '[Aug 8 11:25:50] 14430f2329b8 Authentication failed from 192.0.2.1'),
-			('Aug 8 11:25:50 2014', None, 'Aug 8 11:25:50 2014 14430f2329b8 Authentication failed from 192.0.2.1'),
-			# direct specified patterns:
-			('20:00:00 01.02.2003',    r'%H:%M:%S %d.%m.%Y$', '192.0.2.1 at 20:00:00 01.02.2003'),
-			('[20:00:00 01.02.2003]',  r'\[%H:%M:%S %d.%m.%Y\]', '192.0.2.1[20:00:00 01.02.2003]'),
-			('[20:00:00 01.02.2003]',  r'\[%H:%M:%S %d.%m.%Y\]', '[20:00:00 01.02.2003]192.0.2.1'),
-			('[20:00:00 01.02.2003]',  r'\[%H:%M:%S %d.%m.%Y\]$', '192.0.2.1[20:00:00 01.02.2003]'),
-			('[20:00:00 01.02.2003]',  r'^\[%H:%M:%S %d.%m.%Y\]', '[20:00:00 01.02.2003]192.0.2.1'),
-			('[17/Jun/2011 17:00:45]', r'^\[%d/%b/%Y %H:%M:%S\]', '[17/Jun/2011 17:00:45] Attempt, IP address 192.0.2.1'),
-			('[17/Jun/2011 17:00:45]', r'\[%d/%b/%Y %H:%M:%S\]', 'Attempt [17/Jun/2011 17:00:45] IP address 192.0.2.1'),
-			('[17/Jun/2011 17:00:45]', r'\[%d/%b/%Y %H:%M:%S\]', 'Attempt IP address 192.0.2.1, date: [17/Jun/2011 17:00:45]'),
-			# direct specified patterns (begin/end, missed):
-			(False,                 r'%H:%M:%S %d.%m.%Y', '192.0.2.1x20:00:00 01.02.2003'),
-			(False,                 r'%H:%M:%S %d.%m.%Y', '20:00:00 01.02.2003x192.0.2.1'),
-			# direct specified patterns (begin/end, matched):
-			('20:00:00 01.02.2003', r'%H:%M:%S %d.%m.%Y', '192.0.2.1 20:00:00 01.02.2003'),
-			('20:00:00 01.02.2003', r'%H:%M:%S %d.%m.%Y', '20:00:00 01.02.2003 192.0.2.1'),
-		):
-			logSys.debug('== test: %r', (matched, dp, line))
-			if dp is None:
-				dd = defDD
-			else:
-				dp = DatePatternRegex(dp)
-				dd = DateDetector()
-				dd.appendTemplate(dp)
-			date = dd.getTime(line)
-			if matched:
-				self.assertTrue(date)
-				self.assertEqual(matched, date[1].group())
-			else:
-				self.assertEqual(date, None)
 
 
 class MyTimeTest(unittest.TestCase):

--- a/fail2ban/tests/misctestcase.py
+++ b/fail2ban/tests/misctestcase.py
@@ -86,6 +86,7 @@ def _getSysPythonVersion():
 class SetupTest(unittest.TestCase):
 
 	def setUp(self):
+		super(SetupTest, self).setUp()
 		unittest.F2B.SkipIfFast()
 		setup = os.path.join(os.path.dirname(__file__), '..', '..', 'setup.py')
 		self.setup = os.path.exists(setup) and setup or None

--- a/fail2ban/tests/samplestestcase.py
+++ b/fail2ban/tests/samplestestcase.py
@@ -43,6 +43,7 @@ class FilterSamplesRegex(unittest.TestCase):
 
 	def setUp(self):
 		"""Call before every test case."""
+		super(FilterSamplesRegex, self).setUp()
 		self.filter = Filter(None)
 		self.filter.active = True
 

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -298,14 +298,14 @@ class Transmitter(TransmitterBase):
 
 	def testDatePattern(self):
 		self.setGetTest("datepattern", "%%%Y%m%d%H%M%S",
-			("%%%Y%m%d%H%M%S", "{*WD-BEG}%YearMonthDay24hourMinuteSecond{*WD-END}"),
+			("%%%Y%m%d%H%M%S", "%YearMonthDay24hourMinuteSecond"),
 			jail=self.jailName)
 		self.setGetTest(
-			"datepattern", "Epoch", (None, "Epoch{*WD-END}"), jail=self.jailName)
+			"datepattern", "Epoch", (None, "Epoch"), jail=self.jailName)
 		self.setGetTest(
-			"datepattern", "^Epoch", (None, "{^LN-BEG}Epoch{*WD-END}"), jail=self.jailName)
+			"datepattern", "^Epoch", (None, "{^LN-BEG}Epoch"), jail=self.jailName)
 		self.setGetTest(
-			"datepattern", "TAI64N", (None, "TAI64N{*WD-END}"), jail=self.jailName)
+			"datepattern", "TAI64N", (None, "TAI64N"), jail=self.jailName)
 		self.setGetTestNOK("datepattern", "%Cat%a%%%g", jail=self.jailName)
 
 	def testJailUseDNS(self):

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -298,7 +298,7 @@ class Transmitter(TransmitterBase):
 
 	def testDatePattern(self):
 		self.setGetTest("datepattern", "%%%Y%m%d%H%M%S",
-			("%%%Y%m%d%H%M%S", "%YearMonthDay24hourMinuteSecond"),
+			("%%%Y%m%d%H%M%S", "{*WD-BEG}%YearMonthDay24hourMinuteSecond{*WD-END}"),
 			jail=self.jailName)
 		self.setGetTest(
 			"datepattern", "Epoch", (None, "Epoch"), jail=self.jailName)

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -1107,7 +1107,7 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					# (we don't use it in this test at all):
 					elif unittest.F2B.fast and (
 						len(cmd) > 3 and cmd[0] in ('set', 'multi-set') and cmd[2] == 'addfailregex'
-					):
+					): # pragma: no cover
 						cmd[0] = "set"
 						cmd[3] = "DUMMY-REGEX <HOST>"
 					# command to server, use cmdHandler direct instead of `transm.proceed(cmd)`:

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -65,7 +65,7 @@ class TransmitterBase(unittest.TestCase):
 	
 	def setUp(self):
 		"""Call before every test case."""
-		#super(TransmitterBase, self).setUp()
+		super(TransmitterBase, self).setUp()
 		self.transm = self.server._Server__transm
 		# To test thransmitter we don't need to start server...
 		#self.server.start('/dev/null', '/dev/null', force=False)
@@ -301,9 +301,11 @@ class Transmitter(TransmitterBase):
 			("%%%Y%m%d%H%M%S", "{*WD-BEG}%YearMonthDay24hourMinuteSecond{*WD-END}"),
 			jail=self.jailName)
 		self.setGetTest(
-			"datepattern", "Epoch", (None, "Epoch"), jail=self.jailName)
+			"datepattern", "Epoch", (None, "Epoch{*WD-END}"), jail=self.jailName)
 		self.setGetTest(
-			"datepattern", "TAI64N", (None, "TAI64N"), jail=self.jailName)
+			"datepattern", "^Epoch", (None, "{^LN-BEG}Epoch{*WD-END}"), jail=self.jailName)
+		self.setGetTest(
+			"datepattern", "TAI64N", (None, "TAI64N{*WD-END}"), jail=self.jailName)
 		self.setGetTestNOK("datepattern", "%Cat%a%%%g", jail=self.jailName)
 
 	def testJailUseDNS(self):

--- a/fail2ban/tests/sockettestcase.py
+++ b/fail2ban/tests/sockettestcase.py
@@ -41,6 +41,7 @@ class Socket(unittest.TestCase):
 
 	def setUp(self):
 		"""Call before every test case."""
+		super(Socket, self).setUp()
 		self.server = AsyncServer(self)
 		sock_fd, sock_name = tempfile.mkstemp('fail2ban.sock', 'socket')
 		os.close(sock_fd)

--- a/fail2ban/tests/utils.py
+++ b/fail2ban/tests/utils.py
@@ -48,6 +48,8 @@ from ..version import version
 
 logSys = getLogger(__name__)
 
+TEST_NOW = 1124013600
+
 CONFIG_DIR = os.environ.get('FAIL2BAN_CONFIG_DIR', None)
 
 if not CONFIG_DIR:
@@ -257,6 +259,10 @@ def initTests(opts):
 		def F2B_SkipIfNoNetwork():
 			raise unittest.SkipTest('Skip test because of "--no-network"')
 		unittest.F2B.SkipIfNoNetwork = F2B_SkipIfNoNetwork
+
+	# set alternate now for time related test cases:
+	MyTime.setAlternateNow(TEST_NOW)
+
 	# precache all invalid ip's (TEST-NET-1, ..., TEST-NET-3 according to RFC 5737):
 	c = DNSUtils.CACHE_ipToName
 	for i in xrange(255):
@@ -289,7 +295,7 @@ def setUpMyTime():
 	# yoh: we need to adjust TZ to match the one used by Cyril so all the timestamps match
 	os.environ['TZ'] = 'Europe/Zurich'
 	time.tzset()
-	MyTime.setTime(1124013600)
+	MyTime.setTime(TEST_NOW)
 
 
 def tearDownMyTime():
@@ -384,7 +390,6 @@ def gatherTests(regexps=None, opts=None):
 	tests.addTest(unittest.makeSuite(misctestcase.HelpersTest))
 	tests.addTest(unittest.makeSuite(misctestcase.SetupTest))
 	tests.addTest(unittest.makeSuite(misctestcase.TestsUtilsTest))
-	tests.addTest(unittest.makeSuite(misctestcase.CustomDateFormatsTest))
 	tests.addTest(unittest.makeSuite(misctestcase.MyTimeTest))
 	# Database
 	tests.addTest(unittest.makeSuite(databasetestcase.DatabaseTest))
@@ -404,6 +409,7 @@ def gatherTests(regexps=None, opts=None):
 
 	# DateDetector
 	tests.addTest(unittest.makeSuite(datedetectortestcase.DateDetectorTest))
+	tests.addTest(unittest.makeSuite(datedetectortestcase.CustomDateFormatsTest))
 	# Filter Regex tests with sample logs
 	tests.addTest(unittest.makeSuite(samplestestcase.FilterSamplesRegex))
 

--- a/fail2ban/tests/utils.py
+++ b/fail2ban/tests/utils.py
@@ -260,6 +260,10 @@ def initTests(opts):
 			raise unittest.SkipTest('Skip test because of "--no-network"')
 		unittest.F2B.SkipIfNoNetwork = F2B_SkipIfNoNetwork
 
+	# persistently set time zone to CET (used in zone-related test-cases),
+	# yoh: we need to adjust TZ to match the one used by Cyril so all the timestamps match
+	os.environ['TZ'] = 'Europe/Zurich'
+	time.tzset()
 	# set alternate now for time related test cases:
 	MyTime.setAlternateNow(TEST_NOW)
 
@@ -292,17 +296,10 @@ old_TZ = os.environ.get('TZ', None)
 def setUpMyTime():
 	# Set the time to a fixed, known value
 	# Sun Aug 14 12:00:00 CEST 2005
-	# yoh: we need to adjust TZ to match the one used by Cyril so all the timestamps match
-	os.environ['TZ'] = 'Europe/Zurich'
-	time.tzset()
 	MyTime.setTime(TEST_NOW)
 
 
 def tearDownMyTime():
-	os.environ.pop('TZ')
-	if old_TZ: # pragma: no cover
-		os.environ['TZ'] = old_TZ
-	time.tzset()
 	MyTime.myTime = None
 
 


### PR DESCRIPTION
Fixed ambiguous resp. misleading date detection, if several formats used in log resp. by format switch after restart of some services...

I had long rotated this solution for back and forth, made several attempts to fix resp. optimize it. 
The last straw that broke the camel's back was the try to fix #1548, where the log lines contain dual date time.
This should also fix a possible vulnerability, affected by file-filter only, does not apply to systemd backend (except test-cases), because it uses directly a time from journal record. 
The description of the main problem is a little bit complicated, so hacker thinking expected
_[hacker mode=on]_:
- fail2ban cut out date string (matched datepattern) from each line before it give this line to the filter;
- because the date templates are sorted (by hits) in date detector module, it may cut out the wrong date from log-line (if these are present in log-line, e.g. injecting on some free fields, format switch, etc), so they may be found as first (and correct date will be not found);
- so the fail2ban will overlook this log-line, because the correct date is still present in log-line and it'll never match any specified `failregex` (mostly anchored).
- beyond comes another problem, that some datepatterns are misleading resp. ambiguous and can find date, where it is not.

_[/hacker mode=off]_

---

Here is the last try to fix abovementioned problem (using many different measures)
**WARNING: Theoretically possible backwards incompatibilities** (I cannot judge all the relations in all possible user configurations).
- Misleading date patterns defined more precisely (using extended syntax
  `%Ex[mdHMS]` for exact two-digit match or e. g. `%ExY` as more precise year 
  pattern, within same century of last year and the next 3 years)
- Extends date detector template with distance (position of match in 
  log-line), to prevent grave collision using (re)ordered template list (e.g.
  find-spot of wrong date-match inside foreign input, misleading date patterns
  by ambiguous formats, etc.)
- Distance collision check always prefers template with shortest distance
  (left before right) if date pattern is not anchored
- Fixed UTC/GMT named time zone, using `%Z` and `%z` patterns 
  (special case with 0 zone offset, see gh-1575)
- `filter.d/freeswitch.conf`
  - Optional prefixes (server, daemon, dual time) if systemd daemon logs used (gh-1548)
  - User part rewritten to accept IPv6 resp. domain after "@" (gh-1548)
- More precise date template handling:
  - datedetector rewritten more strict as earlier;
  - default templates can be specified exacter using prefix/suffix syntax (via `datepattern`);
  - more as one date pattern can be specified using option `datepattern` now 
    (new-line separated);
  - some default options like `datepattern` can be specified directly in 
    section `[Definition]`, that avoids contrary usage of unnecessarily `[Init]`
    section, because of performance (each extra section costs time);
  - option `datepattern` can be specified in jail also (e. g. jails without filters 
    or custom log-format, new-line separated for multiple patterns);
  - if first unnamed group specified in pattern, only this will be cut out from
    search log-line (e. g.: `^date:[({DATE})]` will cut out only datetime match 
    pattern, and leaves `date:[] ...` for searching in filter);
  - faster match and fewer searching of appropriate templates
    (DateDetector.matchTime calls rarer DateTemplate.matchDate now);
  - several standard filters extended with exact prefixed or anchored date templates;

Closes #1548
Closes #1575
Closes #1294

The fix was done for 0.10 only, no idea how we could port this to 0.9 without rewriting of half of the code. 
So for 0.9-th branch only solution at moment - to specify (single) exact date pattern per jail (that is always clever).
