### PR TITLE
Support ejabberd 17.06 log format

### DIFF
--- a/config/filter.d/ejabberd-auth.conf
+++ b/config/filter.d/ejabberd-auth.conf
@@ -17,7 +17,7 @@
 # Values:  TEXT
 #
 failregex = ^=INFO REPORT====  ===\nI\(<0\.\d+\.0>:ejabberd_c2s:\d+\) : \([^)]+\) Failed authentication for \S+ from (?:IP )?<HOST>(?: \({{(?:\d+,){3}\d+},\d+}\))?$
-            ^(?:\.\d+)? \[info\] <0\.\d+\.\d>@ejabberd_c2s:\w+:\d+ \([^\)]+\) Failed authentication for \S+ from (?:IP )?<HOST>$
+            ^(?:\.\d+)? \[info\] <0\.\d+\.\d>@ejabberd_c2s:\w+:\d+ \([^\)]+\) Failed (?:c2s \w+ )?authentication for \S+ from (?:IP )?(?:::FFFF:)?<HOST>(: .*)?$
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.

--- a/fail2ban/tests/files/logs/ejabberd-auth
+++ b/fail2ban/tests/files/logs/ejabberd-auth
@@ -14,3 +14,7 @@ I(<0.1440.0>:ejabberd_c2s:813) : ({socket_state,tls,{tlssock,#Port<0.6910>,#Port
 
 # failJSON: { "time": "2015-03-19T13:57:35", "match": true , "host": "192.0.2.6" }
 2015-03-19 13:57:35.805 [info] <0.585.0>@ejabberd_c2s:wait_for_sasl_response:965 ({socket_state,p1_tls,{tlssock,#Port<0.6434>,#Port<0.6436>},<0.584.0>}) Failed authentication for robin@example.com from 192.0.2.6
+
+# 17.06 "new" format:
+# failJSON: { "time": "2017-07-29T08:24:04", "match": true , "host": "192.0.2.3" }
+2017-07-29 08:24:04.773 [info] <0.6668.0>@ejabberd_c2s:handle_auth_failure:433 (http_bind|ejabberd_bosh) Failed c2s PLAIN authentication for test@example.ch from ::FFFF:192.0.2.3: Invalid username or password


### PR DESCRIPTION
Current log output looks as follows:
`2017-07-29 08:24:04.773 [info] <0.6668.0>@ejabberd_c2s:handle_auth_failure:433 (http_bind|ejabberd_bosh) Failed c2s PLAIN authentication for test@example.ch from ::FFFF:192.0.2.3: Invalid username or password`

I have not added an entry in the Changelog, as I believe it still matches the description and title from #993 ("new" is relative)