### PR TITLE
IPv6 addresses may overlap

### DIFF
--- a/config/action.d/helpers-common.conf
+++ b/config/action.d/helpers-common.conf
@@ -5,7 +5,7 @@
 #   (printf %%b "Log-excerpt contains 'test':\n"; %(_grep_logs)s; printf %%b "Log-excerpt contains 'test':\n") | mail ...
 #
 _grep_logs = logpath="<logpath>"; grep <grepopts> -E %(_grep_logs_args)s $logpath | <greplimit>
-_grep_logs_args = '(^|[^0-9])<ip>([^0-9]|$)'
+_grep_logs_args = '(^|[^0-9:])<ip>([^0-9:]|$)'
 
 # Used for actions, that should not by executed if ticket was restored:
 _bypass_if_restored = if [ '<restored>' = '1' ]; then exit 0; fi;

--- a/config/action.d/helpers-common.conf
+++ b/config/action.d/helpers-common.conf
@@ -5,7 +5,7 @@
 #   (printf %%b "Log-excerpt contains 'test':\n"; %(_grep_logs)s; printf %%b "Log-excerpt contains 'test':\n") | mail ...
 #
 _grep_logs = logpath="<logpath>"; grep <grepopts> -E %(_grep_logs_args)s $logpath | <greplimit>
-_grep_logs_args = '(^|[^0-9:])<ip>([^0-9:]|$)'
+_grep_logs_args = "(^|[^0-9a-fA-F:])$(echo '<ip>' | sed 's/\./\\./g')([^0-9a-fA-F:]|$)"
 
 # Used for actions, that should not by executed if ticket was restored:
 _bypass_if_restored = if [ '<restored>' = '1' ]; then exit 0; fi;


### PR DESCRIPTION
**This is just my first thought.**

Could it be that there is a colon before/after an IPv4 address in the log?

IPv6 addresses may overlap because of compression.

- 2001:db8:a0b::1
- 2001:db8:a0b::1:12f0
