### PR TITLE
Update iptables actions to cooperate with and give precedence to iptables-persistent

### DIFF
--- a/config/action.d/iptables-allports.conf
+++ b/config/action.d/iptables-allports.conf
@@ -19,7 +19,7 @@ before = iptables-common.conf
 #
 actionstart = <iptables> -N f2b-<name>
               <iptables> -A f2b-<name> -j <returntype>
-              <iptables> -I <chain> -p <protocol> -j f2b-<name>
+              <iptables> -A <chain> -p <protocol> -j f2b-<name>
 
 # Option:  actionstop
 # Notes.:  command executed once at the end of Fail2Ban

--- a/config/action.d/iptables-multiport-log.conf
+++ b/config/action.d/iptables-multiport-log.conf
@@ -21,7 +21,7 @@ before = iptables-common.conf
 #
 actionstart = <iptables> -N f2b-<name>
               <iptables> -A f2b-<name> -j <returntype>
-              <iptables> -I <chain> 1 -p <protocol> -m multiport --dports <port> -j f2b-<name>
+              <iptables> -A <chain> 1 -p <protocol> -m multiport --dports <port> -j f2b-<name>
               <iptables> -N f2b-<name>-log
               <iptables> -I f2b-<name>-log -j LOG --log-prefix "$(expr f2b-<name> : '\(.\{1,23\}\)'):DROP " --log-level warning -m limit --limit 6/m --limit-burst 2
               <iptables> -A f2b-<name>-log -j <blocktype>

--- a/config/action.d/iptables-multiport.conf
+++ b/config/action.d/iptables-multiport.conf
@@ -16,7 +16,7 @@ before = iptables-common.conf
 #
 actionstart = <iptables> -N f2b-<name>
               <iptables> -A f2b-<name> -j <returntype>
-              <iptables> -I <chain> -p <protocol> -m multiport --dports <port> -j f2b-<name>
+              <iptables> -A <chain> -p <protocol> -m multiport --dports <port> -j f2b-<name>
 
 # Option:  actionstop
 # Notes.:  command executed once at the end of Fail2Ban

--- a/config/action.d/iptables-new.conf
+++ b/config/action.d/iptables-new.conf
@@ -18,7 +18,7 @@ before = iptables-common.conf
 #
 actionstart = <iptables> -N f2b-<name>
               <iptables> -A f2b-<name> -j <returntype>
-              <iptables> -I <chain> -m state --state NEW -p <protocol> --dport <port> -j f2b-<name>
+              <iptables> -A <chain> -m state --state NEW -p <protocol> --dport <port> -j f2b-<name>
 
 # Option:  actionstop
 # Notes.:  command executed once at the end of Fail2Ban


### PR DESCRIPTION
The reasoning for this PR is a solution to a problem I ran across and figured it could be useful to others. I use iptables-persistent to manage static iptables entries and allow fail2ban to manage dynamic iptables entries.

The issue I ran across was that the ssh jail i had running was inadvertently banning valid users who, like all humans, fat fingered their credentials once too many. I traced it down to the actionstart for the included files Inserting the jumps into the INPUT chain AFTER iptables-persistent had Inserted rules, and thus causing the potential for a user to unintentionally ban themself if they flubbed credentials and were targetted by fail2ban.

Observed:
```
iptables -nL INPUT
Chain INPUT (policy ACCEPT)
target     prot opt source               destination
f2b-recidive  tcp  --  0.0.0.0/0            0.0.0.0/0           
f2b-sshd   tcp  --  0.0.0.0/0            0.0.0.0/0            multiport dports 22         
ACCEPT     all  --  172.32.0.0/11        0.0.0.0/0           
ACCEPT     all  --  208.54.128.0/19      0.0.0.0/0           
ACCEPT     all  --  208.54.0.0/17        0.0.0.0/0           
ACCEPT     all  --  206.180.38.20        0.0.0.0/0   
```
Desired (and accomplished):
```
iptables -nL INPUT
Chain INPUT (policy ACCEPT)
target     prot opt source               destination
ACCEPT     all  --  172.32.0.0/11        0.0.0.0/0           
ACCEPT     all  --  208.54.128.0/19      0.0.0.0/0           
ACCEPT     all  --  208.54.0.0/17        0.0.0.0/0           
ACCEPT     all  --  206.180.38.20        0.0.0.0/0   
f2b-recidive  tcp  --  0.0.0.0/0            0.0.0.0/0           
f2b-sshd   tcp  --  0.0.0.0/0            0.0.0.0/0            multiport dports 22         
```