### PR TITLE
systemd service update

### DIFF
--- a/fail2ban/client/fail2bancmdline.py
+++ b/fail2ban/client/fail2bancmdline.py
@@ -274,6 +274,7 @@ class Fail2banCmdLine():
 	def exit(code=0):
 		logSys.debug("Exit with code %s", code)
 		# because of possible buffered output in python, we should flush it before exit:
+		logging.shutdown()
 		sys.stdout.flush()
 		sys.stderr.flush()
 		# exit

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -530,17 +530,19 @@ class Server:
 	# @param target the logging target
 	
 	def setLogTarget(self, target):
+		# check reserved targets in uppercase, don't change target, because it can be file:
+		systarget = target.upper()
 		with self.__loggingLock:
 			# don't set new handlers if already the same
 			# or if "INHERITED" (foreground worker of the test cases, to prevent stop logging):
 			if self.__logTarget == target:
 				return True
-			if target == "INHERITED":
+			if systarget == "INHERITED":
 				self.__logTarget = target
 				return True
 			# set a format which is simpler for console use
 			fmt = "%(asctime)s %(name)-24s[%(process)d]: %(levelname)-7s %(message)s"
-			if target == "SYSLOG":
+			if systarget == "SYSLOG":
 				# Syslog daemons already add date to the message.
 				fmt = "%(name)s[%(process)d]: %(levelname)s %(message)s"
 				facility = logging.handlers.SysLogHandler.LOG_DAEMON
@@ -559,9 +561,9 @@ class Server:
 						"Syslog socket file: %s does not exists"
 						" or is not a socket" % self.__syslogSocket)
 					return False
-			elif target == "STDOUT":
+			elif systarget == "STDOUT":
 				hdlr = logging.StreamHandler(sys.stdout)
-			elif target == "STDERR":
+			elif systarget == "STDERR":
 				hdlr = logging.StreamHandler(sys.stderr)
 			else:
 				# Target should be a file

--- a/files/fail2ban.service
+++ b/files/fail2ban.service
@@ -6,6 +6,7 @@ PartOf=iptables.service firewalld.service
 
 [Service]
 Type=simple
+ExecStartPre=/bin/mkdir -p /var/run/fail2ban
 ExecStart=/usr/bin/fail2ban-server -xf start
 ExecStop=/usr/bin/fail2ban-client stop
 ExecReload=/usr/bin/fail2ban-client reload

--- a/files/fail2ban.service
+++ b/files/fail2ban.service
@@ -8,6 +8,8 @@ PartOf=iptables.service firewalld.service
 Type=simple
 ExecStartPre=/bin/mkdir -p /var/run/fail2ban
 ExecStart=/usr/bin/fail2ban-server -xf start
+# if should be logged in systemd journal, use following line or set logtarget to stdout in fail2ban.local
+# ExecStart=/usr/bin/fail2ban-server -xf --logtarget=stdout start
 ExecStop=/usr/bin/fail2ban-client stop
 ExecReload=/usr/bin/fail2ban-client reload
 PIDFile=/var/run/fail2ban/fail2ban.pid

--- a/files/fail2ban.service
+++ b/files/fail2ban.service
@@ -5,12 +5,13 @@ After=network.target iptables.service firewalld.service
 PartOf=iptables.service firewalld.service
 
 [Service]
-Type=forking
-ExecStart=/usr/bin/fail2ban-client -x start
+Type=simple
+ExecStart=/usr/bin/fail2ban-server -xf start
 ExecStop=/usr/bin/fail2ban-client stop
 ExecReload=/usr/bin/fail2ban-client reload
 PIDFile=/var/run/fail2ban/fail2ban.pid
-Restart=always
+Restart=on-failure
+RestartPreventExitStatus=0 255
 
 [Install]
 WantedBy=multi-user.target

--- a/man/fail2ban-server.1
+++ b/man/fail2ban-server.1
@@ -23,6 +23,9 @@ pidfile path
 logging level
 .HP
 \fB\-\-logtarget\fR <FILE>|STDOUT|STDERR|SYSLOG
+logging target
+.br
+Note. If fail2ban running as systemd-service, for logging to the systemd-journal, the logtarget could be set to STDOUT
 .HP
 \fB\-\-syslogsocket\fR auto|<FILE>
 .TP

--- a/man/jail.conf.5
+++ b/man/jail.conf.5
@@ -130,7 +130,9 @@ The items that can be set are:
 verbosity level of log output: CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG, TRACEDEBUG, HEAVYDEBUG or corresponding numeric value (50-5). Default: ERROR (equal 40)
 .TP
 .B logtarget
-log target: filename, SYSLOG, STDERR or STDOUT. Default: STDERR
+log target: filename, SYSLOG, STDERR or STDOUT. Default: STDOUT if not set in fail2ban.conf/fail2ban.local
+.br
+Note. If fail2ban running as systemd-service, for logging to the systemd-journal, the logtarget could be set to STDOUT
 .br
 Only a single log target can be specified.
 If you change logtarget from the default value and you are using logrotate -- also adjust or disable rotation in the


### PR DESCRIPTION
- starting service in normal mode (without forking)
- does not restart if service exited normally (exit-code 0, e.g. stopped via fail2ban-client)
- does not restart if service can not start (exit-code 255, e.g. wrong configuration, etc.)
- service can be additionally started/stopped with fail2ban commands (fail2ban-client, fail2ban-server)

By the way:
- automatically creates `/var/run/fail2ban` before start fail2ban (systems which `/var/run/` is virtual resp. memory mount device)
- small fixes by logging in stdout (+ system targets also allowed in lowercase now)
- [man] if fail2ban running as systemd-service, for logging to the systemd-journal, the `logtarget` could be set to STDOUT
