### PR TITLE
Add excludepath config option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,7 +30,7 @@ TODO: implementing of options resp. other tasks from PR #1346
   - fixed using new tag `<ip-host>` (without external command execution)
 * fail2ban-regex: fixed matched output by multi-line (buffered) parsing
 * fail2ban-regex: support for multi-line debuggex URL implemented (gh-422)
-* fixed ipv6-action errors on systems not supporting ipv6 und umgekehrt (gh-1741)
+* fixed ipv6-action errors on systems not supporting ipv6 (gh-1741)
 
 ### New Features
 * New Actions:
@@ -38,6 +38,7 @@ TODO: implementing of options resp. other tasks from PR #1346
 * New Filters:
 
 ### Enhancements
+* Introduced new jail option `excludepath`. Files that match both logpath and excludepath are ignored.
 * Introduced new filter option `prefregex` for pre-filtering using single regular expression (gh-1698);
 * Many times faster and fewer CPU-hungry because of parsing with `maxlines=1`, so without 
   line buffering (scrolling of the buffer-window).

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -303,19 +303,25 @@ class JailReaderTest(LogCaptureTestCase):
 	@with_tmpdir
 	def testGlob(self, d):
 		# Generate few files
-		# regular file
+		# regular files
 		f1 = os.path.join(d, 'f1')
-		open(f1, 'w').close()
-		# dangling link
 		f2 = os.path.join(d, 'f2')
-		os.symlink('nonexisting',f2)
+		open(f1, 'w').close()
+		open(f2, 'w').close()
+		# dangling link
+		f3 = os.path.join(d, 'f3')
+		os.symlink('nonexisting',f3)
+
+		# must be only f1 and f2
+		self.assertEqual(sorted(JailReader._glob(os.path.join(d, '*'), [])), [f1, f2])
 
 		# must be only f1
-		self.assertEqual(JailReader._glob(os.path.join(d, '*')), [f1])
-		# since f2 is dangling -- empty list
-		self.assertEqual(JailReader._glob(f2), [])
-		self.assertLogged('File %s is a dangling link, thus cannot be monitored' % f2)
-		self.assertEqual(JailReader._glob(os.path.join(d, 'nonexisting')), [])
+		self.assertEqual(JailReader._glob(os.path.join(d, '*'), ['*2']), [f1])
+
+		# since f3 is dangling -- empty list
+		self.assertEqual(JailReader._glob(f3, []), [])
+		self.assertLogged('File %s is a dangling link, thus cannot be monitored' % f3)
+		self.assertEqual(JailReader._glob(os.path.join(d, 'nonexisting'), []), [])
 
 	def testCommonFunction(self):
 		c = ConfigReader(share_config={})


### PR DESCRIPTION
Add a new jail option "excludepath". Files that match any logpath pattern and also any excludepath pattern
are ignored. We were looking for a way to exclude certain webserver logs. The "create a new directory with a bunch of symlinks" solution doesn't work well for us. We'd much rather have a blacklist than a whitelist.

```ini
[my-jail]
enabled = true
...
logpath = /var/log/nginx/*-access.log
excludepath = /var/log/nginx/api*
```

The PR does not break compatibility; only the client's jail reader is affected.

Mentioning #796 because it shows up on Google when searching "fail2ban exclude logfiles".