### PR TITLE
Wait up to 30 seconds on "stop" to avoid errors.

### DIFF
--- a/files/gentoo-initd
+++ b/files/gentoo-initd
@@ -41,7 +41,7 @@ start() {
 
 stop() {
 	ebegin "Stopping fail2ban"
-	start-stop-daemon --stop --pidfile /var/run/fail2ban/fail2ban.pid \
+	start-stop-daemon --stop --pidfile /var/run/fail2ban/fail2ban.pid --retry 30 \
 	-- ${FAIL2BAN} stop
 	eend $? "Failed to stop fail2ban"
 }


### PR DESCRIPTION
The fail2ban server can take several seconds to shut down.  This can
make Gentoo's start-stop-service time out and decide that stopping has
failed, even if it actually succeeds a few seconds later.

The default timeout for start-stop-service if --retry is not specified
appears to be 5 seconds.  Increase that to 30 seconds to be sure that if
fail2ban-server is going to be able to stop, it has time to do so.

I did not make an issue for this yet, it's small/trivial, but I can if desired.