### PR TITLE
jail.conf: added  `knocking_url` filter-parameter of `pass2allow-ftp`...

### DIFF
--- a/config/jail.conf
+++ b/config/jail.conf
@@ -810,8 +810,9 @@ maxretry = 1
 [pass2allow-ftp]
 # this pass2allow example allows FTP traffic after successful HTTP authentication
 port         = ftp,ftp-data,ftps,ftps-data
-# knocking_url variable must be overridden to some secret value in filter.d/apache-pass.local
-filter       = apache-pass
+# knocking_url variable must be overridden to some secret value in jail.local
+knocking_url = /knocking/
+filter       = apache-pass[knocking_url="%(knocking_url)s"]
 # access log of the website with HTTP auth
 logpath      = %(apache_access_log)s
 blocktype    = RETURN


### PR DESCRIPTION
`knocking_url` variable must be overridden to some secret value in `jail.local`
Closes #1120