### PR TITLE
squid-filter: recognize 407 responses in failregex

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -43,6 +43,8 @@ releases.
     - optimized failregex to match all of "Failed any-method for ... from <HOST>" (gh-1479)
     - eliminated possible complex injections (on user-name resp. auth-info, see gh-1479)
     - optional port part after host (see gh-1533, gh-1581)
+* `filter.d/squid.conf`
+    - Recognize 407 Proxy Authentication Required as failures (gh-1614)
 
 
 ### New Features

--- a/ChangeLog
+++ b/ChangeLog
@@ -42,6 +42,7 @@ releases.
     - recognized "Failed publickey for" (gh-1477);
     - optimized failregex to match all of "Failed any-method for ... from <HOST>" (gh-1479)
     - eliminated possible complex injections (on user-name resp. auth-info, see gh-1479)
+    - optional port part after host (see gh-1533, gh-1581)
 
 
 ### New Features

--- a/config/filter.d/squid.conf
+++ b/config/filter.d/squid.conf
@@ -1,10 +1,10 @@
-# Fail2Ban filter for Squid attempted proxy bypasses
+# Fail2Ban filter for Squid attempted proxy bypasses and bruteforcing
 #
 #
 
 [Definition]
 
-failregex = ^\s+\d\s<HOST>\s+[A-Z_]+_DENIED/403 .*$
+failregex = ^\s+\d\s<HOST>\s+[A-Z_]+_DENIED/40[37] .*$
             ^\s+\d\s<HOST>\s+NONE/405 .*$
 
 ignoreregex =

--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -22,7 +22,7 @@ failregex = ^%(__prefix_line)s(?:error: PAM: )?[aA]uthentication (?:failure|erro
             ^%(__prefix_line)s(?:error: PAM: )?User not known to the underlying authentication module for .* from <HOST>\s*$
             ^%(__prefix_line)sFailed \S+ for (?P<cond_inv>invalid user )?(?P<user>(?P<cond_user>\S+)|(?(cond_inv)(?:(?! from ).)*?|[^:]+)) from <HOST>(?: port \d+)?(?: ssh\d*)?(?(cond_user):|(?:(?:(?! from ).)*)$)
             ^%(__prefix_line)sROOT LOGIN REFUSED.* FROM <HOST>\s*$
-            ^%(__prefix_line)s[iI](?:llegal|nvalid) user .* from <HOST>(?: port \d*)?\s*$
+            ^%(__prefix_line)s[iI](?:llegal|nvalid) user .*? from <HOST>(?: port \d+)?\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because not listed in AllowUsers\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because listed in DenyUsers\s*$
             ^%(__prefix_line)sUser .+ from <HOST> not allowed because not in any group\s*$

--- a/fail2ban/tests/files/logs/squid
+++ b/fail2ban/tests/files/logs/squid
@@ -11,3 +11,6 @@
 
 # failJSON: { "time": "2013-12-09T00:09:06.000", "match": true , "host": "175.42.91.151" }
 1386544146.000      1 175.42.91.151 TCP_DENIED/403 3745 GET http://pkfsp.ru/wp-content/uploads/proxyc/engine.php - HIER_NONE/- text/html
+
+# failJSON: { "time": "2016-11-21T01:12:54.000", "match": true, "host": "98.189.78.228" }
+1479687174.000      1 98.189.78.228 TCP_DENIED/407 4259 CONNECT www.google.com:443 tgu1 HIER_NONE/- text/html

--- a/fail2ban/tests/files/logs/sshd
+++ b/fail2ban/tests/files/logs/sshd
@@ -17,8 +17,10 @@ Jan  5 01:31:41 www sshd[1643]: ROOT LOGIN REFUSED FROM 1.2.3.4
 Jan  5 01:31:41 www sshd[1643]: ROOT LOGIN REFUSED FROM ::ffff:1.2.3.4
 
 #4
-# failJSON: { "time": "2005-07-20T14:42:11", "match": true , "host": "211.114.51.213" }
-Jul 20 14:42:11 localhost sshd[22708]: Invalid user ftp from 211.114.51.213
+# failJSON: { "time": "2005-07-20T14:42:11", "match": true , "host": "192.0.2.1", "desc": "Invalid user" }
+Jul 20 14:42:11 localhost sshd[22708]: Invalid user ftp from 192.0.2.1
+# failJSON: { "time": "2005-07-20T14:42:12", "match": true , "host": "192.0.2.2", "desc": "Invalid user with port" }
+Jul 20 14:42:12 localhost sshd[22708]: Invalid user ftp from 192.0.2.2 port 37220
 
 #5 new filter introduced after looking at 44087D8C.9090407@bluewin.ch
 # yoh: added ':' after [sshd] since the case without is not really common any more
@@ -167,7 +169,3 @@ Apr 27 13:02:04 host sshd[29116]: Received disconnect from 1.2.3.4: 11: Normal S
 # Match sshd auth errors on OpenSUSE systems
 # failJSON: { "time": "2015-04-16T20:02:50", "match": true , "host": "222.186.21.217", "desc": "Authentication for user failed" }
 2015-04-16T18:02:50.321974+00:00 host sshd[2716]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=222.186.21.217  user=root
-
-# Match invalid user messages with port at the end
-# failJSON: {"time": "2004-10-15T11:35:28", "match": true , "host": "1.2.3.4", "desc": "Invalid user root" }
-Oct 15 11:35:28 somehost sshd[7024]: Invalid user root from 1.2.3.4 port 37220


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement against 0.9.x series, choose `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- <s>**LIST ISSUES** this PR resolves</s>
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines       within `fail2ban/tests/files/logs/X` file

407 is the HTTP status code for Proxy Authentication Required, and in Squid such denied requests are results of proxy authentication failures.