### PR TITLE
Fix Gentoo init script's shebang

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,7 +35,7 @@ ver. 0.10.1-dev-1 (2016/??/??) - development edition
 -----------
 
 ### Fixes
-* fix Gentoo init script's shebang to use openrc-run instead of runscript
+* fix Gentoo init script's shebang to use openrc-run instead of runscript (gh-1891)
 * jail "pass2allow-ftp" supply blocktype and returntype parameters to the action (gh-1884)
 * avoid using "ANSI_X3.4-1968" as preferred encoding (if missing environment variables 
   'LANGUAGE', 'LC_ALL', 'LC_CTYPE', and 'LANG', see gh-1587).

--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,7 @@ ver. 0.10.1-dev-1 (2016/??/??) - development edition
 -----------
 
 ### Fixes
+* fix Gentoo init script's shebang to use openrc-run instead of runscript
 * jail "pass2allow-ftp" supply blocktype and returntype parameters to the action (gh-1884)
 * avoid using "ANSI_X3.4-1968" as preferred encoding (if missing environment variables 
   'LANGUAGE', 'LC_ALL', 'LC_CTYPE', and 'LANG', see gh-1587).

--- a/files/gentoo-initd
+++ b/files/gentoo-initd
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # This file is part of Fail2Ban.
 #
 # Fail2Ban is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Use openrc-run instead of runscript.
https://github.com/OpenRC/openrc/commit/5d5856c193768d24f11d5f0533e48c39526aef5c

The current ebuild does it with sed so we might as well fix it upstream:
https://github.com/gentoo/gentoo/commit/48dca3295fe1d9353ecff4e155139aff7deb2351#diff-bebdfc44a2067a248deb151d3547f3c3R44

I hope 0.10 is the right branch to apply my PR to.