### PR TITLE
action.d/pf.conf: wildcard anchoring example + bulk-unban with command `actionflush`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -46,6 +46,7 @@ ver. 0.10.2-dev-1 (2017/??/??) - development edition
 ### New Features
 
 ### Enhancements
+* action.d/pf.conf: extended with bulk-unban, command `actionflush` in order to flush all bans at once.
 
 
 ver. 0.10.1 (2017/10/12) - succeeded-before-friday-the-13th

--- a/config/action.d/pf.conf
+++ b/config/action.d/pf.conf
@@ -16,7 +16,9 @@
 # we don't enable PF automatically; to enable run pfctl -e 
 # or add `pf_enable="YES"` to /etc/rc.conf (tested on FreeBSD)
 # also, these rulesets are loaded into (nested) anchors
-# to enable them, add
+# to enable them, add as wildcard:
+#     anchor "f2b/*"
+# or using jail names:
 #     anchor f2b {
 #        anchor name1
 #        anchor name2
@@ -37,8 +39,15 @@ actionstart_on_demand = false
 #
 # we only disable PF rules we've installed prior
 actionstop = <pfctl> -sr 2>/dev/null | grep -v <tablename>-<name> | <pfctl> -f-
-             <pfctl> -t <tablename>-<name> -T flush
+             %(actionflush)s
              <pfctl> -t <tablename>-<name> -T kill
+
+
+# Option:  actionflush
+# Notes.:  command executed once to flush IPS, by shutdown (resp. by stop of the jail or this action)
+# Values:  CMD
+#
+actionflush = <pfctl> -t <tablename>-<name> -T flush
 
 
 # Option:  actioncheck

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -1505,6 +1505,9 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 						'`echo "table <f2b-j-w-pf> persist counters" | pfctl -a f2b/j-w-pf -f-`',
 						'`echo "block quick proto tcp from <f2b-j-w-pf> to any port {<port>}" | pfctl -a f2b/j-w-pf -f-`',
 					),
+					'flush': (
+						'`pfctl -a f2b/j-w-pf -t f2b-j-w-pf -T flush`',
+					),
 					'stop': (
 						'`pfctl -a f2b/j-w-pf -sr 2>/dev/null | grep -v f2b-j-w-pf | pfctl -a f2b/j-w-pf -f-`',
 						'`pfctl -a f2b/j-w-pf -t f2b-j-w-pf -T flush`',
@@ -1523,6 +1526,9 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					'start': (
 						'`echo "table <f2b-j-w-pf-mp> persist counters" | pfctl -a f2b/j-w-pf-mp -f-`',
 						'`echo "block quick proto tcp from <f2b-j-w-pf-mp> to any port {http,https}" | pfctl -a f2b/j-w-pf-mp -f-`',
+					),
+					'flush': (
+						'`pfctl -a f2b/j-w-pf-mp -t f2b-j-w-pf-mp -T flush`',
 					),
 					'stop': (
 						'`pfctl -a f2b/j-w-pf-mp -sr 2>/dev/null | grep -v f2b-j-w-pf-mp | pfctl -a f2b/j-w-pf-mp -f-`',
@@ -1544,6 +1550,9 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 						'`echo "block quick proto tcp from <f2b-j-w-pf-ap> to any" | pfctl -a f2b/j-w-pf-ap -f-`',
 					),
 					'ip6-start': (), # the same as ipv4
+					'flush': (
+						'`pfctl -a f2b/j-w-pf-ap -t f2b-j-w-pf-ap -T flush`',
+					),
 					'stop': (
 						'`pfctl -a f2b/j-w-pf-ap -sr 2>/dev/null | grep -v f2b-j-w-pf-ap | pfctl -a f2b/j-w-pf-ap -f-`',
 						'`pfctl -a f2b/j-w-pf-ap -t f2b-j-w-pf-ap -T flush`',


### PR DESCRIPTION
- example for wildcard anchoring in documentation of pf-action;
- extended with bulk-unban, command `actionflush` in order to flush all bans at once (by stop jail, resp. shutdown of fail2ban) + covered via test-cases;<br/>This makes possible a fast shutdown of jails using the pf-action.