### PR TITLE
Replace port imap3 with imap

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,8 @@ ver. 0.10.2-dev-1 (2017/??/??) - development edition
   ports are enclosed in curly braces `{ }` in the `jail.local` etc. This may cause a double-brackets now.
 
 ### Fixes
+* jail.conf: port `imap3` replace with `imap` everywhere, since imap3 is not a standard port and old rarely 
+  (if ever) used and missing on some systems (e. g. debian stretch), see gh-1942.
 * action.d/pf.conf: 
   - fixed syntax error in achnor definition (documentation, see gh-1919);
   - enclose ports in braces for multiport jails (see gh-1925);

--- a/ChangeLog
+++ b/ChangeLog
@@ -39,8 +39,8 @@ ver. 0.10.2-dev-1 (2017/??/??) - development edition
   ports are enclosed in curly braces `{ }` in the `jail.local` etc. This may cause a double-brackets now.
 
 ### Fixes
-* jail.conf: port `imap3` replace with `imap` everywhere, since imap3 is not a standard port and old rarely 
-  (if ever) used and missing on some systems (e. g. debian stretch), see gh-1942.
+* jail.conf: port `imap3` replaced with `imap` everywhere, since imap3 is not a standard port and old rarely 
+  (if ever) used and can missing on some systems (e. g. debian stretch), see gh-1942.
 * action.d/pf.conf: 
   - fixed syntax error in achnor definition (documentation, see gh-1919);
   - enclose ports in braces for multiport jails (see gh-1925);

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -622,7 +622,7 @@ logpath = /opt/kerio/mailserver/store/logs/security.log
 
 [courier-auth]
 
-port     = smtp,465,submission,imap,imap3,imaps,pop3,pop3s
+port     = smtp,465,submission,imap,imaps,pop3,pop3s
 logpath  = %(syslog_mail)s
 backend  = %(syslog_backend)s
 
@@ -630,7 +630,7 @@ backend  = %(syslog_backend)s
 [postfix-sasl]
 
 filter   = postfix[mode=auth]
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = smtp,465,submission,imap,imaps,pop3,pop3s
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
 # "warn" level but overall at the smaller filesize.
@@ -640,27 +640,27 @@ backend  = %(postfix_backend)s
 
 [perdition]
 
-port   = imap3,imaps,pop3,pop3s
+port   = imap,imaps,pop3,pop3s
 logpath = %(syslog_mail)s
 backend = %(syslog_backend)s
 
 
 [squirrelmail]
 
-port = smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks
+port = smtp,465,submission,imap,imap2,imaps,pop3,pop3s,http,https,socks
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 
 [cyrus-imap]
 
-port   = imap3,imaps
+port   = imap,imaps
 logpath = %(syslog_mail)s
 backend = %(syslog_backend)s
 
 
 [uwimap-auth]
 
-port   = imap3,imaps
+port   = imap,imaps
 logpath = %(syslog_mail)s
 backend = %(syslog_backend)s
 

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -622,7 +622,7 @@ logpath = /opt/kerio/mailserver/store/logs/security.log
 
 [courier-auth]
 
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = smtp,465,submission,imap,imap3,imaps,pop3,pop3s
 logpath  = %(syslog_mail)s
 backend  = %(syslog_backend)s
 


### PR DESCRIPTION
imap was missing from the list of ports managed by courier-auth, preventing fail2ban from blocking connections on standard IMAP port 143.
