### PR TITLE
Fix fail2ban preferred encoding (ANSI_X3.4-1968 -> UTF-8)

### DIFF
--- a/fail2ban/helpers.py
+++ b/fail2ban/helpers.py
@@ -34,6 +34,10 @@ from .server.mytime import MyTime
 
 
 PREFER_ENC = locale.getpreferredencoding()
+# correct prefered encoding if lang not set in environment:
+if PREFER_ENC.startswith('ANSI_'): # pragma: no cover
+	if all((os.getenv(v) in (None, "") for v in ('LANGUAGE', 'LC_ALL', 'LC_CTYPE', 'LANG'))):
+		PREFER_ENC = 'UTF-8';
 
 
 def formatExceptionInfo():


### PR DESCRIPTION
Avoid using "ANSI_X3.4-1968" as preferred encoding, if missing environment variables 'LANGUAGE', 'LC_ALL', 'LC_CTYPE', and 'LANG' (especially critical if default value `encoding = auto` configured).

As PoC and coverage (this case fails without this "fix"):
```bash
$ env -i PATH="$PATH" bin/fail2ban-testcases -fn testAddBanInvalidEncoded
```

**Note:** Notwithstanding, this fixes many encoding problems, would be a good idea correctly set all expected environment variables for fail2ban daemon in init- resp. systemd-scripts or server configuration.

Closes gh-1587