### PR TITLE
Fix (gh-1707) cyrus-imap.conf: accept entries without login-info resp. hostname before IP address

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -33,6 +33,8 @@ releases.
       and suffix (logged from several ssh versions), according to gh-1206;
 * filter.d/suhosin.conf
     - greedy catch-all before `<HOST>` fixed (potential vulnerability)
+* filter.d/cyrus-imap.conf
+    - accept entries without login-info resp. hostname before IP address (gh-1707)
 * Filter tests extended with check of all config-regexp, that contains greedy catch-all
   before `<HOST>`, that is hard-anchored at end or precise  sub expression after `<HOST>`
 

--- a/config/filter.d/cyrus-imap.conf
+++ b/config/filter.d/cyrus-imap.conf
@@ -13,7 +13,7 @@ before = common.conf
 
 _daemon = (?:cyrus/)?(?:imap(d|s)?|pop3(d|s)?)
 
-failregex = ^%(__prefix_line)sbadlogin: \S+ ?\[<HOST>\] \S+ .*?\[?SASL\(-13\): (authentication failure|user not found): .*\]?$
+failregex = ^%(__prefix_line)sbadlogin: [^\[]*\[<HOST>\] \S+ .*?\[?SASL\(-13\): (authentication failure|user not found): .*\]?$
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/cyrus-imap
+++ b/fail2ban/tests/files/logs/cyrus-imap
@@ -16,3 +16,6 @@ Dec 30 16:03:27 somehost imapd[2517]: badlogin: local-somehost[1.2.3.4] OTP [SAS
 Jul 17 22:55:56 derry cyrus/imaps[7568]: badlogin: serafinat.xxxxxx [1.2.3.4] plain [SASL(-13): user not found: user: pressy@derry property: cmusaslsecretPLAIN not found in sasldb]
 # failJSON: { "time": "2005-07-18T16:46:42", "match": true , "host": "1.2.3.4" }
 Jul 18 16:46:42 derry cyrus/imaps[27449]: badlogin: serafinat.xxxxxx [1.2.3.4] PLAIN [SASL(-13): user not found: Password verification failed]
+
+# failJSON: { "time": "2005-03-08T05:25:21", "match": true , "host": "192.0.2.4", "desc": "entry without loginname/hostname before IP" }
+Mar  8 05:25:21 host imap[22130]: badlogin: [192.0.2.4] plain [SASL(-13): authentication failure: Password verification failed]


### PR DESCRIPTION
Closes #1707