### PR TITLE
filter.d/apache-overflows.conf: rewritten without end-anchor ($)…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,9 @@ releases.
 ### Fixes
 * Fix for systemd-backend: fail2ban hits the ulimit (out of file descriptors), see gh-991.
   Partially back-ported from v.0.10.
+* filter.d/apache-overflows.conf:
+    - Fixes resources greedy expression (see gh-1790);
+    - Rewritten without end-anchor ($), because of potential vulnerability on very long URLs.
 
 ### New Features
 

--- a/config/filter.d/apache-overflows.conf
+++ b/config/filter.d/apache-overflows.conf
@@ -8,11 +8,15 @@ before = apache-common.conf
 
 [Definition]
 
-failregex = ^%(_apache_error_client)s ((AH0013[456]: )?Invalid (method|URI) in request .*( - possible attempt to establish SSL connection on non-SSL port)?|(AH00565: )?request failed: URI too long \(longer than \d+\)|request failed: erroneous characters after protocol string: .*|AH00566: request failed: invalid characters in URI)(, referer: \S+)?$
+failregex = ^%(_apache_error_client)s (?:(?:AH0013[456]: )?Invalid (method|URI) in request\b|(?:AH00565: )?request failed: URI too long \(longer than \d+\)|request failed: erroneous characters after protocol string:|(?:AH00566: )?request failed: invalid characters in URI\b)
 
 ignoreregex =
 
 # DEV Notes:
+#
+# [sebres] Because this apache-log could contain very long URLs (and/or referrer), 
+#          the parsing of it anchored way may be very vulnerable (at least as regards 
+#          the system resources, see gh-1790). Thus rewritten without end-anchor ($).
 # 
 # fgrep -r 'URI too long' httpd-2.*
 #   httpd-2.2.25/server/protocol.c:                          "request failed: URI too long (longer than %d)", r->server->limit_req_line);


### PR DESCRIPTION
filter.d/apache-overflows.conf: rewritten without end-anchor ($), because apache-log could contain very long URLs (and/or referrer), the parsing of it anchored way may be very vulnerable (at least as regards the system resources, see gh-1790).

Closes gh-1790