### PR TITLE
Fix nftables actions for IPv6 addresses, fixes #1893

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,7 @@ ver. 0.10.1-dev-1 (2016/??/??) - development edition
 -----------
 
 ### Fixes
+* fix nftables actions for IPv6 addresses (gh-1893)
 * fix Gentoo init script's shebang to use openrc-run instead of runscript (gh-1891)
 * jail "pass2allow-ftp" supply blocktype and returntype parameters to the action (gh-1884)
 * avoid using "ANSI_X3.4-1968" as preferred encoding (if missing environment variables 

--- a/ChangeLog
+++ b/ChangeLog
@@ -35,7 +35,6 @@ ver. 0.10.1-dev-1 (2016/??/??) - development edition
 -----------
 
 ### Fixes
-* fix nftables actions for IPv6 addresses (gh-1893)
 * fix Gentoo init script's shebang to use openrc-run instead of runscript (gh-1891)
 * jail "pass2allow-ftp" supply blocktype and returntype parameters to the action (gh-1884)
 * avoid using "ANSI_X3.4-1968" as preferred encoding (if missing environment variables 
@@ -55,6 +54,7 @@ ver. 0.10.1-dev-1 (2016/??/??) - development edition
   human readable representation (opposite to `-d`);
 
 ### Enhancements
+* nftables actions are IPv6-capable now (gh-1893)
 * filter.d/dovecot.conf: introduced mode `aggressive` for cases like "disconnected before auth was ready" (gh-1880)
 
 

--- a/config/action.d/nftables-allports.conf
+++ b/config/action.d/nftables-allports.conf
@@ -17,6 +17,6 @@ before = nftables-common.conf
 # Notes.:  additional expressions for nftables filter rule
 # Values:  nftables expressions
 #
-nftables_mode = ip protocol <protocol>
+nftables_mode = meta l4proto <protocol>
 
 [Init]

--- a/config/action.d/nftables-common.conf
+++ b/config/action.d/nftables-common.conf
@@ -28,11 +28,11 @@ nftables_mode = <protocol> dport \{ <port> \}
 # Notes.:  command executed once at the start of Fail2Ban.
 # Values:  CMD
 #
-actionstart = <nftables> add set <nftables_family> <nftables_table> f2b-<name> \{ type <nftables_type>\; \}
-              <nftables> insert rule <nftables_family> <nftables_table> <chain> %(nftables_mode)s ip saddr @f2b-<name> <blocktype>
+actionstart = <nftables> add set <nftables_family> <nftables_table> <set_name> \{ type <nftables_type>\; \}
+              <nftables> insert rule <nftables_family> <nftables_table> <chain> %(nftables_mode)s <address_family> saddr @<set_name> <blocktype>
 
 _nft_list = <nftables> --handle --numeric list chain <nftables_family> <nftables_table> <chain>
-_nft_get_handle_id = grep -m1 'ip saddr @f2b-<name> <blocktype> # handle' | grep -oe ' handle [0-9]*'
+_nft_get_handle_id = grep -m1 '<address_family> saddr @<set_name> <blocktype> # handle' | grep -oe ' handle [0-9]*'
 
 # Option:  actionstop
 # Notes.:  command executed once at the end of Fail2Ban
@@ -40,13 +40,13 @@ _nft_get_handle_id = grep -m1 'ip saddr @f2b-<name> <blocktype> # handle' | grep
 #
 actionstop = HANDLE_ID=$(%(_nft_list)s | %(_nft_get_handle_id)s)
              <nftables> delete rule <nftables_family> <nftables_table> <chain> $HANDLE_ID
-             <nftables> delete set <nftables_family> <nftables_table> f2b-<name>
+             <nftables> delete set <nftables_family> <nftables_table> <set_name>
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command
 # Values:  CMD
 #
-actioncheck = <nftables> list chain <nftables_family> <nftables_table> <chain> | grep -q '@f2b-<name>[ \t]'
+actioncheck = <nftables> list chain <nftables_family> <nftables_table> <chain> | grep -q '@<set_name>[ \t]'
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
@@ -54,7 +54,7 @@ actioncheck = <nftables> list chain <nftables_family> <nftables_table> <chain> |
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = <nftables> add element <nftables_family> <nftables_table> f2b-<name> \{ <ip> \}
+actionban = <nftables> add element <nftables_family> <nftables_table> <set_name> \{ <ip> \}
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -62,7 +62,7 @@ actionban = <nftables> add element <nftables_family> <nftables_table> f2b-<name>
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionunban = <nftables> delete element <nftables_family> <nftables_table> f2b-<name> \{ <ip> \}
+actionunban = <nftables> delete element <nftables_family> <nftables_table> <set_name> \{ <ip> \}
 
 [Init]
 
@@ -117,3 +117,19 @@ blocktype = reject
 # Notes.:  Actual command to be executed, including common to all calls options
 # Values:  STRING
 nftables = nft
+
+# Option: set_name
+# Notes.: The name of the nft set used to store banned addresses
+# Values: STRING
+set_name = f2b-<name>
+
+# Option: address_family
+# Notes.: The family of the banned addresses
+# Values: [ ip | ip6 ]
+address_family = ip
+
+[Init?family=inet6]
+
+nftables_type = ipv6_addr
+set_name = f2b-<name>6
+address_family = ip6


### PR DESCRIPTION
* add `[Init?family=inet6]` to `nftables-common.conf` and make nftable
  expressions more modular
* change `ip protocol` to `meta l4proto` in `nftables-allports.conf`
  since the former only works for IPv4

Although `meta protocol` and `ip protocol` do not seem to be synonyms to each other, they seem to both work. I've [posted on the netfilter mailing list](https://marc.info/?l=netfilter&m=150516423319129&w=2) to know more about this difference.

@albel727 feel free to review my changes since you wrote the action files.

Closes gh-1893