### PR TITLE
postfix: ban lost connection after <STAGE> from <HOST>

### DIFF
--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -19,6 +19,7 @@ failregex = ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 554 5\.7
             ^%(__prefix_line)sNOQUEUE: reject: VRFY from \S+\[<HOST>\]: 550 5\.1\.1 .*$
             ^%(__prefix_line)sNOQUEUE: reject: RCPT from \S+\[<HOST>\]: 450 4\.1\.8 <\S*>: Sender address rejected: Domain not found; from=<\S*> to=<\S+> proto=ESMTP helo=<\S*>$
             ^%(__prefix_line)simproper command pipelining after \S+ from [^[]*\[<HOST>\]:?$
+            ^%(__prefix_line)slost connection after \S+ from \S+\[<HOST>\]$
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/postfix
+++ b/fail2ban/tests/files/logs/postfix
@@ -35,3 +35,9 @@ Jan 31 13:55:24 xxx postfix-incoming/smtpd[3462]: NOQUEUE: reject: EHLO from s27
 
 # failJSON: { "time": "2005-04-12T02:24:11", "match": true , "host": "62.138.2.143" }
 Apr 12 02:24:11 xxx postfix/smtps/smtpd[42]: NOQUEUE: reject: EHLO from astra4139.startdedicated.de[62.138.2.143]: 504 5.5.2 <User>: Helo command rejected: need fully-qualified hostname; proto=SMTP helo=<User>
+
+# failJSON: { "time": "2005-02-18T09:45:12", "match": true , "host": "192.0.2.42" }
+Feb 18 09:45:12 xxx postfix/smtpd[42]: lost connection after STARTTLS from spammer.example.com[192.0.2.42]
+
+# failJSON: { "time": "2005-02-18T09:48:04", "match": true , "host": "192.0.2.23" }
+Feb 18 09:48:04 xxx postfix/smtpd[23]: lost connection after AUTH from unknown[192.0.2.23]


### PR DESCRIPTION
"`lost connection after <STAGE> from <HOST>`" is a common log-filer for Postfix [1]. Analyzing my own logs I did not find any legitimate occurrences of such lines in bulk, see also [2].

The `<STAGE>` could be limited to `AUTH`, as this is the main offender (both according to my logs and "the Internet").

[1] http://www.iredmail.org/forum/topic8172-iredmail-support-howto-protect-against-postfix-auth-dos-attacks.html
[2] https://sourceforge.net/p/fail2ban/mailman/message/31893097/

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
