### PR TITLE
Create nextcloud-auth.conf

### DIFF
--- a/config/filter.d/nextcloud-auth.conf
+++ b/config/filter.d/nextcloud-auth.conf
@@ -1,0 +1,15 @@
+#
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+
+prefregex = ^%(__prefix_line)s<F-CONTENT>.+</F-CONTENT>$
+
+failregex = \{core\} Login failed: '.+' \(Remote IP: '<HOST>'\)
+
+ignoreregex =
+
+journalmatch = SYSLOG_IDENTIFIER=ownCloud


### PR DESCRIPTION
Filter to detect nextcloud (fork of ownCloud) failed auth attempts. Require nextcloud to use syslog (journalctl)

Example of log: journalctl --since '-20m' -o cat  |  grep "Login failed"
  {core} Login failed: 'user_name' (Remote IP: '192.168.0.100')