### PR TITLE
Fix empty logfile.log in xarf login attack action

### DIFF
--- a/config/action.d/xarf-login-attack.conf
+++ b/config/action.d/xarf-login-attack.conf
@@ -48,9 +48,9 @@ actionban = oifs=${IFS}; IFS=.;SEP_IP=( <ip> ); set -- ${SEP_IP}; ADDRESSES=$(di
             PORT=<port>
             DATE=`LC_ALL=C date --date=@<time> +"%%a, %%d %%h %%Y %%T %%z"`
             if [ ! -z "$ADDRESSES" ]; then
-                (printf -- %%b "<header>\n<message>\n<report>\n";
+                (printf -- %%b "<header>\n<message>\n<report>\n\n";
                  date '+Note: Local timezone is %%z (%%Z)';
-                 printf -- %%b "<ipmatches>\n\n<footer>") | <mailcmd> <mailargs> ${ADDRESSES//,/\" \"}
+                 printf -- %%b "\n<ipmatches>\n\n<footer>") | <mailcmd> <mailargs> ${ADDRESSES//,/\" \"}
             fi
 
 actionunban =


### PR DESCRIPTION
Fix empty 3rd MIME part which contains the attack evidence (logfile.log). We need to separate MIME headers and content with an empty line.

Before submitting your PR, please review the following checklist:

- [X] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
