### PR TITLE
Update apache-botsearch.conf

### DIFF
--- a/config/filter.d/apache-botsearch.conf
+++ b/config/filter.d/apache-botsearch.conf
@@ -31,7 +31,7 @@ failregex = ^(?:File does not exist|script not found or unable to stat): <webroo
 ignoreregex = 
 
 # Webroot represents the webroot on which all other files are based
-webroot = /var/www/
+webroot = /var/www/.*?
 
 
 # DEV Notes:


### PR DESCRIPTION
webroot init don't consider multi ip or virtualhosts configuration.
scan attack is blocked only for default apache document root.
