### PR TITLE
Apache, detect syslog prefix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,12 @@ TODO: implementing of options resp. other tasks from PR #1346
 ### Fixes
 * `filter.d/apache-auth.conf`:
   - better failure recognition using short form of regex (url/referer are foreign inputs, see gh-1645)
+* `filter.d/apache-common.conf` (`filter.d/apache-*.conf`):
+  - support of apache log-format if logging into syslog/systemd (gh-1695), using parameter `logging`,
+    parameter usage for jail:
+      filter = apache-auth[logging=syslog]
+    parameter usage for `apache-common.local`:
+      logging = syslog
 * `filter.d/pam-generic.conf`:
   - [grave] injection on user name to host fixed
 * `filter.d/sshd.conf`:

--- a/config/filter.d/apache-common.conf
+++ b/config/filter.d/apache-common.conf
@@ -22,6 +22,9 @@ apache-prefix-syslog = %(__prefix_line)s
 apache-prefix-logfile = \[\]\s
 apache-prefix-all = (?:%(apache-prefix-logfile)s|%(apache-prefix-syslog)s)?
 
+# Setting for __prefix_line (only `logging=syslog`):
+_daemon = (?:apache\d*|httpd(?:/\w+)?)
+
 apache-prefix = <apache-prefix-<logging>>
 
 _apache_error_client = <apache-prefix>\[(:?error|\S+:\S+)\]( \[pid \d+(:\S+ \d+)?\])? \[client <HOST>(:\d{1,5})?\]

--- a/config/filter.d/apache-common.conf
+++ b/config/filter.d/apache-common.conf
@@ -1,23 +1,30 @@
 # Generic configuration items (to be used as interpolations) in other
 # apache filters.
 
-# If you use "ErrorLog syslog" in your Apache configuration,
-# you should then create the following apache-common.local file :
-# [INCLUDES]
-# before = common.conf
-# [DEFAULT]
-# _apache_prefix = %(__prefix_line)s
-
 [INCLUDES]
 
+before = common.conf
 # Load customizations if any available
 after = apache-common.local
 
 [DEFAULT]
 
-_apache_prefix = \[\]\s
+# Apache logging mode:
+#   all - universal prefix (logfile, syslog)
+#   logfile - logfile only
+#   syslog - syslog only
+# Use `filter = apache-auth[logging=syslog]` to get more precise regex if apache logs into syslog (ErrorLog syslog).
+# Use `filter = apache-auth[logging=all]` to get universal regex matches both logging variants.
+logging = logfile
 
-_apache_error_client = ^%(_apache_prefix)s\[(:?error|\S+:\S+)\]( \[pid \d+(:\S+ \d+)?\])? \[client <HOST>(:\d{1,5})?\]
+# Apache logging prefixes (date-pattern prefix, server, process etc.):
+apache-prefix-syslog = %(__prefix_line)s
+apache-prefix-logfile = \[\]\s
+apache-prefix-all = (?:%(apache-prefix-logfile)s|%(apache-prefix-syslog)s)?
+
+apache-prefix = <apache-prefix-<logging>>
+
+_apache_error_client = <apache-prefix>\[(:?error|\S+:\S+)\]( \[pid \d+(:\S+ \d+)?\])? \[client <HOST>(:\d{1,5})?\]
 
 datepattern = {^LN-BEG}
 

--- a/config/filter.d/apache-common.conf
+++ b/config/filter.d/apache-common.conf
@@ -1,6 +1,13 @@
 # Generic configuration items (to be used as interpolations) in other
 # apache filters.
 
+# If you use "ErrorLog syslog" in your Apache configuration,
+# you should then create the following apache-common.local file :
+# [INCLUDES]
+# before = common.conf
+# [DEFAULT]
+# _apache_prefix = %(__prefix_line)s
+
 [INCLUDES]
 
 # Load customizations if any available
@@ -8,7 +15,9 @@ after = apache-common.local
 
 [DEFAULT]
 
-_apache_error_client = \[\] \[(:?error|\S+:\S+)\]( \[pid \d+(:\S+ \d+)?\])? \[client <HOST>(:\d{1,5})?\]
+_apache_prefix = \[\]\s
+
+_apache_error_client = ^%(_apache_prefix)s\[(:?error|\S+:\S+)\]( \[pid \d+(:\S+ \d+)?\])? \[client <HOST>(:\d{1,5})?\]
 
 datepattern = {^LN-BEG}
 

--- a/fail2ban/tests/files/logs/apache-auth
+++ b/fail2ban/tests/files/logs/apache-auth
@@ -11,10 +11,6 @@
 # failJSON: { "time": "2013-07-11T01:21:44", "match": true , "host": "2606:2800:220:1:248:1893:25c8:1946" } 
 [Thu Jul 11 01:21:44 2013] [error] [client 2606:2800:220:1:248:1893:25c8:1946] user test-ipv6 not found: /
 
-# Must mach syslog prefix
-# failJSON: { "time": "2005-02-16T22:32:48", "match": true , "host": "127.0.0.1" }
-Feb 16 22:32:48 srv httpd[22034]: [error] [client 127.0.0.1] user wrongusername not found: /basic/file
-
 # The failures below use the configuration described in fail2ban/tests/files/config/apache-auth
 #
 
@@ -128,3 +124,15 @@ Feb 16 22:32:48 srv httpd[22034]: [error] [client 127.0.0.1] user wrongusername 
 
 # failJSON: { "time": "2013-11-18T22:39:33", "match": true , "host": "91.49.82.139" }
 [Mon Nov 18 22:39:33 2013] [error] [client 91.49.82.139] user gg not found: /, referer: http://sj.hopto.org/management.html
+
+# filterOptions: {"logging": "syslog"}
+
+# failJSON: { "time": "2005-02-15T16:23:00", "match": true , "host": "192.0.2.1", "desc": "using syslog (ErrorLog syslog)" }
+Feb 15 16:23:00 srv httpd[22034]: [authz_core:error] [pid 22034] [client 192.0.2.1:58585] AH01630: client denied by server configuration: /home/www/
+# failJSON: { "time": "2005-02-15T16:23:40", "match": true , "host": "192.0.2.2", "desc": "using syslog (ErrorLog syslog)" }
+Feb 15 16:23:40 srv httpd/backend1[22034]: [authz_core:error] [pid 22036] [client 192.0.2.2:59392] AH01630: client denied by server configuration: /home/backend1/
+# failJSON: { "time": "2005-02-15T16:54:53", "match": true , "host": "192.0.2.3", "desc": "using syslog (ErrorLog syslog)" }
+Feb 15 16:54:53 tools apache2[18154]: [:error] [pid 18154:tid 140680873617152] [client 192.0.2.3:48154] AH01630: client denied by server configuration: /var/www
+
+# failJSON: { "time": "2005-02-16T22:32:48", "match": true , "host": "127.0.0.1" }
+Feb 16 22:32:48 srv httpd[22034]: [error] [client 127.0.0.1] user wrongusername not found: /basic/file

--- a/fail2ban/tests/files/logs/apache-auth
+++ b/fail2ban/tests/files/logs/apache-auth
@@ -11,6 +11,10 @@
 # failJSON: { "time": "2013-07-11T01:21:44", "match": true , "host": "2606:2800:220:1:248:1893:25c8:1946" } 
 [Thu Jul 11 01:21:44 2013] [error] [client 2606:2800:220:1:248:1893:25c8:1946] user test-ipv6 not found: /
 
+# Must mach syslog prefix
+# failJSON: { "time": "2005-02-16T22:32:48", "match": true , "host": "127.0.0.1" }
+Feb 16 22:32:48 srv httpd[22034]: [error] [client 127.0.0.1] user wrongusername not found: /basic/file
+
 # The failures below use the configuration described in fail2ban/tests/files/config/apache-auth
 #
 


### PR DESCRIPTION
Hello,

This PR solves #1693.

It detects syslog prefix (` host process`) in log lines, making fail2ban work when Apache logs using syslog.

Thank you 👍 

Ben