### PR TITLE
Add some path workarounds to Arch path configuration

### DIFF
--- a/config/paths-arch.conf
+++ b/config/paths-arch.conf
@@ -20,6 +20,15 @@ mysql_log = /var/log/mariadb/mariadb.log
 
 roundcube_errors_log = /var/log/roundcubemail/errors
 
+# Workaround missing variables in jail paths
+syslog_authpriv =
+syslog_mail =
+syslog_mail_warn =
+syslog_user =
+syslog_ftp =
+syslog_daemon =
+syslog_local0 =
+
 # These services will log to the journal via syslog, so use the journal by
 # default.
 syslog_backend = systemd


### PR DESCRIPTION
This avoids errors about missing variables in jail configuration. See downstream report at https://bugs.archlinux.org/task/48540

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
