### PR TITLE
Update postfix filters and tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,10 +22,12 @@ TODO: implementing of options resp. other tasks from PR #1346
     (by using tag `<F-MLFID>` instead of buffering with `maxlines`);
   - optional parameter `mode` rewritten: normal (default), ddos, extra or aggressive (combines all),
     see sshd for regex details)
-* filter.d/sendmail-reject.conf:
+* `filter.d/sendmail-reject.conf`:
   - rewritten using `prefregex` and used MLFID-related multi-line parsing;
   - optional parameter `mode` introduced: normal (default), extra or aggressive
-* filter.d/haproxy-http-auth: do not mistake client port for part of an IPv6 address (gh-1745)
+* `filter.d/haproxy-http-auth`: do not mistake client port for part of an IPv6 address (gh-1745)
+* `filter.d/postfix-sasl.conf`
+    - updated to latest postfix formats
 * `action.d/complain.conf`
   - fixed using new tag `<ip-rev>` (sh/dash compliant now)
 * `action.d/sendmail-geoip-lines.conf`

--- a/THANKS
+++ b/THANKS
@@ -61,6 +61,7 @@ John Thoe
 Jacques Lav!gnotte
 Johannes Weberhofer
 Jason H Martin
+Jeaye Wilkerson
 Jisoo Park
 Joel M Snyder
 Jonathan Kamens

--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -15,11 +15,11 @@ _daemon = postfix(-\w+)?/(?:submission/|smtps/)?smtp[ds]
 prefregex = ^%(__prefix_line)s(?:NOQUEUE: reject:|improper command pipelining) <F-CONTENT>.+</F-CONTENT>$
 
 failregex = ^RCPT from \S+\[<HOST>\]: 554 5\.7\.1 
-            ^RCPT from \S+\[<HOST>\]: 450 4\.7\.1 Client host rejected: cannot find your (reverse )?hostname, (\[\S*\]); from=<\S*> to=<\S+> proto=ESMTP helo=<\S*>
-            ^RCPT from \S+\[<HOST>\]: 450 4\.7\.1 (<\S+>)?: Helo command rejected: Host not found; from=<\S*> to=<\S*> proto=\S+ helo=.*$
-            ^EHLO from \S+\[<HOST>\]: 504 5\.5\.2 <\S+>: Helo command rejected: need fully-qualified hostname;
+            ^RCPT from \S+\[<HOST>\]: 450 4\.7\.1 Client host rejected: cannot find your (reverse )?hostname\b
+            ^RCPT from \S+\[<HOST>\]: 450 4\.7\.1 (<[^>]*>)?: Helo command rejected: Host not found\b
+            ^EHLO from \S+\[<HOST>\]: 504 5\.5\.2 (<[^>]*>)?: Helo command rejected: need fully-qualified hostname\b
             ^VRFY from \S+\[<HOST>\]: 550 5\.1\.1 
-            ^RCPT from \S+\[<HOST>\]: 450 4\.1\.8 <\S*>: Sender address rejected: Domain not found; from=<\S*> to=<\S+> proto=ESMTP helo=<\S*>$
+            ^RCPT from \S+\[<HOST>\]: 450 4\.1\.8 (<[^>]*>)?: Sender address rejected: Domain not found\b
             ^after \S+ from [^[]*\[<HOST>\]:?
 
 ignoreregex = 

--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -15,12 +15,12 @@ _daemon = postfix(-\w+)?/(?:submission/|smtps/)?smtp[ds]
 prefregex = ^%(__prefix_line)s(?:NOQUEUE: reject:|improper command pipelining) <F-CONTENT>.+</F-CONTENT>$
 
 failregex = ^RCPT from \S+\[<HOST>\]: 554 5\.7\.1 
-            ^RCPT from \S+\[<HOST>\]: 450 4\.7\.1 Client host rejected: cannot find your hostname, (\[\S*\]); from=<\S*> to=<\S+> proto=ESMTP helo=<\S*>$
-            ^RCPT from \S+\[<HOST>\]: 450 4\.7\.1 : Helo command rejected: Host not found; from=<> to=<> proto=ESMTP helo= *$
+            ^RCPT from \S+\[<HOST>\]: 450 4\.7\.1 Client host rejected: cannot find your (reverse )?hostname, (\[\S*\]); from=<\S*> to=<\S+> proto=ESMTP helo=<\S*>
+            ^RCPT from \S+\[<HOST>\]: 450 4\.7\.1 (<\S+>)?: Helo command rejected: Host not found; from=<\S*> to=<\S*> proto=\S+ helo=.*$
             ^EHLO from \S+\[<HOST>\]: 504 5\.5\.2 <\S+>: Helo command rejected: need fully-qualified hostname;
             ^VRFY from \S+\[<HOST>\]: 550 5\.1\.1 
             ^RCPT from \S+\[<HOST>\]: 450 4\.1\.8 <\S*>: Sender address rejected: Domain not found; from=<\S*> to=<\S+> proto=ESMTP helo=<\S*>$
-            ^after \S+ from [^[]*\[<HOST>\]:?$
+            ^after \S+ from [^[]*\[<HOST>\]:?
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/postfix
+++ b/fail2ban/tests/files/logs/postfix
@@ -35,3 +35,12 @@ Jan 31 13:55:24 xxx postfix-incoming/smtpd[3462]: NOQUEUE: reject: EHLO from s27
 
 # failJSON: { "time": "2005-04-12T02:24:11", "match": true , "host": "62.138.2.143" }
 Apr 12 02:24:11 xxx postfix/smtps/smtpd[42]: NOQUEUE: reject: EHLO from astra4139.startdedicated.de[62.138.2.143]: 504 5.5.2 <User>: Helo command rejected: need fully-qualified hostname; proto=SMTP helo=<User>
+
+# failJSON: { "time": "2005-06-12T08:58:35", "match": true , "host": "1.2.3.4" }
+Jun 12 08:58:35 xxx postfix/smtpd[27296]: NOQUEUE: reject: RCPT from unknown[1.2.3.4]: 450 4.7.1 Client host rejected: cannot find your reverse hostname, [2.3.4.5]; from=<meow@kitty.com> to=<kitty@meow.com> proto=ESMTP helo=<kitty.com>
+
+# failJSON: { "time": "2005-06-12T08:58:35", "match": true , "host": "1.2.3.4" }
+Jun 12 08:58:35 xxx postfix/smtpd[2931]: NOQUEUE: reject: RCPT from unknown[1.2.3.4]: 450 4.7.1 <kitty.com>: Helo command rejected: Host not found; from=<meow@kitty.com> to=<kitty@meow.com> proto=SMTP helo=<kitty.com>
+
+# failJSON: { "time": "2005-06-12T08:58:35", "match": true , "host": "1.2.3.4" }
+Jun 12 08:58:35 xxx postfix/smtpd[13533]: improper command pipelining after AUTH from unknown[1.2.3.4]: QUIT


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [ ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [X] **CONSIDER adding a unit test** if your PR resolves an issue
- [X] **LIST ISSUES** this PR resolves
- [X] **MAKE SURE** this PR doesn't break existing tests
- [X] **KEEP PR small** so it could be easily reviewed.
- [X] **AVOID** making unnecessary stylistic changes in unrelated code
- [X] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file

These updates are for the latest postfix I'm running on NixOS:

```bash
$ postconf -d | grep mail_version
mail_version = 3.1.3
```
These changes could be backported to `master`. I'm not sure of the estimated release schedule of v0.10.