### PR TITLE
Postfix RBL: 554 & SMTP

### DIFF
--- a/config/filter.d/postfix-rbl.conf
+++ b/config/filter.d/postfix-rbl.conf
@@ -12,7 +12,7 @@ before = common.conf
 
 _daemon = postfix(-\w+)?/smtpd
 
-failregex = ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 454 4\.7\.1 Service unavailable; Client host \[\S+\] blocked using .* from=<\S*> to=<\S+> proto=ESMTP helo=<\S*>$
+failregex = ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: [45]54 [45]\.7\.1 Service unavailable; Client host \[\S+\] blocked\b
 
 ignoreregex =
 

--- a/fail2ban/tests/files/logs/postfix-rbl
+++ b/fail2ban/tests/files/logs/postfix-rbl
@@ -3,3 +3,6 @@ Dec 30 18:19:15 xxx postfix/smtpd[1574]: NOQUEUE: reject: RCPT from badguy.examp
 
 # failJSON: { "time": "2004-12-30T18:19:15", "match": true , "host": "93.184.216.34" }
 Dec 30 18:19:15 xxx postfix-incoming/smtpd[1574]: NOQUEUE: reject: RCPT from badguy.example.com[93.184.216.34]: 454 4.7.1 Service unavailable; Client host [93.184.216.34] blocked using rbl.example.com; http://www.example.com/query?ip=93.184.216.34; from=<spammer@example.com> to=<goodguy@example.com> proto=ESMTP helo=<badguy.example.com>
+
+# failJSON: { "time": "2005-02-07T12:25:45", "match": true , "host": "87.236.233.182" }
+Feb  7 12:25:45 xxx12345 postfix/smtpd[13275]: NOQUEUE: reject: RCPT from unknown[87.236.233.182]: 554 5.7.1 Service unavailable; Client host [87.236.233.182] blocked using rbl.example.com; https://www.example.com/query/ip/87.236.233.182; from=<spammer@example.com> to=<goodguy@example.com> proto=SMTP helo=<WIN-5N8GBBS0R5I>


### PR DESCRIPTION
Hi, on my system:

1. Ubuntu 16.04.1 LTS
1. Postfix 3.1.0

The logs of RBL appear with a `554 5.7.1` and `proto=SMTP`