### PR TITLE
Accept new format for filter ejabberd-auth

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -38,6 +38,7 @@ TODO: implementing of options resp. other tasks from PR #1346
     - fixed regex when `X-Real-IP` or/and `X-Forwarded-For` are present after host (gh-1303);
     - fixed regex when logging authentication errors to journal instead to a local file (gh-1159);
     - additionally fixed more complex injections on username (e. g. using dot after fake host).
+* `filter.d/ejabberd-auth.conf`: fixed failregex - accept new log-format (gh-993)
 * `action.d/complain.conf`
   - fixed using new tag `<ip-rev>` (sh/dash compliant now)
 * `action.d/sendmail-geoip-lines.conf`

--- a/config/filter.d/ejabberd-auth.conf
+++ b/config/filter.d/ejabberd-auth.conf
@@ -16,8 +16,8 @@
 #          searched for other failures. This tag can be used multiple times.
 # Values:  TEXT
 #
-failregex = ^=INFO REPORT====  ===\nI\(<0\.\d+\.0>:ejabberd_c2s:\d+\) : \([^)]+\) Failed authentication for .+ from IP <HOST> \({{(?:\d+,){3}\d+},\d+}\)$
-            ^(?:\.\d+)? \[info\] <0\.\d+\.\d>@ejabberd_c2s:wait_for_feature_request:\d+ \([^\)]+\) Failed authentication for \S+ from IP <HOST>$
+failregex = ^=INFO REPORT====  ===\nI\(<0\.\d+\.0>:ejabberd_c2s:\d+\) : \([^)]+\) Failed authentication for \S+ from (?:IP )?<HOST>(?: \({{(?:\d+,){3}\d+},\d+}\))?$
+            ^(?:\.\d+)? \[info\] <0\.\d+\.\d>@ejabberd_c2s:\w+:\d+ \([^\)]+\) Failed authentication for \S+ from (?:IP )?<HOST>$
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.

--- a/fail2ban/tests/files/logs/ejabberd-auth
+++ b/fail2ban/tests/files/logs/ejabberd-auth
@@ -9,3 +9,8 @@ I(<0.370.0>:ejabberd_listener:281) : (#Port<0.6910>) Accepted connection {{192,0
 I(<0.1440.0>:ejabberd_c2s:813) : ({socket_state,tls,{tlssock,#Port<0.6910>,#Port<0.6912>},<0.1439.0>}) Failed authentication for user@example.com from IP 192.0.2.4 ({{192,0,2,4},12716})
 # failJSON: { "time": "2014-01-07T18:09:08", "match": true , "host": "1.2.3.4" }
 2014-01-07 18:09:08.512 [info] <0.22741.1>@ejabberd_c2s:wait_for_feature_request:662 ({socket_state,p1_tls,{tlssock,#Port<0.24718>,#Port<0.24720>},<0.22740.1>}) Failed authentication for test@example.com from IP 1.2.3.4
+
+# new format:
+
+# failJSON: { "time": "2015-03-19T13:57:35", "match": true , "host": "192.0.2.6" }
+2015-03-19 13:57:35.805 [info] <0.585.0>@ejabberd_c2s:wait_for_sasl_response:965 ({socket_state,p1_tls,{tlssock,#Port<0.6434>,#Port<0.6436>},<0.584.0>}) Failed authentication for robin@example.com from 192.0.2.6


### PR DESCRIPTION
`filter.d/ejabberd-auth.conf`: fixed failregex - accept new log-format:
- `wait_for_sasl_response` instead of `wait_for_feature_request` 
- optional part "IP " between `from <HOST>`

Closes gh-993.