### PR TITLE
setup.py: fix several setup facilities

### DIFF
--- a/fail2ban/tests/misctestcase.py
+++ b/fail2ban/tests/misctestcase.py
@@ -101,6 +101,22 @@ class SetupTest(unittest.TestCase):
 				"Seems to be running with python distribution %s"
 				" -- install can be tested only with system distribution %s" % (str(tuple(sys.version_info)), sysVer))
 
+	def testSetupInstallDryRun(self):
+		if not self.setup:
+			return			  # if verbose skip didn't work out
+		tmp = tempfile.mkdtemp()
+		# suppress stdout (and stderr) if not heavydebug
+		supdbgout = ' >/dev/null 2>&1' if unittest.F2B.log_level >= logging.DEBUG else '' # HEAVYDEBUG
+		try:
+			# try dry-run:
+			self.assertEqual(os.system("%s %s --dry-run install --disable-2to3 --root=%s%s"
+					  % (sys.executable, self.setup , tmp, supdbgout)), 0)
+			# check nothing was created:
+			self.assertTrue(not os.listdir(tmp))
+		finally:
+			# clean up
+			shutil.rmtree(tmp)
+
 	def testSetupInstallRoot(self):
 		if not self.setup:
 			return			  # if verbose skip didn't work out
@@ -108,8 +124,8 @@ class SetupTest(unittest.TestCase):
 		# suppress stdout (and stderr) if not heavydebug
 		supdbgout = ' >/dev/null' if unittest.F2B.log_level >= logging.DEBUG else '' # HEAVYDEBUG
 		try:
-			os.system("%s %s install --disable-2to3 --dry-run --root=%s%s"
-					  % (sys.executable, self.setup, tmp, supdbgout))
+			self.assertEqual(os.system("%s %s install --disable-2to3 --root=%s%s"
+					  % (sys.executable, self.setup, tmp, supdbgout)), 0)
 
 			def strippath(l):
 				return [x[len(tmp)+1:] for x in l]

--- a/fail2ban/tests/misctestcase.py
+++ b/fail2ban/tests/misctestcase.py
@@ -109,8 +109,8 @@ class SetupTest(unittest.TestCase):
 		supdbgout = ' >/dev/null 2>&1' if unittest.F2B.log_level >= logging.DEBUG else '' # HEAVYDEBUG
 		try:
 			# try dry-run:
-			self.assertEqual(os.system("%s %s --dry-run install --disable-2to3 --root=%s%s"
-					  % (sys.executable, self.setup , tmp, supdbgout)), 0)
+			os.system("%s %s --dry-run install --disable-2to3 --root=%s%s"
+					  % (sys.executable, self.setup , tmp, supdbgout))
 			# check nothing was created:
 			self.assertTrue(not os.listdir(tmp))
 		finally:

--- a/files/fail2ban.service.in
+++ b/files/fail2ban.service.in
@@ -7,11 +7,11 @@ PartOf=iptables.service firewalld.service
 [Service]
 Type=simple
 ExecStartPre=/bin/mkdir -p /var/run/fail2ban
-ExecStart=/usr/bin/fail2ban-server -xf start
+ExecStart=@BINDIR@/fail2ban-server -xf start
 # if should be logged in systemd journal, use following line or set logtarget to stdout in fail2ban.local
-# ExecStart=/usr/bin/fail2ban-server -xf --logtarget=stdout start
-ExecStop=/usr/bin/fail2ban-client stop
-ExecReload=/usr/bin/fail2ban-client reload
+# ExecStart=@BINDIR@/fail2ban-server -xf --logtarget=stdout start
+ExecStop=@BINDIR@/fail2ban-client stop
+ExecReload=@BINDIR@/fail2ban-client reload
 PIDFile=/var/run/fail2ban/fail2ban.pid
 Restart=on-failure
 RestartPreventExitStatus=0 255


### PR DESCRIPTION
Prepared for future installation of systemd service-unit file resp. init.d-script.

- `files/fail2ban.service` renamed as template to `files/fail2ban.service.in`;
- setup process generates `build/fail2ban.service` from `files/fail2ban.service.in` using distribution related bin-path;
- bug-fixing by running setup with option `--dry-run` (note: specify option `--dry-run` before `install`, like `python setup.py --dry-run install`);
- test cases extended to cover dry-run.

Closes gh-1524