### PR TITLE
Add shorewall IPv6 support

### DIFF
--- a/config/action.d/shorewall.conf
+++ b/config/action.d/shorewall.conf
@@ -34,15 +34,13 @@ actionstop =
 #
 actioncheck = 
 
-[Init]
-
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
 #          command is executed with Fail2Ban user rights.
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = shorewall <blocktype> <ip>
+actionban = shorewall<family> <blocktype> <ip>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -50,7 +48,15 @@ actionban = shorewall <blocktype> <ip>
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionunban = shorewall allow <ip>
+actionunban = shorewall<family> allow <ip>
+
+
+[Init]
+
+# Option:  family
+# Note:    Control which version of command is executed
+# Values:  Empty or 6 in case of IPv6
+family = 
 
 # Option:  blocktype
 # Note:    This is what the action does with rules.
@@ -60,25 +66,8 @@ blocktype = reject
 
 [Init?family=inet6]
 
-# Option:  actionban
-# Notes.:  command executed when banning an IP. Take care that the
-#          command is executed with Fail2Ban user rights.
-# Tags:    See jail.conf(5) man page
-# Values:  CMD
-#
-actionban = shorewall6 <blocktype> <ip>
-
-# Option:  actionunban
-# Notes.:  command executed when unbanning an IP. Take care that the
-#          command is executed with Fail2Ban user rights.
-# Tags:    See jail.conf(5) man page
-# Values:  CMD
-#
-actionunban = shorewall6 allow <ip>
-
-# Option:  blocktype
-# Note:    This is what the action does with rules.
-#          See man page of shorewall6 for options that include drop, logdrop, reject, or logreject
-# Values:  STRING
-blocktype = reject
+# Option:  family
+# Note:    Control which version of command is executed
+# Values:  Empty or 6 in case of IPv6
+family = 6
 

--- a/config/action.d/shorewall.conf
+++ b/config/action.d/shorewall.conf
@@ -34,6 +34,8 @@ actionstop =
 #
 actioncheck = 
 
+[Init]
+
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
 #          command is executed with Fail2Ban user rights.
@@ -50,10 +52,33 @@ actionban = shorewall <blocktype> <ip>
 #
 actionunban = shorewall allow <ip>
 
-[Init]
-
 # Option:  blocktype
 # Note:    This is what the action does with rules.
 #          See man page of shorewall for options that include drop, logdrop, reject, or logreject
 # Values:  STRING
 blocktype = reject
+
+[Init?family=inet6]
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionban = shorewall6 <blocktype> <ip>
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionunban = shorewall6 allow <ip>
+
+# Option:  blocktype
+# Note:    This is what the action does with rules.
+#          See man page of shorewall6 for options that include drop, logdrop, reject, or logreject
+# Values:  STRING
+blocktype = reject
+


### PR DESCRIPTION
Small patch which allow fail2ban to use shorewall for IPv6 bans.