### PR TITLE
filter.d/dovecot: extend failregex to accept another methods as pam/pwd-file

### DIFF
--- a/config/filter.d/dovecot.conf
+++ b/config/filter.d/dovecot.conf
@@ -15,8 +15,7 @@ prefregex = ^%(__prefix_line)s(%(_auth_worker)s(?:\([^\)]+\))?: )?(?:%(__pam_aut
 failregex = ^authentication failure; logname=\S* uid=\S* euid=\S* tty=dovecot ruser=\S* rhost=<HOST>(?:\s+user=\S*)?\s*$
             ^(?:Aborted login|Disconnected)(?::(?: [^ \(]+)+)? \((?:auth failed, \d+ attempts( in \d+ secs)?|tried to use (disabled|disallowed) \S+ auth)\):( user=<[^>]*>,)?( method=\S+,)? rip=<HOST>(?:, lip=\S+)?(?:, TLS(?: handshaking(?:: SSL_accept\(\) failed: error:[\dA-F]+:SSL routines:[TLS\d]+_GET_CLIENT_HELLO:unknown protocol)?)?(: Disconnected)?)?(, session=<\S+>)?\s*$
             ^pam\(\S+,<HOST>\): pam_authenticate\(\) failed: (User not known to the underlying authentication module: \d+ Time\(s\)|Authentication failure \(password mismatch\?\))\s*$
-            ^(?:pam|passwd-file)\(\S+,<HOST>\): unknown user\s*$
-            ^ldap\(\S*,<HOST>,\S*\): invalid credentials\s*$
+            ^[a-z\-]{3,15}\(\S*,<HOST>(?:,\S*)?\): (?:unknown user|invalid credentials)\s*$
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/dovecot
+++ b/fail2ban/tests/files/logs/dovecot
@@ -40,6 +40,9 @@ Jan 29 05:13:40 mail dovecot: auth-worker(31326): pam(username,1.2.3.4): unknown
 # failJSON: { "time": "2005-01-29T05:13:50", "match": true , "host": "1.2.3.4" }
 Jan 29 05:13:50 mail dovecot: auth: passwd-file(username,1.2.3.4): unknown user
 
+# failJSON: { "time": "2005-01-29T13:54:06", "match": true , "host": "192.0.2.5" }
+Jan 29 13:54:06 auth-worker(22401): Info: sql(admin@example.de,192.0.2.5,<n4JLdHNVngZGpV2j>): unknown user
+
 # failJSON: { "time": "2005-04-19T05:22:20", "match": true , "host": "80.255.3.104" }
 Apr 19 05:22:20 vm5 auth: pam_unix(dovecot:auth): authentication failure; logname= uid=0 euid=0 tty=dovecot ruser=informix rhost=80.255.3.104
 


### PR DESCRIPTION
- Recognizes "unknown user" for additional auth-methods (pam, passwd-file, ldap, sql, etc)
- Simplifying regular expressions (put "unknown user" and "invalid credentials" together as one regex).

Currently the `failregex` of dovecot filter will generate two failures for methods like pam or passwd-file (see gh-1849), once after log-entry `unknown user` and once after `Disconnected (auth failed ...)`.
This PR extends it similar for another methods also... But only for 2 cases ("unknown user" and "invalid credentials"), so I think in this cases the attacker can be banned early (`maxretry / 2`), because of the brute-force resp. penetration tests. 

BTW Made for both versions (0.9/0.10)...