### PR TITLE
0.10 small optimization & review, config-reader, pretty-dump, etc.

### DIFF
--- a/fail2ban/client/actionreader.py
+++ b/fail2ban/client/actionreader.py
@@ -88,11 +88,11 @@ class ActionReader(DefinitionInitConfigReader):
 		stream.append(head + ["addaction", self._name])
 		multi = []
 		for opt, optval in opts.iteritems():
-			if opt in self._configOpts:
+			if opt in self._configOpts and not opt.startswith('known/'):
 				multi.append([opt, optval])
 		if self._initOpts:
 			for opt, optval in self._initOpts.iteritems():
-				if opt not in self._configOpts:
+				if opt not in self._configOpts and not opt.startswith('known/'):
 					multi.append([opt, optval])
 		if len(multi) > 1:
 			stream.append(["multi-set", self._jailName, "action", self._name, multi])

--- a/fail2ban/client/configparserinc.py
+++ b/fail2ban/client/configparserinc.py
@@ -20,8 +20,8 @@
 # Author: Yaroslav Halchenko
 # Modified: Cyril Jaquier
 
-__author__ = 'Yaroslav Halhenko'
-__copyright__ = 'Copyright (c) 2007 Yaroslav Halchenko'
+__author__ = 'Yaroslav Halhenko, Serg G. Brester (aka sebres)'
+__copyright__ = 'Copyright (c) 2007 Yaroslav Halchenko, 2015 Serg G. Brester (aka sebres)'
 __license__ = 'GPL'
 
 import os
@@ -150,7 +150,7 @@ after = 1.conf
 					if seclwr == 'known':
 						# try get raw value from known options:
 						try:
-							v = self._sections['KNOWN'][opt]
+							v = self._sections['KNOWN/'+section][opt]
 						except KeyError:
 							# fallback to default:
 							try:
@@ -297,7 +297,6 @@ after = 1.conf
 					# merge defaults and all sections to self:
 					alld.update(cfg.get_defaults())
 					for n, s in cfg.get_sections().iteritems():
-						curalls = alls
 						# conditional sections
 						cond = SafeConfigParserWithIncludes.CONDITIONAL_RE.match(n)
 						if cond:
@@ -313,7 +312,7 @@ after = 1.conf
 						s2 = alls.get(n)
 						if isinstance(s2, dict):
 							# save previous known values, for possible using in local interpolations later:
-							self.merge_section('KNOWN', s2, '')
+							self.merge_section('KNOWN/'+n, s2, '')
 							# merge section
 							s2.update(s)
 						else:

--- a/fail2ban/client/configreader.py
+++ b/fail2ban/client/configreader.py
@@ -20,8 +20,8 @@
 # Author: Cyril Jaquier
 # Modified by: Yaroslav Halchenko (SafeConfigParserWithIncludes)
 
-__author__ = "Cyril Jaquier"
-__copyright__ = "Copyright (c) 2004 Cyril Jaquier"
+__author__ = "Cyril Jaquier, Yaroslav Halchenko, Serg G. Brester (aka sebres)"
+__copyright__ = "Copyright (c) 2004 Cyril Jaquier, 2007 Yaroslav Halchenko, 2015 Serg G. Brester (aka sebres)"
 __license__ = "GPL"
 
 import glob
@@ -110,7 +110,7 @@ class ConfigReader():
 
 	def sections(self):
 		try:
-			return (n for n in self._cfg.sections() if n != 'KNOWN')
+			return (n for n in self._cfg.sections() if not n.startswith('KNOWN/'))
 		except AttributeError:
 			return []
 

--- a/fail2ban/client/configurator.py
+++ b/fail2ban/client/configurator.py
@@ -76,9 +76,9 @@ class Configurator:
 		self.__fail2ban.getOptions(updateMainOpt)
 		return self.__jails.getOptions(jail, ignoreWrong=ignoreWrong)
 		
-	def convertToProtocol(self):
+	def convertToProtocol(self, allow_no_files=False):
 		self.__streams["general"] = self.__fail2ban.convert()
-		self.__streams["jails"] = self.__jails.convert()
+		self.__streams["jails"] = self.__jails.convert(allow_no_files=allow_no_files)
 	
 	def getConfigStream(self):
 		cmds = list()

--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -235,9 +235,12 @@ class JailReader(ConfigReader):
 						found_files += 1
 						stream.append(
 							["set", self.__name, "addlogpath", p, tail])
-				if not (found_files or allow_no_files):
-					raise ValueError(
-						"Have not found any log file for %s jail" % self.__name)
+				if not found_files:
+					msg = "Have not found any log file for %s jail" % self.__name
+					if not allow_no_files:
+						raise ValueError(msg)
+					logSys.warning(msg)
+					
 			elif opt == "logencoding":
 				stream.append(["set", self.__name, "logencoding", value])
 			elif opt == "backend":

--- a/fail2ban/tests/fail2banclienttestcase.py
+++ b/fail2ban/tests/fail2banclienttestcase.py
@@ -426,7 +426,11 @@ class Fail2banClientTest(Fail2banClientServerBase):
 		startparams = _start_params(tmp, True)
 		self.execSuccess(startparams, "-vvd")
 		self.assertLogged("Loading files")
-		self.assertLogged("logtarget")
+		self.assertLogged("['set', 'logtarget',")
+		self.pruneLog()
+		# pretty dump:
+		self.execSuccess(startparams, "--dp")
+		self.assertLogged("['set', 'logtarget',")
 		
 	@with_tmpdir
 	@with_kill_srv


### PR DESCRIPTION
* restrict saving of previous known values to section-related (don't overwrite with the values of other sections, especially like "INCLUDES", etc.)

* don't put parameters starting with `known/` to the ready stream (intermediate options only), makes streams and dumps of configuration shorter and better readable

* introduces new command-line options `--dp`, `--dump-pretty` to dump the configuration using more human readable representation;
* allow dump of configuration, also if log-file is not available (warning only)

