### PR TITLE
config/paths-*.conf: initial values and normalization

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,8 @@ ver. 0.10.2-dev-1 (2017/??/??) - development edition
 ### Fixes
 * jail.conf: port `imap3` replaced with `imap` everywhere, since imap3 is not a standard port and old rarely 
   (if ever) used and can missing on some systems (e. g. debian stretch), see gh-1942.
+* config/paths-common.conf: added missing initial values (and small normalization in config/paths-*.conf)
+  in order to avoid errors while interpolating (e. g. starting with systemd-backend), see gh-1955.
 * action.d/pf.conf: 
   - fixed syntax error in achnor definition (documentation, see gh-1919);
   - enclose ports in braces for multiport jails (see gh-1925);

--- a/config/paths-common.conf
+++ b/config/paths-common.conf
@@ -9,21 +9,36 @@ after  = paths-overrides.local
 
 default_backend = %(default/backend)s
 
+# Initial common values (to overwrite in path-<distribution>.conf)...
+# There is no sensible generic defaults for syslog log targets, thus
+# leaving them empty here (resp. set to mostly used variant) in order 
+# to avoid errors while parsing/interpolating configs.
+#
+# Note systemd-backend does not need the logpath at all.
+#
+syslog_local0 = /var/log/messages
+
+syslog_authpriv = /var/log/auth.log
+syslog_daemon  = %(syslog_local0)s
+syslog_ftp = %(syslog_local0)s
+syslog_mail =
+syslog_mail_warn =
+syslog_user = %(syslog_local0)s
+
+# Set the default syslog backend target to default_backend
+syslog_backend = %(default_backend)s
+
+# Default values for several jails:
+
 sshd_log = %(syslog_authpriv)s
 sshd_backend = %(default_backend)s
 
 dropbear_log = %(syslog_authpriv)s
 dropbear_backend = %(default_backend)s
 
-# There is no sensible generic defaults for syslog log targets, thus
-# leaving them empty here so that no errors while parsing/interpolating configs
-syslog_daemon =
-syslog_ftp =
-syslog_local0 =
-syslog_mail_warn =
-syslog_user =
-# Set the default syslog backend target to default_backend
-syslog_backend = %(default_backend)s
+apache_error_log = /var/log/apache2/*error.log
+
+apache_access_log = /var/log/apache2/*access.log
 
 # from /etc/audit/auditd.conf
 auditd_log = /var/log/audit/audit.log

--- a/config/paths-debian.conf
+++ b/config/paths-debian.conf
@@ -15,22 +15,11 @@ syslog_mail = /var/log/mail.log
 # syslog_mail_warn = /var/log/mail.warn
 syslog_mail_warn = %(syslog_mail)s
 
-syslog_authpriv = /var/log/auth.log
-
-# syslog_auth = /var/log/auth.log
-#
 syslog_user  =  /var/log/user.log
 
 syslog_ftp = /var/log/syslog
 
 syslog_daemon =  /var/log/daemon.log
-
-syslog_local0 =  /var/log/messages
-
-
-apache_error_log = /var/log/apache2/*error.log
-
-apache_access_log = /var/log/apache2/*access.log
 
 exim_main_log = /var/log/exim4/mainlog
 

--- a/config/paths-fedora.conf
+++ b/config/paths-fedora.conf
@@ -15,15 +15,6 @@ syslog_mail_warn = /var/log/maillog
 
 syslog_authpriv = /var/log/secure
 
-syslog_user =  /var/log/messages
-
-syslog_ftp  = /var/log/messages
-
-syslog_daemon  = /var/log/messages
-
-syslog_local0  = /var/log/messages
-
-
 apache_error_log = /var/log/httpd/*error_log
 
 apache_access_log = /var/log/httpd/*access_log

--- a/config/paths-freebsd.conf
+++ b/config/paths-freebsd.conf
@@ -15,19 +15,10 @@ syslog_mail = /var/log/maillog
 
 syslog_mail_warn = /var/log/maillog
 
-syslog_authpriv = /var/log/auth.log
-
 # note - is only ftp.info - if notice /var/log/messages may be needed
 syslog_ftp = /var/log/xferlog
 
-syslog_daemon = /var/log/messages
-
-syslog_local0 = /var/log/messages
-
 # Linux things
-# we fake to avoid parse error in startups
-
-auditd_log = /dev/null
 
 # http://svnweb.freebsd.org/ports/head/www/apache24/files/patch-docs__conf__extra__httpd-ssl.conf.in?view=markup
 # http://svnweb.freebsd.org/ports/head/www/apache22/files/patch-docs__conf__extra__httpd-ssl.conf.in?view=markup

--- a/config/paths-opensuse.conf
+++ b/config/paths-opensuse.conf
@@ -9,23 +9,11 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
-syslog_local0  = /var/log/messages
-
 syslog_mail = /var/log/mail
 
 syslog_mail_warn = %(syslog_mail)s
 
 syslog_authpriv = %(syslog_local0)s
-
-syslog_user =  %(syslog_local0)s
-
-syslog_ftp  = %(syslog_local0)s
-
-syslog_daemon  = %(syslog_local0)s
-
-apache_error_log = /var/log/apache2/*error_log
-
-apache_access_log = /var/log/apache2/*access_log
 
 pureftpd_log = %(syslog_local0)s
 

--- a/config/paths-osx.conf
+++ b/config/paths-osx.conf
@@ -17,11 +17,11 @@ syslog_mail_warn = /var/log/mail.warn
 syslog_authpriv = /var/log/secure.log
 #syslog_auth = 
 
-#syslog_user = 
+syslog_user = 
 
-#syslog_ftp = 
+syslog_ftp = 
 
-#syslog_daemon = 
+syslog_daemon = 
 
-#syslog_local0 =
+syslog_local0 =
 


### PR DESCRIPTION
config/paths-common.conf: Added initial values for `syslog_authpriv`, `syslog_mail` in order to avoid errors while parsing/interpolating configuration;
Some defaults normalized (minimized configs, don't need to overwrite values in distribution-related path if equal).

Note the systemd-backend does not need the logpath at all;
Replacement for gh-1954

All current configs are backwards-compatible.
Below a bit clearer comparison of all changes:
```diff
***************************
/config/paths-common.conf :
***************************
-syslog_local0 =
+syslog_local0 = /var/log/messages
+syslog_authpriv = /var/log/auth.log
-syslog_daemon =
+syslog_daemon  = %(syslog_local0)s
-syslog_ftp =
+syslog_ftp = %(syslog_local0)s
+syslog_mail =
-syslog_user =
+syslog_user = %(syslog_local0)s

+apache_error_log = /var/log/apache2/*error.log
+apache_access_log = /var/log/apache2/*access.log

***************************
/config/paths-debian.conf :
***************************
-syslog_authpriv = /var/log/auth.log
-syslog_local0 =  /var/log/messages
-apache_error_log = /var/log/apache2/*error.log
-apache_access_log = /var/log/apache2/*access.log

***************************
/config/paths-fedora.conf :
***************************
-syslog_user =  /var/log/messages
-syslog_ftp  = /var/log/messages
-syslog_daemon  = /var/log/messages
-syslog_local0  = /var/log/messages

****************************
/config/paths-freebsd.conf :
****************************
-syslog_authpriv = /var/log/auth.log
-syslog_daemon = /var/log/messages
-syslog_local0 = /var/log/messages
-auditd_log = /dev/null

*****************************
/config/paths-opensuse.conf :
*****************************
-syslog_local0  = /var/log/messages
-syslog_user =  %(syslog_local0)s
-syslog_ftp  = %(syslog_local0)s
-syslog_daemon  = %(syslog_local0)s
-apache_error_log = /var/log/apache2/*error_log
-apache_access_log = /var/log/apache2/*access_log

************************
/config/paths-osx.conf :
************************
-#syslog_user = 
+syslog_user = 
-#syslog_ftp = 
+syslog_ftp = 
-#syslog_daemon = 
+syslog_daemon = 
-#syslog_local0 =
+syslog_local0 =
```