### PR TITLE
Added filter for phpMyAdmin+syslog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,6 +30,7 @@ releases.
 ### Enhancements
 * action.d/cloudflare.conf - Cloudflare API v4 implementation (gh-1651)
 * filter.d/kerio.conf - filter extended with new rules (see gh-1455)
+* filter.d/phpmyadmin-syslog.conf - new filter for phpMyAdmin using syslog for auth logging
 
 
 ver. 0.9.7 (2017/05/11) - awaiting-victory

--- a/config/filter.d/phpmyadmin-syslog.conf
+++ b/config/filter.d/phpmyadmin-syslog.conf
@@ -1,0 +1,17 @@
+# Fail2Ban fitler for the phpMyAdmin-syslog
+#
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+
+_daemon = phpMyAdmin
+
+failregex = ^%(__prefix_line)suser denied: .* \(mysql-denied\) from <HOST>\s*$
+
+ignoreregex =
+
+
+# Author: Pavel Mihadyuk

--- a/config/filter.d/phpmyadmin-syslog.conf
+++ b/config/filter.d/phpmyadmin-syslog.conf
@@ -9,9 +9,10 @@ before = common.conf
 
 _daemon = phpMyAdmin
 
-failregex = ^%(__prefix_line)suser denied: .* \(mysql-denied\) from <HOST>\s*$
+failregex = ^%(__prefix_line)suser denied: (?:\S+|.*?) \(mysql-denied\) from <HOST>\s*$
 
 ignoreregex =
 
 
 # Author: Pavel Mihadyuk
+# Regex fixes: Serg G. Brester

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -860,3 +860,9 @@ logpath = /var/log/slapd.log
 port    = smtp,ssmtp
 filter  = domino-smtp
 logpath = /home/domino01/data/IBM_TECHNICAL_SUPPORT/console.log
+
+[phpmyadmin-syslog]
+port    = http,https
+filter  = phpmyadmin-syslog
+logpath = %(syslog_authpriv)s
+backend = %(syslog_backend)s

--- a/fail2ban/tests/files/logs/phpmyadmin-syslog
+++ b/fail2ban/tests/files/logs/phpmyadmin-syslog
@@ -1,0 +1,2 @@
+# failJSON: { "time": "2017-08-22T14:50:22", "match": true , "host": "81.62.21.201" }
+Aug 22 14:50:22 eurostream phpMyAdmin[16358]: user denied: root (mysql-denied) from 81.62.21.201

--- a/fail2ban/tests/files/logs/phpmyadmin-syslog
+++ b/fail2ban/tests/files/logs/phpmyadmin-syslog
@@ -1,2 +1,2 @@
-# failJSON: { "time": "2017-08-22T14:50:22", "match": true , "host": "81.62.21.201" }
-Aug 22 14:50:22 eurostream phpMyAdmin[16358]: user denied: root (mysql-denied) from 81.62.21.201
+# failJSON: { "time": "2004-08-22T14:50:22", "match": true , "host": "192.0.2.1" }
+Aug 22 14:50:22 eurostream phpMyAdmin[16358]: user denied: root (mysql-denied) from 192.0.2.1

--- a/fail2ban/tests/files/logs/phpmyadmin-syslog.conf
+++ b/fail2ban/tests/files/logs/phpmyadmin-syslog.conf
@@ -1,0 +1,2 @@
+# failJSON: { "time": "2017-08-22T14:50:22", "match": true , "host": "81.62.21.201" }
+Aug 22 14:50:22 eurostream phpMyAdmin[16358]: user denied: root (mysql-denied) from 81.62.21.201

--- a/fail2ban/tests/files/logs/phpmyadmin-syslog.conf
+++ b/fail2ban/tests/files/logs/phpmyadmin-syslog.conf
@@ -1,2 +1,0 @@
-# failJSON: { "time": "2017-08-22T14:50:22", "match": true , "host": "81.62.21.201" }
-Aug 22 14:50:22 eurostream phpMyAdmin[16358]: user denied: root (mysql-denied) from 81.62.21.201


### PR DESCRIPTION
Added a minor filter for phpMyAdmin>=4.7.0 which now has an ability to log auth-related events via Syslog.
Closes #1713 

P.S. Pretty much unsure about ChangeLog, sorry.