### PR TITLE
Fix pyinotify directory-based log-rotate

### DIFF
--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -895,7 +895,8 @@ class FileFilter(Filter):
 			# see http://python.org/dev/peps/pep-3151/
 			except IOError as e:
 				logSys.error("Unable to open %s", filename)
-				logSys.exception(e)
+				if e.errno != 2:
+					logSys.exception(e)
 				return False
 			except OSError as e: # pragma: no cover - requires race condition to tigger this
 				logSys.error("Error opening %s", filename)

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -895,7 +895,7 @@ class FileFilter(Filter):
 			# see http://python.org/dev/peps/pep-3151/
 			except IOError as e:
 				logSys.error("Unable to open %s", filename)
-				if e.errno != 2:
+				if e.errno != 2: # errno.ENOENT
 					logSys.exception(e)
 				return False
 			except OSError as e: # pragma: no cover - requires race condition to tigger this

--- a/fail2ban/server/filtergamin.py
+++ b/fail2ban/server/filtergamin.py
@@ -143,6 +143,8 @@ class FilterGamin(FileFilter):
 	# Desallocates the resources used by Gamin.
 
 	def __cleanup(self):
+		if not self.monitor:
+			return
 		for filename in self.getLogPaths():
 			self.monitor.stop_watch(filename)
 		self.monitor = None

--- a/fail2ban/server/filterpyinotify.py
+++ b/fail2ban/server/filterpyinotify.py
@@ -78,7 +78,8 @@ class FilterPyinotify(FileFilter):
 		self.__modified = False
 		# Pyinotify watch manager
 		self.__monitor = pyinotify.WatchManager()
-		self.__watches = dict()
+		self.__watchFiles = dict()
+		self.__watchDirs = dict()
 		self.__pending = dict()
 		self.__pendingChkTime = 0
 		self.__pendingNextTime = 0
@@ -87,44 +88,55 @@ class FilterPyinotify(FileFilter):
 	def callback(self, event, origin=''):
 		logSys.log(7, "[%s] %sCallback for Event: %s", self.jailName, origin, event)
 		path = event.pathname
+		# check watching of this path:
+		isWF = isWD = False
+		if path in self.__watchDirs:
+			isWD = True
+		elif path in self.__watchFiles:
+			isWF = True
+		# fix pyinotify behavior with '-unknown-path' (if target not watched also):
+		if (event.mask & pyinotify.IN_MOVE_SELF and 
+				path.endswith('-unknown-path') and not isWF and not isWD
+		):
+			path = path[:-len('-unknown-path')]
+			isWD = path in self.__watchDirs
+		assumeNoDir = False
 		if event.mask & ( pyinotify.IN_CREATE | pyinotify.IN_MOVED_TO ):
+			# refresh watched dir (may be expected):
+			if isWD:
+				self._refreshWatcher(path, isDir=True)
+				return
 			# skip directories altogether
 			if event.mask & pyinotify.IN_ISDIR:
 				logSys.debug("Ignoring creation of directory %s", path)
 				return
 			# check if that is a file we care about
-			if path not in self.__watches:
+			if not isWF:
 				logSys.debug("Ignoring creation of %s we do not monitor", path)
 				return
-			self._refreshFileWatcher(path)
+			self._refreshWatcher(path)
 		elif event.mask & (pyinotify.IN_IGNORED | pyinotify.IN_MOVE_SELF | pyinotify.IN_DELETE_SELF):
-			# fix pyinotify behavior with '-unknown-path' (if target not watched also):
-			if (event.mask & pyinotify.IN_MOVE_SELF and path not in self.__watches and 
-					path.endswith('-unknown-path')
-			):
-				path = path[:-len('-unknown-path')]
 			# watch was removed for some reasons (log-rotate?):
-			if not os.path.isfile(path):
-				for log in self.getLogs():
-					logpath = log.getFileName()
-					if logpath.startswith(path):
-						# check exists (rotated):
-						if event.mask & pyinotify.IN_MOVE_SELF or not os.path.isfile(logpath):
-							self._addPendingFile(logpath, event)
-						else:
-							path = logpath
-							break
-			if path not in self.__watches:
-				logSys.debug("Ignoring event of %s we do not monitor", path)
-				return
-			if not os.path.isfile(path):
-				if self.containsLogPath(path):
-					self._addPendingFile(path, event)
-				logSys.debug("Ignoring watching/rotation event (%s) for %s", event.maskname, path)
-				return
-			self._refreshFileWatcher(path)
+			assumeNoDir = event.mask & (pyinotify.IN_MOVE_SELF | pyinotify.IN_DELETE_SELF)
+			if isWD and (assumeNoDir or not os.path.isdir(path)):
+				self._addPending(path, event, isDir=True)
+			elif not isWF:
+				for logpath in self.__watchDirs:
+					if logpath.startswith(path + pathsep) and (assumeNoDir or not os.path.isdir(logpath)):
+						self._addPending(logpath, event, isDir=True)
+		# pending file:
+		for logpath in self.__watchFiles:
+			if logpath.startswith(path + pathsep) and (assumeNoDir or not os.path.isfile(logpath)):
+				self._addPending(logpath, event)
+		if isWF and not os.path.isfile(path):
+			self._addPending(path, event)
+			return
 		# do nothing if idle:
 		if self.idle:
+			return
+		# be sure we process a file:
+		if not isWF:
+			logSys.debug("Ignoring event (%s) of %s we do not monitor", event.maskname, path)
 			return
 		self._process_file(path)
 
@@ -143,27 +155,36 @@ class FilterPyinotify(FileFilter):
 			self.failManager.cleanup(MyTime.time())
 		self.__modified = False
 
-	def _addPendingFile(self, path, event):
+	def _addPending(self, path, event, isDir=False):
 		if path not in self.__pending:
-			self.__pending[path] = self.sleeptime / 10;
+			self.__pending[path] = [self.sleeptime / 10, isDir];
+			self.__pendingNextTime = 0
 			logSys.log(logging.MSG, "Log absence detected (possibly rotation) for %s, reason: %s of %s",
 				path, event.maskname, event.pathname)
 
-	def _checkPendingFiles(self):
+	def _delPending(self, path):
+		try:
+			del self.__pending[path]
+		except KeyError: pass
+
+	def _checkPending(self):
 		if self.__pending:
 			ntm = time.time()
 			if ntm > self.__pendingNextTime:
 				found = {}
 				minTime = 60
-				for path, retardTM in self.__pending.iteritems():
+				for path, (retardTM, isDir) in self.__pending.iteritems():
 					if ntm - self.__pendingChkTime > retardTM:
-						if not os.path.isfile(path): # not found - prolong for next time
+						chkpath = os.path.isdir if isDir else os.path.isfile
+						if not chkpath(path): # not found - prolong for next time
 							if retardTM < 60: retardTM *= 2
 							if minTime > retardTM: minTime = retardTM
-							self.__pending[path] = retardTM
+							self.__pending[path][0] = retardTM
 							continue
-						found[path] = 1
-						self._refreshFileWatcher(path)
+						logSys.log(logging.MSG, "Log presence detected for %s %s", 
+							"directory" if isDir else "file", path)
+						found[path] = isDir
+						self._refreshWatcher(path, isDir=isDir)
 				for path in found:
 					try:
 						del self.__pending[path]
@@ -171,24 +192,32 @@ class FilterPyinotify(FileFilter):
 				self.__pendingChkTime = time.time()
 				self.__pendingNextTime = self.__pendingChkTime + minTime
 				# process now because we'he missed it in monitoring:
-				for path in found:
-					self._process_file(path)
+				for path, isDir in found.iteritems():
+					if not isDir:
+						self._process_file(path)
 
-	def _refreshFileWatcher(self, oldPath, newPath=None):
+	def _refreshWatcher(self, oldPath, newPath=None, isDir=False):
+		if not newPath: newPath = oldPath
 		# we need to substitute the watcher with a new one, so first
-		# remove old one
-		self._delFileWatcher(oldPath)
-		# place a new one
-		self._addFileWatcher(newPath or oldPath)
+		# remove old one and then place a new one
+		if not isDir:
+			self._delFileWatcher(oldPath)
+			self._addFileWatcher(newPath)
+		else:
+			self._delDirWatcher(oldPath)
+			self._addDirWatcher(newPath)
 
 	def _addFileWatcher(self, path):
+		# we need to watch also the directory for IN_CREATE
+		self._addDirWatcher(dirname(path))
+		# add file watcher:
 		wd = self.__monitor.add_watch(path, pyinotify.IN_MODIFY)
-		self.__watches.update(wd)
+		self.__watchFiles.update(wd)
 		logSys.debug("Added file watcher for %s", path)
 
 	def _delFileWatcher(self, path):
 		try:
-			wdInt = self.__watches.pop(path)
+			wdInt = self.__watchFiles.pop(path)
 			wd = self.__monitor.rm_watch(wdInt)
 			if wd[wdInt]:
 				logSys.debug("Removed file watcher for %s", path)
@@ -197,21 +226,30 @@ class FilterPyinotify(FileFilter):
 			pass
 		return False
 
+	def _addDirWatcher(self, path_dir):
+		# Add watch for the directory:
+		if path_dir not in self.__watchDirs:
+			self.__watchDirs.update(
+				self.__monitor.add_watch(path_dir, pyinotify.IN_CREATE | 
+					pyinotify.IN_MOVED_TO | pyinotify.IN_MOVE_SELF |
+					pyinotify.IN_DELETE_SELF | pyinotify.IN_ISDIR))
+			logSys.debug("Added monitor for the parent directory %s", path_dir)
+
+	def _delDirWatcher(self, path_dir):
+		# Remove watches for the directory:
+		try:
+			wdInt = self.__watchDirs.pop(path_dir)
+			self.__monitor.rm_watch(wdInt)
+		except KeyError: # pragma: no cover
+			pass
+		logSys.debug("Removed monitor for the parent directory %s", path_dir)
+
 	##
 	# Add a log file path
 	#
 	# @param path log file path
 
 	def _addLogPath(self, path):
-		path_dir = dirname(path)
-		if not (path_dir in self.__watches):
-			# we need to watch also  the directory for IN_CREATE
-			self.__watches.update(
-				self.__monitor.add_watch(path_dir, pyinotify.IN_CREATE | 
-					pyinotify.IN_MOVED_TO | pyinotify.IN_MOVE_SELF |
-					pyinotify.IN_DELETE_SELF | pyinotify.IN_ISDIR))
-			logSys.debug("Added monitor for the parent directory %s", path_dir)
-
 		self._addFileWatcher(path)
 		self._process_file(path)
 
@@ -223,18 +261,18 @@ class FilterPyinotify(FileFilter):
 	def _delLogPath(self, path):
 		if not self._delFileWatcher(path):
 			logSys.error("Failed to remove watch on path: %s", path)
+		self._delPending(path)
 
 		path_dir = dirname(path)
-		if not len([k for k in self.__watches
-					if k.startswith(path_dir + pathsep)]):
+		for k in self.__watchFiles:
+			if k.startswith(path_dir + pathsep):
+				path_dir = None
+				break
+		if path_dir:
 			# Remove watches for the directory
 			# since there is no other monitored file under this directory
-			try:
-				wdInt = self.__watches.pop(path_dir)
-				self.__monitor.rm_watch(wdInt)
-			except KeyError: # pragma: no cover
-				pass
-			logSys.debug("Removed monitor for the parent directory %s", path_dir)
+			self._delDirWatcher(path_dir)
+			self._delPending(path_dir)
 
 	# pyinotify.ProcessEvent default handler:
 	def __process_default(self, event):
@@ -247,14 +285,16 @@ class FilterPyinotify(FileFilter):
 
 	# slow check events while idle:
 	def __check_events(self, *args, **kwargs):
-		# check pending files (logrotate ready):
-		self._checkPendingFiles()
-
 		if self.idle:
 			if Utils.wait_for(lambda: not self.active or not self.idle,
 				self.sleeptime * 10, self.sleeptime
 			):
 				pass
+
+		# check pending files/dirs (logrotate ready):
+		if not self.idle:
+			self._checkPending()
+
 		self.ticks += 1
 		return pyinotify.ThreadedNotifier.check_events(self.__notifier, *args, **kwargs)
 

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -957,7 +957,6 @@ def get_monitor_failures_testcase(Filter_):
 			self.file = _copy_lines_between_files(GetFailures.FILENAME_01, self.name,
 												  n=14, mode='w')
 			self._wait4failures()
-			self.assertEqual(self.filter.failManager.getFailTotal(), 2)
 
 			# move aside, but leaving the handle still open...
 			os.rename(self.name, self.name + '.bak')

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -43,7 +43,7 @@ from ..server.failmanager import FailManagerEmpty
 from ..server.ipdns import DNSUtils, IPAddr
 from ..server.mytime import MyTime
 from ..server.utils import Utils, uni_decode
-from .utils import setUpMyTime, tearDownMyTime, mtimesleep, LogCaptureTestCase
+from .utils import setUpMyTime, tearDownMyTime, mtimesleep, with_tmpdir, LogCaptureTestCase
 from .dummyjail import DummyJail
 
 TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "files")
@@ -942,17 +942,21 @@ def get_monitor_failures_testcase(Filter_):
 												  skip=3, mode='w')
 			self.assert_correct_last_attempt(GetFailures.FAILURES_01)
 
-		def test_move_file(self):
-			# if we move file into a new location while it has been open already
-			self.file.close()
-			self.file = _copy_lines_between_files(GetFailures.FILENAME_01, self.name,
-												  n=14, mode='w')
+		def _wait4failures(self, count=2):
 			# Poll might need more time
 			self.assertTrue(self.isEmpty(_maxWaitTime(5)),
 							"Queue must be empty but it is not: %s."
 							% (', '.join([str(x) for x in self.jail.queue])))
 			self.assertRaises(FailManagerEmpty, self.filter.failManager.toBan)
-			Utils.wait_for(lambda: self.filter.failManager.getFailTotal() == 2, _maxWaitTime(10))
+			Utils.wait_for(lambda: self.filter.failManager.getFailTotal() >= count, _maxWaitTime(10))
+			self.assertEqual(self.filter.failManager.getFailTotal(), count)
+
+		def test_move_file(self):
+			# if we move file into a new location while it has been open already
+			self.file.close()
+			self.file = _copy_lines_between_files(GetFailures.FILENAME_01, self.name,
+												  n=14, mode='w')
+			self._wait4failures()
 			self.assertEqual(self.filter.failManager.getFailTotal(), 2)
 
 			# move aside, but leaving the handle still open...
@@ -966,6 +970,34 @@ def get_monitor_failures_testcase(Filter_):
 			_copy_lines_between_files(GetFailures.FILENAME_01, self.name, n=100).close()
 			self.assert_correct_last_attempt(GetFailures.FAILURES_01)
 			self.assertEqual(self.filter.failManager.getFailTotal(), 6)
+
+		@with_tmpdir
+		def test_move_dir(self, tmp):
+			self.file.close()
+			self.filter.delLogPath(self.name)
+			# if we rename parent dir into a new location (simulate directory-base log rotation)
+			tmpsub1 = os.path.join(tmp, "1")
+			tmpsub2 = os.path.join(tmp, "2")
+			os.mkdir(tmpsub1)
+			self.name = os.path.join(tmpsub1, os.path.basename(self.name))
+			os.close(os.open(self.name, os.O_CREAT|os.O_APPEND)); # create empty file
+			self.filter.addLogPath(self.name, autoSeek=False)
+			
+			self.file = _copy_lines_between_files(GetFailures.FILENAME_01, self.name,
+												  skip=12, n=1, mode='w')
+			self.file.close()
+			self._wait4failures(1)
+
+			# rotate whole directory: rename directory 1 as 2:
+			os.rename(tmpsub1, tmpsub2)
+			os.mkdir(tmpsub1)
+			self.file = _copy_lines_between_files(GetFailures.FILENAME_01, self.name,
+												  skip=12, n=1, mode='w')
+			self.file.close()
+			self._wait4failures(2)
+			# stop before tmpdir deleted (just prevents many monitor events)
+			self.filter.stop()
+
 
 		def _test_move_into_file(self, interim_kill=False):
 			# if we move a new file into the location of an old (monitored) file


### PR DESCRIPTION
* Fixed detection of directory-based log-rotation of pyinotify backend.
If directory moved and the target is not watched path, so the monitoring of it could not be continued.
Now fixed with pending files await a monitoring if there (resp. its directories) appears again (respawn).

* Differentiate between watched directories and files (refreshing monitoring of files/dirs expected different flags for watcher).

* Switch from ThreadedNotifier to Notifier:
  - instance of Filter is already a thread;
  - avoid stop of pyinotify processing if an interim error occurs (and breaks main-loop, e. g. during multi-threaded processing by add/remove log-files)

This logic (pending restoration) can be used in observer-thread by the implementation to fix #1379

Closes #1769 