### PR TITLE
Fixes test_smtp connects to wrong inet (if listening on ::1 instead of 127.0.0.1)

### DIFF
--- a/fail2ban/tests/action_d/test_smtp.py
+++ b/fail2ban/tests/action_d/test_smtp.py
@@ -67,7 +67,7 @@ class SMTPActionTest(unittest.TestCase):
 		port = self.smtpd.socket.getsockname()[1]
 
 		self.action = customActionModule.Action(
-			self.jail, "test", host="127.0.0.1:%i" % port)
+			self.jail, "test", host="localhost:%i" % port)
 
 		## because of bug in loop (see loop in asyncserver.py) use it's loop instead of asyncore.loop:
 		self._active = True


### PR DESCRIPTION
Hi, while running the tests with --no-network, I got errors for `test_smtp`, it seems that it was missing the bit to be skipped under these conditions (although one may find skipping it entirely a bit too harsh)

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue (this is just about tests)
- [ ] **LIST ISSUES** this PR resolves (no user issue related, I can make one if you like)
- [x] **MAKE SURE** this PR doesn't break existing tests (checked with py2/py3 with -fng)
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file (there's none)
