### PR TITLE
Recognize state of restored tickets

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -166,11 +166,14 @@ fail2ban-client set loglevel INFO
     (DateDetector.matchTime calls rarer DateTemplate.matchDate now);
   - several standard filters extended with exact prefixed or anchored date templates;
 * Added possibility to recognize restored state of the tickets (see gh-1669).
-  For the shell-based actions it is enough to add following script-piece at begin 
-  of `actionban` (or `actionunban`), to prevent execution for the restored 
-  (after restart) tickets.
+  New option `norestored` introduced, to ignore restored tickets (after restart).
+  To avoid execution of ban/unban for the restored tickets, `norestored = true`
+  could be added in definition section of action.
+  For conditional usage in the shell-based actions an interpolation `<restored>` 
+  could be used also. E. g. it is enough to add following script-piece at begin
+  of `actionban` (or `actionunban`) to prevent execution:
   `if [ '<restored>' = '1' ]; then exit 0; fi;`
-  Several actions extended now:
+  Several actions extended now using `norestored` option:
   - complain.conf
   - dshield.conf
   - mail-buffered.conf

--- a/ChangeLog
+++ b/ChangeLog
@@ -165,6 +165,28 @@ fail2ban-client set loglevel INFO
   - faster match and fewer searching of appropriate templates
     (DateDetector.matchTime calls rarer DateTemplate.matchDate now);
   - several standard filters extended with exact prefixed or anchored date templates;
+* Added possibility to recognize restored state of the tickets (see gh-1669).
+  For the shell-based actions it is enough to add following script-piece at begin 
+  of `actionban` (or `actionunban`), to prevent execution for the restored 
+  (after restart) tickets.
+  `if [ '<restored>' = '1' ]; then exit 0; fi;`
+  Several actions extended now:
+  - complain.conf
+  - dshield.conf
+  - mail-buffered.conf
+  - mail-whois-lines.conf
+  - mail-whois.conf
+  - mail.conf
+  - sendmail-buffered.conf
+  - sendmail-geoip-lines.conf
+  - sendmail-whois-ipjailmatches.conf
+  - sendmail-whois-ipmatches.conf
+  - sendmail-whois-lines.conf
+  - sendmail-whois-matches.conf
+  - sendmail-whois.conf
+  - sendmail.conf
+  - smtp.py
+  - xarf-login-attack.conf
 * fail2ban-testcases:
   - `assertLogged` extended with parameter wait (to wait up to specified timeout,
     before we throw assert exception) + test cases rewritten using that

--- a/config/action.d/complain.conf
+++ b/config/action.d/complain.conf
@@ -34,6 +34,9 @@ before = helpers-common.conf
 
 [Definition]
 
+# bypass ban/unban for restored tickets
+norestored = 1
+
 # Option:  actionstart
 # Notes.:  command executed once at the start of Fail2Ban.
 # Values:  CMD
@@ -58,8 +61,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = %(_bypass_if_restored)s
-            oifs=${IFS}; 
+actionban = oifs=${IFS}; 
               IFS=.; SEP_IP=( <ip> ); set -- ${SEP_IP}; ADDRESSES=$(dig +short -t txt -q $4.$3.$2.$1.abuse-contacts.abusix.org); 
               IFS=,; ADDRESSES=$(echo $ADDRESSES)
             IFS=${oifs}

--- a/config/action.d/complain.conf
+++ b/config/action.d/complain.conf
@@ -58,7 +58,8 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = oifs=${IFS}; 
+actionban = %(_bypass_if_restored)s
+            oifs=${IFS}; 
               IFS=.; SEP_IP=( <ip> ); set -- ${SEP_IP}; ADDRESSES=$(dig +short -t txt -q $4.$3.$2.$1.abuse-contacts.abusix.org); 
               IFS=,; ADDRESSES=$(echo $ADDRESSES)
             IFS=${oifs}

--- a/config/action.d/dshield.conf
+++ b/config/action.d/dshield.conf
@@ -26,11 +26,10 @@
 # configure how often the buffer is flushed).
 #
 
-[INCLUDES]
-
-before = helpers-common.conf
-
 [Definition]
+
+# bypass ban/unban for restored tickets
+norestored = 1
 
 # Option:  actionstart
 # Notes.:  command executed once at the start of Fail2Ban.
@@ -68,8 +67,7 @@ actioncheck =
 # few seconds out, are incorrect. See
 # http://sourceforge.net/tracker/index.php?func=detail&aid=2017795&group_id=121032&atid=689047
 #
-actionban = %(_bypass_if_restored)s
-            TZONE=`date +%%z | sed 's/\([+-]..\)\(..\)/\1:\2/'`
+actionban = TZONE=`date +%%z | sed 's/\([+-]..\)\(..\)/\1:\2/'`
             DATETIME="`perl -e '@t=localtime(<time>);printf "%%4d-%%02d-%%02d %%02d:%%02d:%%02d",1900+$t[5],$t[4]+1,$t[3],$t[2],$t[1],$t[0]'` $TZONE"
 	    PROTOCOL=`awk '{IGNORECASE=1;if($1=="<protocol>"){print $2;exit}}' /etc/protocols`
 	    if [ -z "$PROTOCOL" ]; then PROTOCOL=<protocol>; fi
@@ -96,8 +94,7 @@ actionban = %(_bypass_if_restored)s
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionunban = %(_bypass_if_restored)s
-              if [ -f <tmpfile>.first ]; then
+actionunban = if [ -f <tmpfile>.first ]; then
                   NOW=`date +%%s`
                   LOGAGE=$(($NOW - `cat <tmpfile>.first`))
                   if [ $LOGAGE -gt <maxbufferage> ]; then

--- a/config/action.d/dshield.conf
+++ b/config/action.d/dshield.conf
@@ -26,6 +26,10 @@
 # configure how often the buffer is flushed).
 #
 
+[INCLUDES]
+
+before = helpers-common.conf
+
 [Definition]
 
 # Option:  actionstart
@@ -64,7 +68,8 @@ actioncheck =
 # few seconds out, are incorrect. See
 # http://sourceforge.net/tracker/index.php?func=detail&aid=2017795&group_id=121032&atid=689047
 #
-actionban = TZONE=`date +%%z | sed 's/\([+-]..\)\(..\)/\1:\2/'`
+actionban = %(_bypass_if_restored)s
+            TZONE=`date +%%z | sed 's/\([+-]..\)\(..\)/\1:\2/'`
             DATETIME="`perl -e '@t=localtime(<time>);printf "%%4d-%%02d-%%02d %%02d:%%02d:%%02d",1900+$t[5],$t[4]+1,$t[3],$t[2],$t[1],$t[0]'` $TZONE"
 	    PROTOCOL=`awk '{IGNORECASE=1;if($1=="<protocol>"){print $2;exit}}' /etc/protocols`
 	    if [ -z "$PROTOCOL" ]; then PROTOCOL=<protocol>; fi
@@ -91,7 +96,8 @@ actionban = TZONE=`date +%%z | sed 's/\([+-]..\)\(..\)/\1:\2/'`
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionunban = if [ -f <tmpfile>.first ]; then
+actionunban = %(_bypass_if_restored)s
+              if [ -f <tmpfile>.first ]; then
                   NOW=`date +%%s`
                   LOGAGE=$(($NOW - `cat <tmpfile>.first`))
                   if [ $LOGAGE -gt <maxbufferage> ]; then

--- a/config/action.d/helpers-common.conf
+++ b/config/action.d/helpers-common.conf
@@ -7,6 +7,9 @@
 _grep_logs = logpath="<logpath>"; grep <grepopts> -E %(_grep_logs_args)s $logpath | <greplimit>
 _grep_logs_args = '(^|[^0-9])<ip>([^0-9]|$)'
 
+# Used for actions, that should not by executed if ticket was restored:
+_bypass_if_restored = if [ '<restored>' = '1' ]; then exit 0; fi;
+
 [Init]
 greplimit = tail -n <grepmax>
 grepmax = 1000

--- a/config/action.d/mail-buffered.conf
+++ b/config/action.d/mail-buffered.conf
@@ -4,6 +4,11 @@
 #
 #
 
+[INCLUDES]
+
+before = helpers-common.conf
+
+
 [Definition]
 
 # Option:  actionstart
@@ -45,7 +50,8 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "`date`: <ip> (<failures> failures)\n" >> <tmpfile>
+actionban = %(_bypass_if_restored)s
+            printf %%b "`date`: <ip> (<failures> failures)\n" >> <tmpfile>
             LINE=$( wc -l <tmpfile> | awk '{ print $1 }' )
             if [ $LINE -ge <lines> ]; then
                 printf %%b "Hi,\n

--- a/config/action.d/mail-buffered.conf
+++ b/config/action.d/mail-buffered.conf
@@ -4,12 +4,10 @@
 #
 #
 
-[INCLUDES]
-
-before = helpers-common.conf
-
-
 [Definition]
+
+# bypass ban/unban for restored tickets
+norestored = 1
 
 # Option:  actionstart
 # Notes.:  command executed once at the start of Fail2Ban.
@@ -50,8 +48,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = %(_bypass_if_restored)s
-            printf %%b "`date`: <ip> (<failures> failures)\n" >> <tmpfile>
+actionban = printf %%b "`date`: <ip> (<failures> failures)\n" >> <tmpfile>
             LINE=$( wc -l <tmpfile> | awk '{ print $1 }' )
             if [ $LINE -ge <lines> ]; then
                 printf %%b "Hi,\n

--- a/config/action.d/mail-whois-lines.conf
+++ b/config/action.d/mail-whois-lines.conf
@@ -52,7 +52,9 @@ _ban_mail_content = ( printf %%b "Hi,\n
             printf %%b "\n
             Regards,\n
             Fail2Ban" )
-actionban = %(_ban_mail_content)s | <mailcmd> "[Fail2Ban] <name>: banned <ip> from  `uname -n`" <dest>
+
+actionban = %(_bypass_if_restored)s
+            %(_ban_mail_content)s | <mailcmd> "[Fail2Ban] <name>: banned <ip> from  `uname -n`" <dest>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the

--- a/config/action.d/mail-whois-lines.conf
+++ b/config/action.d/mail-whois-lines.conf
@@ -11,6 +11,9 @@ before = mail-whois-common.conf
 
 [Definition]
 
+# bypass ban/unban for restored tickets
+norestored = 1
+
 # Option:  actionstart
 # Notes.:  command executed once at the start of Fail2Ban.
 # Values:  CMD
@@ -53,8 +56,7 @@ _ban_mail_content = ( printf %%b "Hi,\n
             Regards,\n
             Fail2Ban" )
 
-actionban = %(_bypass_if_restored)s
-            %(_ban_mail_content)s | <mailcmd> "[Fail2Ban] <name>: banned <ip> from  `uname -n`" <dest>
+actionban = %(_ban_mail_content)s | <mailcmd> "[Fail2Ban] <name>: banned <ip> from  `uname -n`" <dest>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the

--- a/config/action.d/mail-whois.conf
+++ b/config/action.d/mail-whois.conf
@@ -7,6 +7,7 @@
 [INCLUDES]
 
 before = mail-whois-common.conf
+         helpers-common.conf
 
 [Definition]
 
@@ -40,7 +41,8 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "Hi,\n
+actionban = %(_bypass_if_restored)s
+            printf %%b "Hi,\n
             The IP <ip> has just been banned by Fail2Ban after
             <failures> attempts against <name>.\n\n
             Here is more information about <ip> :\n

--- a/config/action.d/mail-whois.conf
+++ b/config/action.d/mail-whois.conf
@@ -7,9 +7,11 @@
 [INCLUDES]
 
 before = mail-whois-common.conf
-         helpers-common.conf
 
 [Definition]
+
+# bypass ban/unban for restored tickets
+norestored = 1
 
 # Option:  actionstart
 # Notes.:  command executed once at the start of Fail2Ban.
@@ -41,8 +43,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = %(_bypass_if_restored)s
-            printf %%b "Hi,\n
+actionban = printf %%b "Hi,\n
             The IP <ip> has just been banned by Fail2Ban after
             <failures> attempts against <name>.\n\n
             Here is more information about <ip> :\n

--- a/config/action.d/mail.conf
+++ b/config/action.d/mail.conf
@@ -4,6 +4,10 @@
 #
 #
 
+[INCLUDES]
+
+before = helpers-common.conf
+
 [Definition]
 
 # Option:  actionstart
@@ -36,7 +40,8 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "Hi,\n
+actionban = %(_bypass_if_restored)s
+            printf %%b "Hi,\n
             The IP <ip> has just been banned by Fail2Ban after
             <failures> attempts against <name>.\n
             Regards,\n

--- a/config/action.d/mail.conf
+++ b/config/action.d/mail.conf
@@ -4,11 +4,10 @@
 #
 #
 
-[INCLUDES]
-
-before = helpers-common.conf
-
 [Definition]
+
+# bypass ban/unban for restored tickets
+norestored = 1
 
 # Option:  actionstart
 # Notes.:  command executed once at the start of Fail2Ban.
@@ -40,8 +39,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = %(_bypass_if_restored)s
-            printf %%b "Hi,\n
+actionban = printf %%b "Hi,\n
             The IP <ip> has just been banned by Fail2Ban after
             <failures> attempts against <name>.\n
             Regards,\n

--- a/config/action.d/sendmail-buffered.conf
+++ b/config/action.d/sendmail-buffered.conf
@@ -7,6 +7,7 @@
 [INCLUDES]
 
 before = sendmail-common.conf
+         helpers-common.conf
 
 [Definition]
 
@@ -58,7 +59,8 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "`date`: <ip> (<failures> failures)\n" >> <tmpfile>
+actionban = %(_bypass_if_restored)s
+            printf %%b "`date`: <ip> (<failures> failures)\n" >> <tmpfile>
             LINE=$( wc -l <tmpfile> | awk '{ print $1 }' )
             if [ $LINE -ge <lines> ]; then
                 printf %%b "Subject: [Fail2Ban] <name>: summary from `uname -n`

--- a/config/action.d/sendmail-buffered.conf
+++ b/config/action.d/sendmail-buffered.conf
@@ -7,9 +7,11 @@
 [INCLUDES]
 
 before = sendmail-common.conf
-         helpers-common.conf
 
 [Definition]
+
+# bypass ban/unban for restored tickets
+norestored = 1
 
 # Option:  actionstart
 # Notes.:  command executed once at the start of Fail2Ban.
@@ -59,8 +61,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = %(_bypass_if_restored)s
-            printf %%b "`date`: <ip> (<failures> failures)\n" >> <tmpfile>
+actionban = printf %%b "`date`: <ip> (<failures> failures)\n" >> <tmpfile>
             LINE=$( wc -l <tmpfile> | awk '{ print $1 }' )
             if [ $LINE -ge <lines> ]; then
                 printf %%b "Subject: [Fail2Ban] <name>: summary from `uname -n`

--- a/config/action.d/sendmail-geoip-lines.conf
+++ b/config/action.d/sendmail-geoip-lines.conf
@@ -20,7 +20,8 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = ( printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = %(_bypass_if_restored)s
+            ( printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail-geoip-lines.conf
+++ b/config/action.d/sendmail-geoip-lines.conf
@@ -11,6 +11,9 @@ before = sendmail-common.conf
 
 [Definition]
 
+# bypass ban/unban for restored tickets
+norestored = 1
+
 # Option:  actionban
 # Notes.:  Command executed when banning an IP. Take care that the
 #          command is executed with Fail2Ban user rights.
@@ -20,8 +23,7 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = %(_bypass_if_restored)s
-            ( printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = ( printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail-whois-ipjailmatches.conf
+++ b/config/action.d/sendmail-whois-ipjailmatches.conf
@@ -7,6 +7,7 @@
 [INCLUDES]
 
 before = sendmail-common.conf
+         helpers-common.conf
 
 [Definition]
 
@@ -16,7 +17,8 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = %(_bypass_if_restored)s
+            printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail-whois-ipjailmatches.conf
+++ b/config/action.d/sendmail-whois-ipjailmatches.conf
@@ -7,9 +7,11 @@
 [INCLUDES]
 
 before = sendmail-common.conf
-         helpers-common.conf
 
 [Definition]
+
+# bypass ban/unban for restored tickets
+norestored = 1
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
@@ -17,8 +19,7 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = %(_bypass_if_restored)s
-            printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail-whois-ipmatches.conf
+++ b/config/action.d/sendmail-whois-ipmatches.conf
@@ -7,6 +7,7 @@
 [INCLUDES]
 
 before = sendmail-common.conf
+         helpers-common.conf
 
 [Definition]
 
@@ -16,7 +17,8 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = %(_bypass_if_restored)s
+            printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail-whois-ipmatches.conf
+++ b/config/action.d/sendmail-whois-ipmatches.conf
@@ -7,9 +7,11 @@
 [INCLUDES]
 
 before = sendmail-common.conf
-         helpers-common.conf
 
 [Definition]
+
+# bypass ban/unban for restored tickets
+norestored = 1
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
@@ -17,8 +19,7 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = %(_bypass_if_restored)s
-            printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail-whois-lines.conf
+++ b/config/action.d/sendmail-whois-lines.conf
@@ -17,7 +17,8 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = ( printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = %(_bypass_if_restored)s
+            ( printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail-whois-lines.conf
+++ b/config/action.d/sendmail-whois-lines.conf
@@ -11,14 +11,16 @@ before = sendmail-common.conf
 
 [Definition]
 
+# bypass ban/unban for restored tickets
+norestored = 1
+
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
 #          command is executed with Fail2Ban user rights.
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = %(_bypass_if_restored)s
-            ( printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = ( printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail-whois-matches.conf
+++ b/config/action.d/sendmail-whois-matches.conf
@@ -7,6 +7,7 @@
 [INCLUDES]
 
 before = sendmail-common.conf
+         helpers-common.conf
 
 [Definition]
 
@@ -16,7 +17,8 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = %(_bypass_if_restored)s
+            printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail-whois-matches.conf
+++ b/config/action.d/sendmail-whois-matches.conf
@@ -7,9 +7,11 @@
 [INCLUDES]
 
 before = sendmail-common.conf
-         helpers-common.conf
 
 [Definition]
+
+# bypass ban/unban for restored tickets
+norestored = 1
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
@@ -17,8 +19,7 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = %(_bypass_if_restored)s
-            printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail-whois.conf
+++ b/config/action.d/sendmail-whois.conf
@@ -7,6 +7,7 @@
 [INCLUDES]
 
 before = sendmail-common.conf
+         helpers-common.conf
 
 [Definition]
 
@@ -16,7 +17,8 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = %(_bypass_if_restored)s
+            printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail-whois.conf
+++ b/config/action.d/sendmail-whois.conf
@@ -7,9 +7,11 @@
 [INCLUDES]
 
 before = sendmail-common.conf
-         helpers-common.conf
 
 [Definition]
+
+# bypass ban/unban for restored tickets
+norestored = 1
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
@@ -17,8 +19,7 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = %(_bypass_if_restored)s
-            printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail.conf
+++ b/config/action.d/sendmail.conf
@@ -7,6 +7,7 @@
 [INCLUDES]
 
 before = sendmail-common.conf
+         helpers-common.conf
 
 [Definition]
 
@@ -16,7 +17,8 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = %(_bypass_if_restored)s
+            printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/sendmail.conf
+++ b/config/action.d/sendmail.conf
@@ -7,9 +7,11 @@
 [INCLUDES]
 
 before = sendmail-common.conf
-         helpers-common.conf
 
 [Definition]
+
+# bypass ban/unban for restored tickets
+norestored = 1
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
@@ -17,8 +19,7 @@ before = sendmail-common.conf
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = %(_bypass_if_restored)s
-            printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
+actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from `uname -n`
             Date: `LC_ALL=C date +"%%a, %%d %%h %%Y %%T %%z"`
             From: <sendername> <<sender>>
             To: <dest>\n

--- a/config/action.d/smtp.py
+++ b/config/action.d/smtp.py
@@ -211,6 +211,8 @@ class SMTPAction(ActionBase):
 			Dictionary which includes information in relation to
 			the ban.
 		"""
+		if aInfo.get('restored'):
+			return
 		aInfo.update(self.message_values)
 		message = "".join([
 			messages['ban']['head'],

--- a/config/action.d/smtp.py
+++ b/config/action.d/smtp.py
@@ -126,6 +126,9 @@ class SMTPAction(ActionBase):
 			bantime = self._jail.actions.getBanTime,
 			)
 
+		# bypass ban/unban for restored tickets
+		self.norestored = 1
+
 	def _sendMessage(self, subject, text):
 		"""Sends message based on arguments and instance's properties.
 

--- a/config/action.d/xarf-login-attack.conf
+++ b/config/action.d/xarf-login-attack.conf
@@ -30,6 +30,10 @@
 #
 #
 
+[INCLUDES]
+
+before = helpers-common.conf
+
 [Definition]
 
 actionstart =
@@ -38,7 +42,8 @@ actionstop =
 
 actioncheck =
 
-actionban = oifs=${IFS}; IFS=.;SEP_IP=( <ip> ); set -- ${SEP_IP}; ADDRESSES=$(dig +short -t txt -q $4.$3.$2.$1.abuse-contacts.abusix.org); IFS=${oifs}
+actionban = %(_bypass_if_restored)s
+            oifs=${IFS}; IFS=.;SEP_IP=( <ip> ); set -- ${SEP_IP}; ADDRESSES=$(dig +short -t txt -q $4.$3.$2.$1.abuse-contacts.abusix.org); IFS=${oifs}
             IP=<ip>
             FROM=<sender>
             SERVICE=<service>

--- a/config/action.d/xarf-login-attack.conf
+++ b/config/action.d/xarf-login-attack.conf
@@ -30,11 +30,10 @@
 #
 #
 
-[INCLUDES]
-
-before = helpers-common.conf
-
 [Definition]
+
+# bypass ban/unban for restored tickets
+norestored = 1
 
 actionstart =
 
@@ -42,8 +41,7 @@ actionstop =
 
 actioncheck =
 
-actionban = %(_bypass_if_restored)s
-            oifs=${IFS}; IFS=.;SEP_IP=( <ip> ); set -- ${SEP_IP}; ADDRESSES=$(dig +short -t txt -q $4.$3.$2.$1.abuse-contacts.abusix.org); IFS=${oifs}
+actionban = oifs=${IFS}; IFS=.;SEP_IP=( <ip> ); set -- ${SEP_IP}; ADDRESSES=$(dig +short -t txt -q $4.$3.$2.$1.abuse-contacts.abusix.org); IFS=${oifs}
             IP=<ip>
             FROM=<sender>
             SERVICE=<service>

--- a/fail2ban/client/filterreader.py
+++ b/fail2ban/client/filterreader.py
@@ -27,8 +27,7 @@ __license__ = "GPL"
 import os
 import shlex
 
-from .configreader import DefinitionInitConfigReader, _merge_dicts
-from ..server.action import CommandAction
+from .configreader import DefinitionInitConfigReader
 from ..helpers import getLogger
 
 # Gets the instance of the logger.
@@ -52,17 +51,6 @@ class FilterReader(DefinitionInitConfigReader):
 	def getFile(self):
 		return self.__file
 
-	def getCombined(self):
-		combinedopts = self._opts
-		if self._initOpts:
-			combinedopts = _merge_dicts(self._opts, self._initOpts)
-		if not len(combinedopts):
-			return {}
-		opts = CommandAction.substituteRecursiveTags(combinedopts)
-		if not opts:
-			raise ValueError('recursive tag definitions unable to be resolved')
-		return opts
-	
 	def convert(self):
 		stream = list()
 		opts = self.getCombined()
@@ -70,6 +58,7 @@ class FilterReader(DefinitionInitConfigReader):
 			return stream
 		for opt, value in opts.iteritems():
 			if opt in ("failregex", "ignoreregex"):
+				if value is None: continue
 				multi = []
 				for regex in value.split('\n'):
 					# Do not send a command if the rule is empty.
@@ -87,6 +76,7 @@ class FilterReader(DefinitionInitConfigReader):
 				stream.append(["set", self._jailName, "datepattern", value])
 			# Do not send a command if the match is empty.
 			elif opt == 'journalmatch':
+				if value is None: continue
 				for match in value.split("\n"):
 					if match == '': continue
 					stream.append(

--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -136,7 +136,8 @@ class JailReader(ConfigReader):
 				if not filterName:
 					raise JailDefError("Invalid filter definition %r" % flt)
 				self.__filter = FilterReader(
-					filterName, self.__name, filterOpt, share_config=self.share_config, basedir=self.getBaseDir())
+					filterName, self.__name, filterOpt, 
+					share_config=self.share_config, basedir=self.getBaseDir())
 				ret = self.__filter.read()
 				# merge options from filter as 'known/...':
 				self.__filter.getOptions(self.__opts)

--- a/fail2ban/server/action.py
+++ b/fail2ban/server/action.py
@@ -219,9 +219,9 @@ class CommandAction(ActionBase):
 			self.timeout = 60
 			## Command executed in order to initialize the system.
 			self.actionstart = ''
-			## Command executed when an IP address gets banned.
+			## Command executed when ticket gets banned.
 			self.actionban = ''
-			## Command executed when an IP address gets removed.
+			## Command executed when ticket gets removed.
 			self.actionunban = ''
 			## Command executed in order to check requirements.
 			self.actioncheck = ''

--- a/fail2ban/server/actions.py
+++ b/fail2ban/server/actions.py
@@ -348,6 +348,8 @@ class Actions(JailThread, Mapping):
 			aInfo["failures"] = bTicket.getAttempt()
 			aInfo["time"] = bTicket.getTime()
 			aInfo["matches"] = "\n".join(bTicket.getMatches())
+			# to bypass actions, that should not be executed for restored tickets
+			aInfo["restored"] = 1 if ticket.restored else 0
 			if self._jail.database is not None:
 				mi4ip = lambda overalljails=False, self=self, \
 					mi={'ip':ip, 'ticket':bTicket}: self.__getBansMerged(mi, overalljails)
@@ -449,6 +451,8 @@ class Actions(JailThread, Mapping):
 		aInfo["failures"] = ticket.getAttempt()
 		aInfo["time"] = ticket.getTime()
 		aInfo["matches"] = "".join(ticket.getMatches())
+		# to bypass actions, that should not be executed for restored tickets
+		aInfo["restored"] = 1 if ticket.restored else 0
 		if actions is None:
 			logSys.notice("[%s] Unban %s", self._jail.name, aInfo["ip"])
 		for name, action in unbactions.iteritems():

--- a/fail2ban/server/actions.py
+++ b/fail2ban/server/actions.py
@@ -363,6 +363,8 @@ class Actions(JailThread, Mapping):
 				logSys.notice("[%s] %sBan %s", self._jail.name, ('' if not bTicket.restored else 'Restore '), ip)
 				for name, action in self._actions.iteritems():
 					try:
+						if ticket.restored and getattr(action, 'norestored', False):
+							continue
 						action.ban(aInfo.copy())
 					except Exception as e:
 						logSys.error(
@@ -457,6 +459,8 @@ class Actions(JailThread, Mapping):
 			logSys.notice("[%s] Unban %s", self._jail.name, aInfo["ip"])
 		for name, action in unbactions.iteritems():
 			try:
+				if ticket.restored and getattr(action, 'norestored', False):
+					continue
 				logSys.debug("[%s] action %r: unban %s", self._jail.name, name, aInfo["ip"])
 				action.unban(aInfo.copy())
 			except Exception as e:

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -546,7 +546,10 @@ class JailsReaderTest(LogCaptureTestCase):
 				actionName = os.path.basename(actionConfig).replace('.conf', '')
 				actionReader = ActionReader(actionName, "TEST", {}, basedir=CONFIG_DIR)
 				self.assertTrue(actionReader.read())
-				actionReader.getOptions({})	  # populate _opts
+				try:
+					actionReader.getOptions({})	  # populate _opts
+				except Exception as e: # pragma: no cover
+					self.fail("action %r\n%s: %s" % (actionName, type(e).__name__, e))
 				if not actionName.endswith('-common'):
 					self.assertIn('Definition', actionReader.sections(),
 						msg="Action file %r is lacking [Definition] section" % actionConfig)

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -347,7 +347,7 @@ class FilterReaderTest(unittest.TestCase):
 			['set', 'testcase01', 'addjournalmatch',
 				"FIELD= with spaces ", "+", "AFIELD= with + char and spaces"],
 			['set', 'testcase01', 'datepattern', "%Y %m %d %H:%M:%S"],
-			['set', 'testcase01', 'maxlines', "1"], # Last for overide test
+			['set', 'testcase01', 'maxlines', 1], # Last for overide test
 		]
 		filterReader = FilterReader("testcase01", "testcase01", {})
 		filterReader.setBaseDir(TEST_FILES_DIR)
@@ -517,12 +517,10 @@ class JailsReaderTest(LogCaptureTestCase):
 			 ['add', 'brokenaction', 'auto'],
 			 ['set', 'brokenaction', 'addfailregex', '<IP>'],
 			 ['set', 'brokenaction', 'addaction', 'brokenaction'],
-			 ['set',
-			  'brokenaction',
-			  'action',
-			  'brokenaction',
-			  'actionban',
-			  'hit with big stick <ip>'],
+			 ['multi-set', 'brokenaction', 'action', 'brokenaction', [
+				 ['actionban', 'hit with big stick <ip>'],
+				 ['actname', 'brokenaction']
+			 ]],
 			 ['add', 'parse_to_end_of_jail.conf', 'auto'],
 			 ['set', 'parse_to_end_of_jail.conf', 'addfailregex', '<IP>'],
 			 ['start', 'emptyaction'],


### PR DESCRIPTION
Recognize restored (from database) tickets after restart (tell action restored state of the ticket).
Prevent executing of several actions (e.g. mail, send-mail etc) on restart (bans were already notified).
Test cases extended (smtp and by restart in ServerReloadTest).
Closes gh-1141
Closes gh-921

Affected actions:
  - complain.conf
  - dshield.conf
  - mail-buffered.conf
  - mail-whois-lines.conf
  - mail-whois.conf
  - mail.conf
  - sendmail-buffered.conf
  - sendmail-geoip-lines.conf
  - sendmail-whois-ipjailmatches.conf
  - sendmail-whois-ipmatches.conf
  - sendmail-whois-lines.conf
  - sendmail-whois-matches.conf
  - sendmail-whois.conf
  - sendmail.conf
  - smtp.py
  - xarf-login-attack.conf

New option `norestored` introduced for actions, to complete avoid of execution ban/unban for such tickets.
Usage: `norestored = true`.

For conditional usage in the shell-based actions an interpolation `<restored>` could be used also. 
E. g. it is enough to add following script-piece at begin of `actionban` (or `actionunban`), to prevent execution for restored tickets.
```bash
if [ '<restored>' = '1' ]; then exit 0; fi;
```
How it can be implemented you can see in https://github.com/fail2ban/fail2ban/pull/1669/commits/ee3c787cc68f6d043c8702c8f53a566277e2ee02#diff-b8000792a7bad4f1b05eeddea812cec5