### PR TITLE
don't call setLogTarget from setSyslogSocket when holding the lock

### DIFF
--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -638,9 +638,9 @@ class Server:
 			if self.__syslogSocket == syslogsocket:
 				return True
 			self.__syslogSocket = syslogsocket
-			# Conditionally reload, logtarget depends on socket path when SYSLOG
-			return self.__logTarget != "SYSLOG"\
-				   or self.setLogTarget(self.__logTarget)
+		# Conditionally reload, logtarget depends on socket path when SYSLOG
+		return self.__logTarget != "SYSLOG"\
+			   or self.setLogTarget(self.__logTarget)
 
 	def getLogTarget(self):
 		with self.__loggingLock:


### PR DESCRIPTION
If we do, setLogTarget will wait for the lock, but it will never be released

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
