### PR TITLE
Ensure filtersystemd closes the journal when stopped

### DIFF
--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -290,6 +290,13 @@ class Filter(JailThread):
 		raise Exception("run() is abstract")
 
 	##
+	# Clean up resources allocated by the filter, if necessary.
+	#
+
+	def cleanup(self):
+		pass
+
+	##
 	# Set external command, for ignoredips
 	#
 

--- a/fail2ban/server/filtergamin.py
+++ b/fail2ban/server/filtergamin.py
@@ -128,7 +128,12 @@ class FilterGamin(FileFilter):
 	##
 	# Desallocates the resources used by Gamin.
 
+	def cleanup(self):
+		super(FilterGamin, self).cleanup()
+		self.__cleanup()
+
 	def __cleanup(self):
-		for log in self.getLogs():
-			self.monitor.stop_watch(log.getFileName())
-		del self.monitor
+		if self.monitor:
+			for log in self.getLogs():
+				self.monitor.stop_watch(log.getFileName())
+		self.monitor = None

--- a/fail2ban/server/filterpyinotify.py
+++ b/fail2ban/server/filterpyinotify.py
@@ -189,6 +189,10 @@ class FilterPyinotify(FileFilter):
 	##
 	# Deallocates the resources used by pyinotify.
 
+	def cleanup(self):
+		super(FilterPyinotify, self).cleanup()
+		self.__cleanup()
+
 	def __cleanup(self):
 		self.__notifier = None
 		self.__monitor = None

--- a/fail2ban/server/filtersystemd.py
+++ b/fail2ban/server/filtersystemd.py
@@ -256,9 +256,23 @@ class FilterSystemd(JournalFilter): # pragma: systemd no cover
 						self.failManager.cleanup(MyTime.time())
 					self.__modified = False
 			self.__journal.wait(self.sleeptime)
+		self.__cleanup()
 		logSys.debug((self.jail is not None and self.jail.name
                       or "jailless") +" filter terminated")
 		return True
+
+	def cleanup(self):
+		super(FilterSystemd, self).cleanup()
+		self.__cleanup()
+
+	def __cleanup(self):
+		if self.__journal:
+			try:
+				self.__journal.close()
+			except Exception as e: # pragma: no cover
+				logSys.error("Close journal failed: %r", e,
+					exc_info=logSys.getEffectiveLevel()<=logging.DEBUG)
+		self.__journal = None
 
 	def status(self, flavor="basic"):
 		ret = super(FilterSystemd, self).status(flavor=flavor)

--- a/fail2ban/server/jail.py
+++ b/fail2ban/server/jail.py
@@ -227,6 +227,11 @@ class Jail:
 		self.actions.join()
 		logSys.info("Jail '%s' stopped" % self.name)
 
+	def cleanup(self):
+		"""Clean up resources allocated by the filter, if necessary.
+		"""
+		self.filter.cleanup()
+
 	def is_alive(self):
 		"""Check jail "is_alive" by checking filter and actions threads.
 		"""

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -150,6 +150,7 @@ class Server:
 			self.__db.addJail(self.__jails[name])
 		
 	def delJail(self, name):
+		self.__jails[name].cleanup()
 		if self.__db is not None:
 			self.__db.delJail(self.__jails[name])
 		del self.__jails[name]
@@ -168,7 +169,7 @@ class Server:
 			self.__lock.acquire()
 			if self.__jails[name].is_alive():
 				self.__jails[name].stop()
-				self.delJail(name)
+			self.delJail(name)
 		finally:
 			self.__lock.release()
 	


### PR DESCRIPTION
As of fail2ban 0.9.5, `fail2ban-client reload` or `fail2ban-client stop jail` does not properly close the `journal.Reader` object in `filtersystemd`, relying instead on Python's garbage collection to do that... eventually. Unfortunately, Python may not get around to GCing the object for a long time, and in the meantime all journal files will continue to be held open by the object, even long after they've been rotated and unlinked off the system. In some of my tests, I had journal files held open for several days after they'd been unlinked. The problem is exacerbated since new files are opened each time fail2ban is reloaded.

This patch series introduces a new `cleanup` hook for filters to perform various cleanups when a jail is deleted (which is not necessarily when the jail is stopped, since it looks like it's possible to add and then stop a jail, without it ever being started). `filtersystemd` is updated to use this hook, as are `filtergamin` and `filterpyinotify` which require similar cleanups.