### PR TITLE
gentoo-initd: add descriptions

### DIFF
--- a/files/gentoo-initd
+++ b/files/gentoo-initd
@@ -18,6 +18,9 @@
 # Author: Sireyessire, Cyril Jaquier
 #
 
+description="Daemon to ban hosts that cause multiple authentication errors"
+description_reload="reload configuration"
+description_showlog="show fail2ban logs"
 extra_started_commands="reload showlog"
 
 FAIL2BAN="/usr/bin/fail2ban-client ${FAIL2BAN_OPTIONS}"


### PR DESCRIPTION
add descriptions to stop `syslog` errors for `extra_started_commands` when running:

`rc-service ipset describe`

```
Oct 28 15:13:30 xxxx daemon.warn /etc/init.d/fail2ban[26446]: ^[[1m^[[36mreload^[[m: no description
Oct 28 15:13:30 xxxx daemon.warn /etc/init.d/fail2ban[26447]: ^[[1m^[[36mshowlog^[[m: no description
```
