### PR TITLE
pf.conf: fix multiport syntax …

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -34,7 +34,14 @@ Incompatibility list (compared to v.0.9):
 ver. 0.10.2-dev-1 (2017/??/??) - development edition
 -----------
 
+### Incompatibility list:
+* The configuration for multiport jails using banaction `pf` can be incompatible after upgrade, if
+  ports are enclosed in curly braces `{ }` in the `jail.local` etc. This may cause a double-brackets now.
+
 ### Fixes
+* action.d/pf.conf: 
+  - fixed syntax error in achnor definition (documentation, see gh-1919);
+  - enclose ports in braces for multiport jails (see gh-1925);
 
 ### New Features
 

--- a/config/action.d/pf.conf
+++ b/config/action.d/pf.conf
@@ -110,5 +110,5 @@ allports = any
 # Option: multiport
 # Notes.: addition to block access only to specific ports
 # Usage.: use in jail config: "banaction = pf[actiontype=<multiport>]"
-multiport = any port <port>
+multiport = any port {<port>}
 

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -1503,7 +1503,7 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					'ip4': (), 'ip6': (),
 					'start': (
 						'`echo "table <f2b-j-w-pf> persist counters" | pfctl -a f2b/j-w-pf -f-`',
-						'`echo "block quick proto tcp from <f2b-j-w-pf> to any port <port>" | pfctl -a f2b/j-w-pf -f-`',
+						'`echo "block quick proto tcp from <f2b-j-w-pf> to any port {<port>}" | pfctl -a f2b/j-w-pf -f-`',
 					),
 					'stop': (
 						'`pfctl -a f2b/j-w-pf -sr 2>/dev/null | grep -v f2b-j-w-pf | pfctl -a f2b/j-w-pf -f-`',
@@ -1517,12 +1517,12 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					'ip6-ban':   ("`pfctl -a f2b/j-w-pf -t f2b-j-w-pf -T add 2001:db8::`",),
 					'ip6-unban': ("`pfctl -a f2b/j-w-pf -t f2b-j-w-pf -T delete 2001:db8::`",),
 				}),
-				# pf multiport with custom port --
-				('j-w-pf-mp', 'pf[actiontype=<multiport>][name=%(__name__)s, port=http]', {
+				# pf multiport with custom ports --
+				('j-w-pf-mp', 'pf[actiontype=<multiport>][name=%(__name__)s, port="http,https"]', {
 					'ip4': (), 'ip6': (),
 					'start': (
 						'`echo "table <f2b-j-w-pf-mp> persist counters" | pfctl -a f2b/j-w-pf-mp -f-`',
-						'`echo "block quick proto tcp from <f2b-j-w-pf-mp> to any port http" | pfctl -a f2b/j-w-pf-mp -f-`',
+						'`echo "block quick proto tcp from <f2b-j-w-pf-mp> to any port {http,https}" | pfctl -a f2b/j-w-pf-mp -f-`',
 					),
 					'stop': (
 						'`pfctl -a f2b/j-w-pf-mp -sr 2>/dev/null | grep -v f2b-j-w-pf-mp | pfctl -a f2b/j-w-pf-mp -f-`',


### PR DESCRIPTION
pf.conf: enclose ports in braces, multiple ports expecting this syntax `... any port {http, https}`.

Note this can be backwards-incompatible change (for the people already enclosing multiports in braces in `jail.local`).

Closes #1915
