### PR TITLE
fixes default backend handling (as default used value of `known/backe…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -134,6 +134,13 @@ TODO: implementing of options resp. other tasks from PR #1346
         Hence `%z` currently match literal Z|UTC|GMT only (and offset-based), and `%Exz` - all zone 
 	abbreviations.
 * `filter.d/courier-auth.conf`: support failed logins with method only
+* Config reader's: introduced new syntax `%(section/option)s`, in opposite to extended interpolation of
+  python 3 `${section:option}` work with all supported python version in fail2ban and this syntax is 
+  like our another features like `%(known/option)s`, etc. (gh-1750)
+* Variable `default_backend` switched to `%(default/backend)s`, so totally backwards compatible now,
+  but now the setting of parameter `backend` in default section of `jail.local` can overwrite default
+  backend also (see gh-1750). In the future versions parameter `default_backend` can be removed (incompatibility, 
+  possibly some distributions affected).
 
 
 ver. 0.10.0-alpha-1 (2016/07/14) - ipv6-support-etc

--- a/config/paths-common.conf
+++ b/config/paths-common.conf
@@ -7,7 +7,7 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
-default_backend = auto
+default_backend = %(known/backend)s
 
 sshd_log = %(syslog_authpriv)s
 sshd_backend = %(default_backend)s

--- a/config/paths-common.conf
+++ b/config/paths-common.conf
@@ -7,7 +7,7 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
-default_backend = %(known/backend)s
+default_backend = %(default/backend)s
 
 sshd_log = %(syslog_authpriv)s
 sshd_backend = %(default_backend)s

--- a/fail2ban/client/configparserinc.py
+++ b/fail2ban/client/configparserinc.py
@@ -73,11 +73,6 @@ else: # pragma: no cover
 		return self._cp_interpolate_some(option, accum, rest, section, map, *args, **kwargs)
 	SafeConfigParser._interpolate_some = _interpolate_some
 
-try:
-	from configparser import _UNSET
-except ImportError:
-	_UNSET = object()
-
 # Gets the instance of the logger.
 logSys = getLogger(__name__)
 logLevel = 7
@@ -117,7 +112,6 @@ after = 1.conf
 
 	SECTION_NAME = "INCLUDES"
 
-	SECTION_OPT_CRE = re.compile(r'^([\w\-]+)/(.+)$')
 	SECTION_OPTSUBST_CRE = re.compile(r'%\(([\w\-]+/([^\)]+))\)s')
 
 	CONDITIONAL_RE = re.compile(r"^(\w+)(\?.+)$")
@@ -161,7 +155,7 @@ after = 1.conf
 							# fallback to default:
 							try:
 								v = self._defaults[opt]
-							except KeyError:
+							except KeyError: # pragma: no cover
 								continue
 					else:
 						# get raw value of opt in section:
@@ -169,7 +163,7 @@ after = 1.conf
 				else:
 					try:
 						v = self._defaults[opt]
-					except KeyError:
+					except KeyError: # pragma: no cover
 						continue
 				self._defaults[sopt] = v
 				try: # for some python versions need to duplicate it in map-vars also:
@@ -260,18 +254,6 @@ after = 1.conf
 	def get_sections(self):
 		return self._sections
 
-	def get(self, sec, opt, raw=False, vars={}, fallback=_UNSET):
-		try:
-			return SafeConfigParser.get(self, sec, opt, raw=raw, vars=vars)
-		except:
-			sopt = SafeConfigParserWithIncludes.SECTION_OPT_CRE.match(opt)
-			if not sopt: raise
-			sec, opt = sopt.groups()
-			if sec.lower() == 'default':
-				# get default raw value:
-				return self._defaults[opt]
-			return SafeConfigParser.get(self, sec, opt, raw=raw, vars=vars)
-
 	def options(self, section, withDefault=True):
 		"""Return a list of option names for the given section name.
 
@@ -279,7 +261,7 @@ after = 1.conf
 		"""
 		try:
 			opts = self._sections[section]
-		except KeyError:
+		except KeyError: # pragma: no cover
 			raise NoSectionError(section)
 		if withDefault:
 			# mix it with defaults:

--- a/fail2ban/client/configparserinc.py
+++ b/fail2ban/client/configparserinc.py
@@ -117,8 +117,8 @@ after = 1.conf
 
 	SECTION_NAME = "INCLUDES"
 
-	SECTION_OPT_CRE = re.compile(r'^(\w+)/(.+)$')
-	SECTION_OPTSUBST_CRE = re.compile(r'%\((\w+/([^\)]+))\)s')
+	SECTION_OPT_CRE = re.compile(r'^([\w\-]+)/(.+)$')
+	SECTION_OPTSUBST_CRE = re.compile(r'%\(([\w\-]+/([^\)]+))\)s')
 
 	CONDITIONAL_RE = re.compile(r"^(\w+)(\?.+)$")
 

--- a/fail2ban/client/configparserinc.py
+++ b/fail2ban/client/configparserinc.py
@@ -164,8 +164,8 @@ after = 1.conf
 							except KeyError:
 								continue
 					else:
-						# get substituted value of opt in section:
-						v = self.get(sec, opt)
+						# get raw value of opt in section:
+						v = self.get(sec, opt, raw=True)
 				else:
 					try:
 						v = self._defaults[opt]

--- a/fail2ban/client/configreader.py
+++ b/fail2ban/client/configreader.py
@@ -110,7 +110,7 @@ class ConfigReader():
 
 	def sections(self):
 		try:
-			return self._cfg.sections()
+			return (n for n in self._cfg.sections() if n != 'KNOWN')
 		except AttributeError:
 			return []
 

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -162,6 +162,33 @@ c = d ;in line comment
 		self.assertEqual(self.c.get('DEFAULT', 'b'), 'a')
 		self.assertEqual(self.c.get('DEFAULT', 'c'), 'd')
 
+	def testTargetedSectionOptions(self):
+		self.assertFalse(self.c.read('g'))	# nothing is there yet
+		self._write("g.conf", value=None, content="""
+[DEFAULT]
+a = def-a
+b = def-b,a:`%(a)s`
+c = def-c,b:"%(b)s"
+d = def-d-b:"%(known/b)s"
+[jail]
+a = jail-a-%(test/a)s
+b = jail-b-%(test/b)s
+[test]
+a = test-a-%(default/a)s
+b = test-b-%(known/b)s
+""")
+		self.assertTrue(self.c.read('g'))
+		self.assertEqual(self.c.get('test', 'a'), 'test-a-def-a')
+		self.assertEqual(self.c.get('test', 'b'), 'test-b-def-b,a:`test-a-def-a`')
+		self.assertEqual(self.c.get('jail', 'a'), 'jail-a-test-a-def-a')
+		self.assertEqual(self.c.get('jail', 'b'), 'jail-b-test-b-def-b,a:`test-a-def-a`')
+		self.assertEqual(self.c.get('jail', 'c'), 'def-c,b:"jail-b-test-b-def-b,a:`test-a-def-a`"')
+		self.assertEqual(self.c.get('jail', 'd'), 'def-d-b:"def-b,a:`jail-a-test-a-def-a`"')
+		self.assertEqual(self.c.get('test', 'c'), 'def-c,b:"test-b-def-b,a:`test-a-def-a`"')
+		self.assertEqual(self.c.get('test', 'd'),  'def-d-b:"def-b,a:`test-a-def-a`"')
+		self.assertEqual(self.c.get('DEFAULT', 'c'), 'def-c,b:"def-b,a:`def-a`"')
+		self.assertEqual(self.c.get('DEFAULT', 'd'), 'def-d-b:"def-b,a:`def-a`"')
+
 
 class JailReaderTest(LogCaptureTestCase):
 

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -170,24 +170,31 @@ a = def-a
 b = def-b,a:`%(a)s`
 c = def-c,b:"%(b)s"
 d = def-d-b:"%(known/b)s"
+
 [jail]
 a = jail-a-%(test/a)s
 b = jail-b-%(test/b)s
+y = %(test/y)s
+
 [test]
 a = test-a-%(default/a)s
 b = test-b-%(known/b)s
+x = %(test/x)s
+y = %(jail/y)s
 """)
 		self.assertTrue(self.c.read('g'))
 		self.assertEqual(self.c.get('test', 'a'), 'test-a-def-a')
 		self.assertEqual(self.c.get('test', 'b'), 'test-b-def-b,a:`test-a-def-a`')
 		self.assertEqual(self.c.get('jail', 'a'), 'jail-a-test-a-def-a')
-		self.assertEqual(self.c.get('jail', 'b'), 'jail-b-test-b-def-b,a:`test-a-def-a`')
-		self.assertEqual(self.c.get('jail', 'c'), 'def-c,b:"jail-b-test-b-def-b,a:`test-a-def-a`"')
+		self.assertEqual(self.c.get('jail', 'b'), 'jail-b-test-b-def-b,a:`jail-a-test-a-def-a`')
+		self.assertEqual(self.c.get('jail', 'c'), 'def-c,b:"jail-b-test-b-def-b,a:`jail-a-test-a-def-a`"')
 		self.assertEqual(self.c.get('jail', 'd'), 'def-d-b:"def-b,a:`jail-a-test-a-def-a`"')
 		self.assertEqual(self.c.get('test', 'c'), 'def-c,b:"test-b-def-b,a:`test-a-def-a`"')
 		self.assertEqual(self.c.get('test', 'd'),  'def-d-b:"def-b,a:`test-a-def-a`"')
 		self.assertEqual(self.c.get('DEFAULT', 'c'), 'def-c,b:"def-b,a:`def-a`"')
 		self.assertEqual(self.c.get('DEFAULT', 'd'), 'def-d-b:"def-b,a:`def-a`"')
+		self.assertRaises(Exception, self.c.get, 'test', 'x')
+		self.assertRaises(Exception, self.c.get, 'jail', 'y')
 
 
 class JailReaderTest(LogCaptureTestCase):

--- a/man/jail.conf.5
+++ b/man/jail.conf.5
@@ -90,11 +90,16 @@ indicates that the specified file is to be parsed after the current file.
 .RE
 
 Using Python "string interpolation" mechanisms, other definitions are allowed and can later be used within other definitions as %(name)s.
-Additionally fail2ban has an extended interpolation feature named \fB%(known/parameter)s\fR (means last known option with name \fBparameter\fR). This interpolation makes possible to extend a stock filter or jail regexp in .local file (opposite to simply set failregex/ignoreregex that overwrites it), e.g.
+
+Fail2ban has more advanced syntax (similar python extended interpolation). This extended interpolation is using \fB%(section/parameter)s\fR to denote a value from a foreign section.
+.br
+Besides cross section interpolation the value of parameter in \fI[DEFAULT]\fR section can be retrieved with \fB%(default/parameter)s\fR.
+.br
+Fail2ban supports also another feature named \fB%(known/parameter)s\fR (means last known option with name \fBparameter\fR). This interpolation makes possible to extend a stock filter or jail regexp in .local file (opposite to simply set failregex/ignoreregex that overwrites it), e.g.
 
 .RS
 .nf
-baduseragents = IE|wget
+baduseragents = IE|wget|%(my-settings/baduseragents)s
 failregex = %(known/failregex)s
             useragent=%(baduseragents)s
 .fi


### PR DESCRIPTION
* fixes default backend handling (as default used value of `known/backend`, which can now be overridden in default section of jail.local);
* introduces fallback for `known/option`: interpolates missing `known/option` as `option` from default section

Closes issues with `default_backend` introduced in #1225, like #1372, #1554 etc.
Closes gh-1554
