### PR TITLE
Fix logging to systemd-journal (gh-1876)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,8 @@ ver. 0.10.2-dev-1 (2017/??/??) - development edition
   ports are enclosed in curly braces `{ }` in the `jail.local` etc. This may cause a double-brackets now.
 
 ### Fixes
+* Fixed logging to systemd-journal: new logtarget value SYSOUT can be used instead of STDOUT, to avoid 
+  write of the time-stamp, if logging to systemd-journal from foreground mode (gh-1876)
 * jail.conf: port `imap3` replaced with `imap` everywhere, since imap3 is not a standard port and old rarely 
   (if ever) used and can missing on some systems (e. g. debian stretch), see gh-1942.
 * config/paths-common.conf: added missing initial values (and small normalization in config/paths-*.conf)

--- a/config/fail2ban.conf
+++ b/config/fail2ban.conf
@@ -30,7 +30,7 @@ loglevel = INFO
 #         using logrotate -- also adjust or disable rotation in the
 #         corresponding configuration file
 #         (e.g. /etc/logrotate.d/fail2ban on Debian systems)
-# Values: [ STDOUT | STDERR | SYSLOG | FILE ]  Default: STDERR
+# Values: [ STDOUT | STDERR | SYSLOG | SYSOUT | FILE ]  Default: STDERR
 #
 logtarget = /var/log/fail2ban.log
 

--- a/fail2ban/client/fail2bancmdline.py
+++ b/fail2ban/client/fail2bancmdline.py
@@ -99,7 +99,7 @@ class Fail2banCmdLine():
 		output("    -s <FILE>               socket path")
 		output("    -p <FILE>               pidfile path")
 		output("    --loglevel <LEVEL>      logging level")
-		output("    --logtarget <FILE>|STDOUT|STDERR|SYSLOG")
+		output("    --logtarget <TARGET>    logging target, use file-name or stdout, stderr, syslog or sysout.")
 		output("    --syslogsocket auto|<FILE>")
 		output("    -d                      dump configuration. For debugging")
 		output("    --dp, --dump-pretty     dump the configuration using more human readable representation")

--- a/fail2ban/client/fail2banserver.py
+++ b/fail2ban/client/fail2banserver.py
@@ -210,7 +210,8 @@ class Fail2banServer(Fail2banCmdLine):
 					if server: # pragma: no cover
 						server.quit()
 					exit(-1)
-				logSys.debug('Starting server done')
+				if background:
+					logSys.debug('Starting server done')
 
 		except Exception as e:
 			if self._conf["verbose"] > 1:

--- a/fail2ban/helpers.py
+++ b/fail2ban/helpers.py
@@ -143,7 +143,7 @@ def str2LogLevel(value):
 		raise ValueError("Invalid log level %r" % value)
 	return ll
 
-def getVerbosityFormat(verbosity, fmt=' %(message)s'):
+def getVerbosityFormat(verbosity, fmt=' %(message)s', addtime=True):
 	"""Custom log format for the verbose runs
 	"""
 	if verbosity > 1: # pragma: no cover
@@ -152,7 +152,9 @@ def getVerbosityFormat(verbosity, fmt=' %(message)s'):
 		if verbosity > 2:
 			fmt = ' +%(relativeCreated)5d %(thread)X %(name)-25.25s %(levelname)-5.5s' + fmt
 		else:
-			fmt = ' %(asctime)-15s %(thread)X %(levelname)-5.5s' + fmt
+			fmt = ' %(thread)X %(levelname)-5.5s' + fmt
+			if addtime:
+				fmt = ' %(asctime)-15s' + fmt
 	return fmt
 
 

--- a/files/bash-completion
+++ b/files/bash-completion
@@ -108,7 +108,7 @@ _fail2ban () {
                     ;;
                 logtarget)
                     if [[ "$cmd" == "set" ]];then
-                        COMPREPLY=( $( compgen -W "STDOUT STDERR SYSLOG" -- "$cur" ) )
+                        COMPREPLY=( $( compgen -W "STDOUT STDERR SYSLOG SYSOUT" -- "$cur" ) )
                         _filedir # And files
                     fi
                     return 0

--- a/files/fail2ban.service.in
+++ b/files/fail2ban.service.in
@@ -8,8 +8,8 @@ PartOf=iptables.service firewalld.service ip6tables.service ipset.service
 Type=simple
 ExecStartPre=/bin/mkdir -p /var/run/fail2ban
 ExecStart=@BINDIR@/fail2ban-server -xf start
-# if should be logged in systemd journal, use following line or set logtarget to stdout in fail2ban.local
-# ExecStart=@BINDIR@/fail2ban-server -xf --logtarget=stdout start
+# if should be logged in systemd journal, use following line or set logtarget to sysout in fail2ban.local
+# ExecStart=@BINDIR@/fail2ban-server -xf --logtarget=sysout start
 ExecStop=@BINDIR@/fail2ban-client stop
 ExecReload=@BINDIR@/fail2ban-client reload
 PIDFile=/var/run/fail2ban/fail2ban.pid

--- a/man/fail2ban-client.1
+++ b/man/fail2ban-client.1
@@ -21,8 +21,9 @@ pidfile path
 .TP
 \fB\-\-loglevel\fR <LEVEL>
 logging level
-.HP
-\fB\-\-logtarget\fR <FILE>|STDOUT|STDERR|SYSLOG
+.TP
+\fB\-\-logtarget\fR <TARGET>
+logging target, use file\-name or stdout, stderr, syslog or sysout.
 .HP
 \fB\-\-syslogsocket\fR auto|<FILE>
 .TP

--- a/man/fail2ban-server.1
+++ b/man/fail2ban-server.1
@@ -21,8 +21,9 @@ pidfile path
 .TP
 \fB\-\-loglevel\fR <LEVEL>
 logging level
-.HP
-\fB\-\-logtarget\fR <FILE>|STDOUT|STDERR|SYSLOG
+.TP
+\fB\-\-logtarget\fR <TARGET>
+logging target, use file\-name or stdout, stderr, syslog or sysout.
 .HP
 \fB\-\-syslogsocket\fR auto|<FILE>
 .TP


### PR DESCRIPTION
* added new logtarget "SYSOUT" to log from fail2ban working in foreground as systemd-service (in opposite to "STDOUT" don't log time-stamps).
Closes gh-1876
* better handling by start/stop of server in foreground mode;
