### PR TITLE
More specific configuration file to FreeBSD OS and ipfw

### DIFF
--- a/config/action.d/freebsd-ipfw.conf
+++ b/config/action.d/freebsd-ipfw.conf
@@ -1,0 +1,99 @@
+# Fail2Ban configuration file
+#
+# This file was created to provide ipfw with a configuration for FreeBSD
+# as flexible as possible
+# Author:	Nilton J. Rizzo
+#
+#
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed once at the start of Fail2Ban.
+# Values:  CMD
+#
+actionstart = 
+
+
+# Option:  actionstop
+# Notes.:  command executed once at the end of Fail2Ban
+# Values:  CMD
+#
+actionstop =  ipfw delete <rulenumber>
+
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+actioncheck = 
+
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+#actionban = ipfw add <rulenumber> <blocktype> <proto> from <ip> to <localhost> dst-port <port> in via <nic> 
+actionban = ipfw add <rulenumber> <blocktype> <proto> from <ip> to <localhost> <port>
+
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionunban = ipfw delete `ipfw list | grep -i "[^0-9]<ip>[^0-9]" | awk '{print $1;}'`
+
+[Init]
+
+# Option:  port
+# Notes.:  specifies port to monitor
+# Values:  [ NUM | STRING ]
+#
+port = ssh
+
+# Option:  localhost
+# Notes.:  the local IP address of the network interface
+# Values:  IP
+#
+#localhost = me # first nic on system
+localhost = 127.0.0.1
+
+
+# Option:  blocktype
+# Notes.:  How to block the traffic. Use a action from man 5 ipfw
+#          Common values: deny, unreach port, reset
+# Values:  STRING
+#
+blocktype = deny
+
+
+# Option:  rulenumber
+# Notes.:  Number of set of rules.  IPFW can manipulate some rules on the same number rule
+#          Common values: 10000
+# Values:  NUM
+#
+rulenumber = 10000
+
+
+
+# Option:  proto
+# Notes.:  Name of protocoll under rule
+#          Common values: tcp, udp, all, ip
+#				see ipfw man page
+# Values:  STRING
+#
+proto = ip   
+
+
+
+# Option:  nic
+# Notes.:  Name of network inteface, see /etc/rc.conf
+#          Common values: em0, re0, ....
+#				see /usr/src/sys/{ARCH}/conf/LINT for all nic names
+# Values:  STRING
+#
+nic = 

--- a/config/action.d/freebsd-ipfw.conf
+++ b/config/action.d/freebsd-ipfw.conf
@@ -19,7 +19,10 @@ actionstart =
 # Notes.:  command executed once at the end of Fail2Ban
 # Values:  CMD
 #
-actionstop =  ipfw delete <rulenumber>
+#actionstop =  ipfw delete <rulenumber>
+actionstop =  a=$((<rulenumber>+<numberofrules>)); e=`ipfw show <rulenumber>-$a
+| wc -l` ; r=`ipfw delete <rulenumber>-$a` ; g=`ipfw show <rulenumber>-$a | wc -
+l `
 
 
 # Option:  actioncheck
@@ -36,8 +39,10 @@ actioncheck =
 # Values:  CMD
 #
 #actionban = ipfw add <rulenumber> <blocktype> <proto> from <ip> to <localhost> dst-port <port> in via <nic> 
-actionban = ipfw add <rulenumber> <blocktype> <proto> from <ip> to <localhost> <port>
-
+#actionban = ipfw add <rulenumber> <blocktype> <proto> from <ip> to <localhost> <port>
+actionban = a=$((<rulenumber>+<numberofrules>)); e=`ipfw show <rulenumber>-$a |
+wc -l` ; r=$(($e+<rulenumber>)) ; i=`ipfw add $r <blocktype> <proto> from <ip> t
+o <localhost> <port> in via <nic>`
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -59,8 +64,9 @@ port = ssh
 # Notes.:  the local IP address of the network interface
 # Values:  IP
 #
-#localhost = me # first nic on system
 localhost = 127.0.0.1
+# first nic on system
+localhost = me 
 
 
 # Option:  blocktype
@@ -78,6 +84,16 @@ blocktype = deny
 #
 rulenumber = 10000
 
+# Option:  numberofrules
+# Notes.:  Numbers of rules.  IPFW can manipulate some rules on
+#               the same rule number , but when unban action the 
+#               ipfw will delete all rules with same number.  
+#               With numberofrules we can define a set of rules 
+#               ipfw can use.
+#          Common values: 20000
+# Values:  NUM
+#
+numberofrules = 20000
 
 
 # Option:  proto


### PR DESCRIPTION
HI,

I wrote this to more specific on FreeBSD OS and IPFW
I created some new variables, because on my system 
when I ran this by first time, create some problems, like
putting a new rule after the last deny rule.

I suggest this variables names to add more functionalities

rulenumber    - rule number under all ban IPs will be
nic                  - nic name on no default  network interface
proto               - to choice a better protocol (tcp, udp or both, or others)

TIA

Nilton J. Rizzo

