### PR TITLE
Apache <HOST> field can contain several hosts

### DIFF
--- a/config/filter.d/apache-common.conf
+++ b/config/filter.d/apache-common.conf
@@ -27,7 +27,7 @@ _daemon = (?:apache\d*|httpd(?:/\w+)?)
 
 apache-prefix = <apache-prefix-<logging>>
 
-_apache_error_client = <apache-prefix>\[(:?error|\S+:\S+)\]( \[pid \d+(:\S+ \d+)?\])? \[client <HOST>(:\d{1,5})?\]
+_apache_error_client = <apache-prefix>\[(:?error|\S+:\S+)\]( \[pid \d+(:\S+ \d+)?\])? \[client <HOST>(:\d{1,5})?(,[ \d\.]+)*\]
 
 datepattern = {^LN-BEG}
 

--- a/fail2ban/tests/files/logs/apache-auth
+++ b/fail2ban/tests/files/logs/apache-auth
@@ -122,6 +122,9 @@
 # failJSON: { "time": "2013-06-01T02:17:42", "match": true , "host": "192.168.0.2" }
 [Sat Jun 01 02:17:42 2013] [error] [client 192.168.0.2] user root not found
 
+# failJSON: { "time": "2013-06-01T02:17:42", "match": true , "host": "192.168.0.2" }
+[Sat Jun 01 02:17:42 2013] [error] [client 192.168.0.2, 1.2.3.4] user root not found
+
 # failJSON: { "time": "2013-11-18T22:39:33", "match": true , "host": "91.49.82.139" }
 [Mon Nov 18 22:39:33 2013] [error] [client 91.49.82.139] user gg not found: /, referer: http://sj.hopto.org/management.html
 


### PR DESCRIPTION
Hello,

Apache let us configure the `ErrorLogFormat` :
https://httpd.apache.org/docs/2.4/mod/core.html#errorlogformat
In case of a server behind a `ProxyPass` directive, it is then very easy to log the original client IP replacing `%a` by `%{X-Forwarded-For}i` or `%{HTTP_X_FORWARDED_FOR}e`.
This situation can however produce log lines with several addresses :
`[Sat Jun 01 02:17:42 2013] [error] [client 192.168.0.2, 1.2.3.4] user root not found`

This PR then detects this and works on the left-most address, the original client one.

Thank you 👍 

Ben