### PR TITLE
0.10 grave fix escape tags

### DIFF
--- a/fail2ban/client/configparserinc.py
+++ b/fail2ban/client/configparserinc.py
@@ -200,13 +200,16 @@ after = 1.conf
 	def get_sections(self):
 		return self._sections
 
-	def options(self, section, onlyOwn=False):
-		"""Return a list of option names for the given section name."""
+	def options(self, section, withDefault=True):
+		"""Return a list of option names for the given section name.
+
+		Parameter `withDefault` controls the include of names from section `[DEFAULT]`
+		"""
 		try:
 			opts = self._sections[section]
 		except KeyError:
 			raise NoSectionError(section)
-		if not onlyOwn:
+		if withDefault:
 			# mix it with defaults:
 			return set(opts.keys()) | set(self._defaults)
 		# only own option names:

--- a/fail2ban/client/configparserinc.py
+++ b/fail2ban/client/configparserinc.py
@@ -32,7 +32,7 @@ from ..helpers import getLogger
 if sys.version_info >= (3,2):
 
 	# SafeConfigParser deprecated from Python 3.2 (renamed to ConfigParser)
-	from configparser import ConfigParser as SafeConfigParser, \
+	from configparser import ConfigParser as SafeConfigParser, NoSectionError, \
 		BasicInterpolation
 
 	# And interpolation of __name__ was simply removed, thus we need to
@@ -60,7 +60,7 @@ if sys.version_info >= (3,2):
 				parser, option, accum, rest, section, map, depth)
 
 else: # pragma: no cover
-	from ConfigParser import SafeConfigParser
+	from ConfigParser import SafeConfigParser, NoSectionError
 
 # Gets the instance of the logger.
 logSys = getLogger(__name__)
@@ -199,6 +199,18 @@ after = 1.conf
 
 	def get_sections(self):
 		return self._sections
+
+	def options(self, section, onlyOwn=False):
+		"""Return a list of option names for the given section name."""
+		try:
+			opts = self._sections[section]
+		except KeyError:
+			raise NoSectionError(section)
+		if not onlyOwn:
+			# mix it with defaults:
+			return set(opts.keys()) | set(self._defaults)
+		# only own option names:
+		return opts.keys()
 
 	def read(self, filenames, get_includes=True):
 		if not isinstance(filenames, list):

--- a/fail2ban/client/configreader.py
+++ b/fail2ban/client/configreader.py
@@ -109,33 +109,40 @@ class ConfigReader():
 			self._cfg = ConfigReaderUnshared(**self._cfg_share_kwargs)
 
 	def sections(self):
-		if self._cfg is not None:
+		try:
 			return self._cfg.sections()
-		return []
+		except AttributeError:
+			return []
 
 	def has_section(self, sec):
-		if self._cfg is not None:
+		try:
 			return self._cfg.has_section(sec)
-		return False
+		except AttributeError:
+			return False
 
-	def merge_section(self, *args, **kwargs):
-		if self._cfg is not None:
-			return self._cfg.merge_section(*args, **kwargs)
-
+	def merge_section(self, section, *args, **kwargs):
+		try:
+			return self._cfg.merge_section(section, *args, **kwargs)
+		except AttributeError:
+			raise NoSectionError(section)
+	
 	def options(self, section, onlyOwn=False):
-		if self._cfg is not None:
+		try:
 			return self._cfg.options(section, onlyOwn)
-		return {}
+		except AttributeError:
+			raise NoSectionError(section)
 
 	def get(self, sec, opt, raw=False, vars={}):
-		if self._cfg is not None:
+		try:
 			return self._cfg.get(sec, opt, raw=raw, vars=vars)
-		return None
+		except AttributeError:
+			raise NoSectionError(sec)
 
-	def getOptions(self, *args, **kwargs):
-		if self._cfg is not None:
-			return self._cfg.getOptions(*args, **kwargs)
-		return {}
+	def getOptions(self, section, *args, **kwargs):
+		try:
+			return self._cfg.getOptions(section, *args, **kwargs)
+		except AttributeError:
+			raise NoSectionError(section)
 
 
 class ConfigReaderUnshared(SafeConfigParserWithIncludes):

--- a/fail2ban/client/configreader.py
+++ b/fail2ban/client/configreader.py
@@ -126,9 +126,13 @@ class ConfigReader():
 		except AttributeError:
 			raise NoSectionError(section)
 	
-	def options(self, section, onlyOwn=False):
+	def options(self, section, withDefault=False):
+		"""Return a list of option names for the given section name.
+
+		Parameter `withDefault` controls the include of names from section `[DEFAULT]`
+		"""
 		try:
-			return self._cfg.options(section, onlyOwn)
+			return self._cfg.options(section, withDefault)
 		except AttributeError:
 			raise NoSectionError(section)
 
@@ -317,7 +321,7 @@ class DefinitionInitConfigReader(ConfigReader):
 		if self.has_section("Init"):
 			# get only own options (without options from default):
 			getopt = lambda opt: self.get("Init", opt)
-			for opt in self.options("Init", onlyOwn=True):
+			for opt in self.options("Init", withDefault=False):
 				if opt == '__name__': continue
 				v = None
 				if not opt.startswith('known/'):

--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -139,11 +139,11 @@ class JailReader(ConfigReader):
 					filterName, self.__name, filterOpt, 
 					share_config=self.share_config, basedir=self.getBaseDir())
 				ret = self.__filter.read()
-				# merge options from filter as 'known/...':
-				self.__filter.getOptions(self.__opts)
-				ConfigReader.merge_section(self, self.__name, self.__filter.getCombined(), 'known/')
 				if not ret:
 					raise JailDefError("Unable to read the filter %r" % filterName)
+				# merge options from filter as 'known/...' (all options unfiltered):
+				self.__filter.getOptions(self.__opts, all=True)
+				ConfigReader.merge_section(self, self.__name, self.__filter.getCombined(), 'known/')
 			else:
 				self.__filter = None
 				logSys.warning("No filter set for jail %s" % self.__name)

--- a/fail2ban/server/action.py
+++ b/fail2ban/server/action.py
@@ -453,7 +453,7 @@ class CommandAction(ActionBase):
 		return value
 
 	@classmethod
-	def replaceTag(cls, query, aInfo, conditional='', cache=None, substRec=True):
+	def replaceTag(cls, query, aInfo, conditional='', cache=None):
 		"""Replaces tags in `query` with property values.
 
 		Parameters
@@ -481,9 +481,8 @@ class CommandAction(ActionBase):
 		# **Important**: don't replace if calling map - contains dynamic values only,
 		# no recursive tags, otherwise may be vulnerable on foreign user-input:
 		noRecRepl = isinstance(aInfo, CallingMap)
-		if noRecRepl:
-			subInfo = aInfo
-		else:
+		subInfo = aInfo
+		if not noRecRepl:
 			# substitute tags recursive (and cache if possible),
 			# first try get cached tags dictionary:
 			subInfo = csubkey = None
@@ -534,12 +533,49 @@ class CommandAction(ActionBase):
 					"unexpected too long replacement interpolation, "
 					"possible self referencing definitions in query: %s" % (query,))
 
-
 		# cache if possible:
 		if cache is not None:
 			cache[ckey] = value
 		#
 		return value
+
+	@classmethod
+	def replaceDynamicTags(cls, realCmd, aInfo):
+		"""Replaces dynamical tags in `query` with property values.
+
+		**Important**
+		-------------
+		Because this tags are dynamic resp. foreign (user) input:
+		  - values should be escaped
+		  - no recursive substitution (no interpolation for <a<b>>)
+		  - don't use cache
+
+		Parameters
+		----------
+		query : str
+			String with tags.
+		aInfo : dict
+			Tags(keys) and associated values for substitution in query.
+
+		Returns
+		-------
+		str
+			shell script as string or array with tags replaced (direct or as variables).
+		"""
+		realCmd = cls.replaceTag(realCmd, aInfo, conditional=False)
+		# Replace ticket options (filter capture groups) non-recursive:
+		if '<' in realCmd:
+			tickData = aInfo.get("F-*")
+			if not tickData: tickData = {}
+			def substTag(m):
+				tn = mapTag2Opt(m.groups()[0])
+				try:
+					return str(tickData[tn])
+				except KeyError:
+					return ""
+			
+			realCmd = FCUSTAG_CRE.sub(substTag, realCmd)
+		return realCmd
 
 	def _processCmd(self, cmd, aInfo=None, conditional=''):
 		"""Executes a command with preliminary checks and substitutions.
@@ -605,21 +641,9 @@ class CommandAction(ActionBase):
 		realCmd = self.replaceTag(cmd, self._properties, 
 			conditional=conditional, cache=self.__substCache)
 
-		# Replace dynamical tags (don't use cache here)
+		# Replace dynamical tags, important - don't cache, no recursion and auto-escape here
 		if aInfo is not None:
-			realCmd = self.replaceTag(realCmd, aInfo, conditional=conditional)
-			# Replace ticket options (filter capture groups) non-recursive:
-			if '<' in realCmd:
-				tickData = aInfo.get("F-*")
-				if not tickData: tickData = {}
-				def substTag(m):
-					tn = mapTag2Opt(m.groups()[0])
-					try:
-						return str(tickData[tn])
-					except KeyError:
-						return ""
-				
-				realCmd = FCUSTAG_CRE.sub(substTag, realCmd)
+			realCmd = self.replaceDynamicTags(realCmd, aInfo)
 		else:
 			realCmd = cmd
 
@@ -653,8 +677,5 @@ class CommandAction(ActionBase):
 			logSys.debug("Nothing to do")
 			return True
 
-		_cmd_lock.acquire()
-		try:
+		with _cmd_lock:
 			return Utils.executeCmd(realCmd, timeout, shell=True, output=False, **kwargs)
-		finally:
-			_cmd_lock.release()

--- a/fail2ban/server/actions.py
+++ b/fail2ban/server/actions.py
@@ -290,6 +290,7 @@ class Actions(JailThread, Mapping):
 
 		AI_DICT = {
 			"ip":				lambda self: self.__ticket.getIP(),
+			"family":   lambda self: self['ip'].familyStr,
 			"ip-rev":		lambda self: self['ip'].getPTR(''),
 			"ip-host":	lambda self: self['ip'].getHost(),
 			"fid":			lambda self: self.__ticket.getID(),

--- a/fail2ban/server/ipdns.py
+++ b/fail2ban/server/ipdns.py
@@ -261,6 +261,11 @@ class IPAddr(object):
 	def family(self):
 		return self._family
 
+	FAM2STR = {socket.AF_INET: 'inet4', socket.AF_INET6: 'inet6'}
+	@property
+	def familyStr(self):
+		return IPAddr.FAM2STR.get(self._family)
+
 	@property
 	def plen(self):
 		return self._plen

--- a/fail2ban/server/utils.py
+++ b/fail2ban/server/utils.py
@@ -319,7 +319,7 @@ class Utils():
 				return e.errno == errno.EPERM
 			else:
 				return True
-	else:
+	else: # pragma : no cover (no windows currently supported)
 		@staticmethod
 		def pid_exists(pid):
 			import ctypes

--- a/fail2ban/server/utils.py
+++ b/fail2ban/server/utils.py
@@ -60,6 +60,7 @@ class Utils():
 	DEFAULT_SLEEP_TIME = 2
 	DEFAULT_SLEEP_INTERVAL = 0.2
 	DEFAULT_SHORT_INTERVAL = 0.001
+	DEFAULT_SHORTEST_INTERVAL = DEFAULT_SHORT_INTERVAL / 100
 
 
 	class Cache(object):
@@ -183,8 +184,8 @@ class Utils():
 				def _popen_wait_end():
 					retcode = popen.poll()
 					return (True, retcode) if retcode is not None else None
-				# popen.poll is fast operation so we can put down the sleep interval:
-				retcode = Utils.wait_for(_popen_wait_end, timeout, Utils.DEFAULT_SHORT_INTERVAL / 100)
+				# popen.poll is fast operation so we can use the shortest sleep interval:
+				retcode = Utils.wait_for(_popen_wait_end, timeout, Utils.DEFAULT_SHORTEST_INTERVAL)
 				if retcode:
 					retcode = retcode[1]
 			# if timeout:

--- a/fail2ban/tests/actiontestcase.py
+++ b/fail2ban/tests/actiontestcase.py
@@ -389,6 +389,23 @@ class CommandActionTest(LogCaptureTestCase):
 		self.assertLogged('Nothing to do')
 		self.pruneLog()
 
+	def testExecuteWithVars(self):
+		self.assertTrue(self.__action.executeCmd(
+			r'''printf %b "foreign input:\n'''
+			r''' -- $f2bV_A --\n'''
+			r''' -- $f2bV_B --\n'''
+			r''' -- $(echo $f2bV_C) --''' # echo just replaces \n to test it as single line
+			r'''"''', 
+			varsDict={
+			'f2bV_A': 'I\'m a hacker; && $(echo $f2bV_B)', 
+			'f2bV_B': 'I"m very bad hacker', 
+			'f2bV_C': '`Very | very\n$(bad & worst hacker)`'
+		}))
+		self.assertLogged(r"""foreign input:""",
+			' -- I\'m a hacker; && $(echo $f2bV_B) --',
+			' -- I"m very bad hacker --',
+			' -- `Very | very $(bad & worst hacker)` --', all=True)
+
 	def testExecuteIncorrectCmd(self):
 		CommandAction.executeCmd('/bin/ls >/dev/null\nbogusXXX now 2>/dev/null')
 		self.assertLogged('HINT on 127: "Command not found"')
@@ -400,8 +417,9 @@ class CommandActionTest(LogCaptureTestCase):
 		self.assertFalse(CommandAction.executeCmd('sleep 30', timeout=timeout))
 		# give a test still 1 second, because system could be too busy
 		self.assertTrue(time.time() >= stime + timeout and time.time() <= stime + timeout + 1)
-		self.assertLogged('sleep 30 -- timed out after')
-		self.assertLogged('sleep 30 -- killed with SIGTERM')
+		self.assertLogged('sleep 30', ' -- timed out after', all=True)
+		self.assertLogged(' -- killed with SIGTERM', 
+		                  ' -- killed with SIGKILL')
 
 	def testExecuteTimeoutWithNastyChildren(self):
 		# temporary file for a nasty kid shell script
@@ -457,9 +475,9 @@ class CommandActionTest(LogCaptureTestCase):
 		# Verify that the process itself got killed
 		self.assertTrue(Utils.wait_for(lambda: not pid_exists(cpid), 3))
 		self.assertLogged('my pid ', 'Resource temporarily unavailable')
-		self.assertLogged('timed out')
-		self.assertLogged('killed with SIGTERM', 
-		                  'killed with SIGKILL')
+		self.assertLogged(' -- timed out')
+		self.assertLogged(' -- killed with SIGTERM', 
+		                  ' -- killed with SIGKILL')
 		os.unlink(tmpFilename)
 		os.unlink(tmpFilename + '.pid')
 

--- a/fail2ban/tests/config/filter.d/test.conf
+++ b/fail2ban/tests/config/filter.d/test.conf
@@ -1,6 +1,13 @@
 #[INCLUDES]
 #before = common.conf
 
-[Definition]
-failregex = failure test 1 (filter.d/test.conf) <HOST>
+[DEFAULT]
+_daemon = default
 
+[Definition]
+where = conf
+failregex = failure <_daemon> <one> (filter.d/test.%(where)s) <HOST>
+
+[Init]
+# test parameter, should be overriden in jail by "filter=test[one=1,...]"
+one = *1*

--- a/fail2ban/tests/config/filter.d/test.local
+++ b/fail2ban/tests/config/filter.d/test.local
@@ -2,6 +2,15 @@
 #before = common.conf
 
 [Definition]
+# overwrite default daemon, additionally it should be accessible in jail with "%(known/_daemon)s":
+_daemon = test
+# interpolate previous regex (from test.conf) + new 2nd + dynamical substitution) of "two" an "where":
 failregex = %(known/failregex)s
-            failure test 2 (filter.d/test.local) <HOST>
+            failure %(_daemon)s <two> (filter.d/test.<where>) <HOST>
+# parameter "two" should be specified in jail by "filter=test[..., two=2]"
 
+[Init]
+# this parameter can be used in jail with "%(known/three)s":
+three = 3
+# this parameter "where" does not overwrite "where" in definition of test.conf (dynamical values only):
+where = local

--- a/fail2ban/tests/config/jail.conf
+++ b/fail2ban/tests/config/jail.conf
@@ -15,9 +15,9 @@ ignoreip =
 
 [test-known-interp]
 enabled = true
-filter = test
+filter = test[one=1,two=2]
 failregex = %(known/failregex)s
-            failure test 3 (jail.local) <HOST>
+            failure %(known/_daemon)s %(known/three)s (jail.local) <HOST>
 
 [missinglogfiles]
 enabled = true

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -1679,7 +1679,7 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 				# complain --
 				('j-complain-abuse', 
 					'complain['
-					  'name=%(__name__)s, grepopts="-m 1", grepmax=2, mailcmd="mail -s Hostname: <ip-host> - ",' +
+					  'name=%(__name__)s, grepopts="-m 1", grepmax=2, mailcmd="mail -s \'Hostname: <ip-host>, family: <family>\' - ",' +
 					  # test reverse ip:
 					  'debug=1,' +
 						# 2 logs to test grep from multiple logs:
@@ -1694,14 +1694,14 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 						'testcase01.log:Dec 31 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 87.142.124.10',
 						'testcase01a.log:Dec 31 11:55:01 [sshd] error: PAM: Authentication failure for test from 87.142.124.10',
 						# both abuse mails should be separated with space:
-						'mail -s Hostname: test-host - Abuse from 87.142.124.10 abuse-1@abuse-test-server abuse-2@abuse-test-server',
+						'mail -s Hostname: test-host, family: inet4 - Abuse from 87.142.124.10 abuse-1@abuse-test-server abuse-2@abuse-test-server',
 					),
 					'ip6-ban': (
 						# test reverse ip:
 						'try to resolve 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.abuse-contacts.abusix.org',
 						'Lines containing failures of 2001:db8::1 (max 2)',
 						# both abuse mails should be separated with space:
-						'mail -s Hostname: test-host - Abuse from 2001:db8::1 abuse-1@abuse-test-server abuse-2@abuse-test-server',
+						'mail -s Hostname: test-host, family: inet6 - Abuse from 2001:db8::1 abuse-1@abuse-test-server abuse-2@abuse-test-server',
 					),
 				}),
 			)


### PR DESCRIPTION
* fixed grave vulnerability by wrong escape of tags by executing of shell actions:
  - now all dynamic data (foreign input) will be escaped (if needed)
  - tag escaping implemented via variables mapped to the parameters of the command line:
`action-script ...<matches>...` will be replaced into:
`'f2bV_matches=$0 ... action-script ...$f2bV_matches...' 'matches-value1\n...\nmatches-valueN'`
* bug fix in the config readers: mixing with the init section should affect only own init options (from init section only bypass default section);
