### PR TITLE
0.9 new log level MSG

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -46,6 +46,7 @@ releases.
     - filter.d/domino-smtp: IBM Domino SMTP task (gh-1603)
 
 ### Enhancements
+* Introduced new log-level `MSG` (as INFO-2, equivalent to 18)
 
 
 ver. 0.9.6 (2016/12/10) - stretch-is-coming

--- a/fail2ban/__init__.py
+++ b/fail2ban/__init__.py
@@ -34,7 +34,9 @@ Below derived from:
 	https://mail.python.org/pipermail/tutor/2007-August/056243.html
 """
 
+logging.MSG = logging.INFO - 2
 logging.NOTICE = logging.INFO + 5
+logging.addLevelName(logging.MSG, 'MSG')
 logging.addLevelName(logging.NOTICE, 'NOTICE')
 
 

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -820,7 +820,7 @@ class FileContainer:
 		## sys.stdout.flush()
 		# Compare hash and inode
 		if self.__hash != myHash or self.__ino != stats.st_ino:
-			logSys.info("Log rotation detected for %s" % self.__filename)
+			logSys.log(logging.MSG, "Log rotation detected for %s" % self.__filename)
 			self.__hash = myHash
 			self.__ino = stats.st_ino
 			self.__pos = 0


### PR DESCRIPTION
amend resp. restore of change from 59c35bc44a175a672e084bc30511dfa3436ff052 (gh-129):
- logging of "Log rotation detected" with new MSG level
- introduces new log-level MSG (as INFO-2, 18)
