### PR TITLE
squid-filter: recognize 407 responses in failregex

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -43,6 +43,8 @@ releases.
     - optimized failregex to match all of "Failed any-method for ... from <HOST>" (gh-1479)
     - eliminated possible complex injections (on user-name resp. auth-info, see gh-1479)
     - optional port part after host (see gh-1533, gh-1581)
+* `filter.d/squid.conf`
+    - Recognize 407 Proxy Authentication Required as failures (gh-1615)
 
 
 ### New Features

--- a/config/filter.d/squid.conf
+++ b/config/filter.d/squid.conf
@@ -1,10 +1,10 @@
-# Fail2Ban filter for Squid attempted proxy bypasses
+# Fail2Ban filter for Squid attempted proxy bypasses and bruteforcing
 #
 #
 
 [Definition]
 
-failregex = ^\s+\d\s<HOST>\s+[A-Z_]+_DENIED/403 .*$
+failregex = ^\s+\d\s<HOST>\s+[A-Z_]+_DENIED/40[37] .*$
             ^\s+\d\s<HOST>\s+NONE/405 .*$
 
 ignoreregex =

--- a/fail2ban/tests/files/logs/squid
+++ b/fail2ban/tests/files/logs/squid
@@ -11,3 +11,6 @@
 
 # failJSON: { "time": "2013-12-09T00:09:06.000", "match": true , "host": "175.42.91.151" }
 1386544146.000      1 175.42.91.151 TCP_DENIED/403 3745 GET http://pkfsp.ru/wp-content/uploads/proxyc/engine.php - HIER_NONE/- text/html
+
+# failJSON: { "time": "2016-11-21T01:12:54.000", "match": true, "host": "98.189.78.228" }
+1479687174.000      1 98.189.78.228 TCP_DENIED/407 4259 CONNECT www.google.com:443 tgu1 HIER_NONE/- text/html


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement against 0.9.x series, choose `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- <s>**LIST ISSUES** this PR resolves</s>
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines       within `fail2ban/tests/files/logs/X` file

407 is the HTTP status code for Proxy Authentication Required, and in Squid such denied requests are results of proxy authentication failures.