### PR TITLE
htaccess.conf: ban IPs using the Deny directive of Apache in htaccess

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@ releases.
 
 ### Enhancements
 * filter.d/kerio.conf - filter extended with new rules (see gh-1455)
+* action.d/htaccess.conf - ban IPs using the Deny directive of Apache in htaccess (gh-1177)
 
 
 ver. 0.9.7 (2017/05/11) - awaiting-victory

--- a/THANKS
+++ b/THANKS
@@ -36,6 +36,7 @@ Daniel B.
 Daniel Black
 David Nutter
 David Reagan (jerrac)
+Denis Pitzalis
 Derek Atkins
 Donald Yandt
 Eric Gerbier

--- a/config/action.d/htaccess.conf
+++ b/config/action.d/htaccess.conf
@@ -1,0 +1,59 @@
+# Fail2Ban configuration file
+# htaccess
+# You can ban IPs using the Deny directive of Apache in your htaccess. 
+# You should add, at the very end of the .htaccess  "Order Deny,Allow"
+# This action will append the "deny" rule at the end of the file.
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed once at the start of Fail2Ban.
+# Values:  CMD
+#
+actionstart =
+
+
+# Option:  actionstop
+# Notes.:  command executed once at the end of Fail2Ban
+# Values:  CMD
+#
+actionstop =
+
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+actioncheck =
+
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    <ip>  IP address
+#          <file>  htaccess
+# Values:  CMD
+# You can have multiple virtual hosts
+#
+actionban = printf %%b "Deny from <ip>\n" >> "<htaccess>"
+#	printf %%b "Deny from <ip>\n" >> "<htaccess2>"
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    <ip>  IP address
+#          <failures>  number of failures
+#          <time>  unix timestamp of the ban time
+# Values:  CMD
+#
+actionunban = sed -i '/Deny from <ip>$/d' "<htaccess>"
+#	sed -i '/Deny from <ip>$/d' "<htaccess2>"
+
+[Init]
+
+# Option:  localhost
+# Notes.:  htaccess file path.
+# Values:  STR Default /var/www/.htaccess
+#
+htaccess = /var/www/.htaccess
+#htaccess2 = /var/www/site2/.htaccess

--- a/config/action.d/htaccess.conf
+++ b/config/action.d/htaccess.conf
@@ -4,26 +4,17 @@
 # You should add, at the very end of the .htaccess  "Order Deny,Allow"
 # This action will append the "deny" rule at the end of the file.
 
+# Usage:
+# action = htaccess
+#          htaccess[htaccess="/var/www/site1/.htaccess"]
+#          htaccess[htaccess="/var/www/site2/.htaccess"]
+
 [Definition]
 
-# Option:  actionstart
-# Notes.:  command executed once at the start of Fail2Ban.
-# Values:  CMD
-#
 actionstart =
-
-
-# Option:  actionstop
-# Notes.:  command executed once at the end of Fail2Ban
-# Values:  CMD
-#
 actionstop =
 
 
-# Option:  actioncheck
-# Notes.:  command executed once before each actionban command
-# Values:  CMD
-#
 actioncheck =
 
 
@@ -31,23 +22,20 @@ actioncheck =
 # Notes.:  command executed when banning an IP. Take care that the
 #          command is executed with Fail2Ban user rights.
 # Tags:    <ip>  IP address
-#          <file>  htaccess
+#          <htaccess>  htaccess file
 # Values:  CMD
 # You can have multiple virtual hosts
 #
 actionban = printf %%b "Deny from <ip>\n" >> "<htaccess>"
-#	printf %%b "Deny from <ip>\n" >> "<htaccess2>"
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
 #          command is executed with Fail2Ban user rights.
 # Tags:    <ip>  IP address
-#          <failures>  number of failures
-#          <time>  unix timestamp of the ban time
+#          <htaccess>  htaccess file
 # Values:  CMD
 #
 actionunban = sed -i '/Deny from <ip>$/d' "<htaccess>"
-#	sed -i '/Deny from <ip>$/d' "<htaccess2>"
 
 [Init]
 
@@ -56,4 +44,3 @@ actionunban = sed -i '/Deny from <ip>$/d' "<htaccess>"
 # Values:  STR Default /var/www/.htaccess
 #
 htaccess = /var/www/.htaccess
-#htaccess2 = /var/www/site2/.htaccess


### PR DESCRIPTION
Ban IPs using the Deny directive of Apache in htaccess.

Previously #1177 (rebased to 0.9, small review)