### PR TITLE
bug-fix: restoring of tickets from database for jails with persistent ban

### DIFF
--- a/fail2ban/server/database.py
+++ b/fail2ban/server/database.py
@@ -593,7 +593,7 @@ class Fail2BanDb(object):
 		if ip is not None:
 			query += " AND ip=?"
 			queryArgs.append(ip)
-		if forbantime is not None:
+		if forbantime not in (None, -1): # not specified or persistent (all)
 			query += " AND timeofban > ?"
 			queryArgs.append(fromtime - forbantime)
 		if ip is None:

--- a/fail2ban/tests/databasetestcase.py
+++ b/fail2ban/tests/databasetestcase.py
@@ -358,6 +358,19 @@ class DatabaseTest(LogCaptureTestCase):
 		self.assertEqual(len(tickets), 2)
 		ticket = self.db.getCurrentBans(jail=None, ip="127.0.0.1");
 		self.assertEqual(ticket.getIP(), "127.0.0.1")
+		
+		# positive case (1 ticket not yet expired):
+		tickets = self.db.getCurrentBans(jail=self.jail, forbantime=15,
+			fromtime=MyTime.time())
+		self.assertEqual(len(tickets), 1)
+		# negative case (all are expired in 1year):
+		tickets = self.db.getCurrentBans(jail=self.jail, forbantime=15,
+			fromtime=MyTime.time() + MyTime.str2seconds("1year"))
+		self.assertEqual(len(tickets), 0)
+		# persistent bantime (-1), so never expired:
+		tickets = self.db.getCurrentBans(jail=self.jail, forbantime=-1,
+			fromtime=MyTime.time() + MyTime.str2seconds("1year"))
+		self.assertEqual(len(tickets), 2)
 
 	def testActionWithDB(self):
 		# test action together with database functionality


### PR DESCRIPTION
Fixes restoring of tickets from database for jails with persistent ban (if `bantime = -1`)
Closes gh-1806