### PR TITLE
Exim aggressive

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -60,11 +60,13 @@ ver. 0.10.2-dev-1 (2017/??/??) - development edition
     (corresponds %H, but allows space if not zero-padded).
   - %l - one- or two-digit number giving the hour of the day (12-11) on a 12-hour clock,
     (corresponds %I, but allows space if not zero-padded).
+* `filter.d/exim.conf`: added mode `aggressive` to ban flood resp. DDOS-similar failures (gh-1983);
 * New Actions:
   - `action.d/nginx-block-map.conf` - in order to ban not IP-related tickets via nginx (session blacklisting in
     nginx-location with map-file);
 
 ### Enhancements
+* jail.conf: extended with new parameter `mode` for the filters supporting it (gh-1988);
 * action.d/pf.conf: extended with bulk-unban, command `actionflush` in order to flush all bans at once.
 
 

--- a/config/filter.d/exim.conf
+++ b/config/filter.d/exim.conf
@@ -24,6 +24,21 @@ failregex = ^%(pid)s %(host_info)ssender verify fail for <\S+>: (?:Unknown user|
             ^%(pid)s SMTP protocol error in "[^"]+(?:"+[^"]*(?="))*?" %(host_info)sAUTH command used when not advertised\s*$
             ^%(pid)s no MAIL in SMTP connection from (?:[^\[\( ]* )?(?:\(\S*\) )?%(host_info)sD=\d\S*s(?: C=\S*)?\s*$
             ^%(pid)s (?:[\w\-]+ )?SMTP connection from (?:[^\[\( ]* )?(?:\(\S*\) )?%(host_info)sclosed by DROP in ACL\s*$
+            <mdre-<mode>>
+
+mdre-aggressive = ^%(pid)s no host name found for IP address <HOST>$
+                  ^%(pid)s no IP address found for host \S+ \(during SMTP connection from \[<HOST>\]\)$
+
+mdre-normal = 
+
+# Parameter `mode` - `normal` or `aggressive`.
+# Aggressive mode can be used to match flood and ddos-similar log-entries like:
+#   'no host found for IP', 'no IP found for host'.
+# Note this is not an authentication failures, so it may produce lots of false 
+# positives on misconfigured MTAs.
+# Ex.:
+#   filter = exim[mode=aggressive]
+mode = normal
 
 ignoreregex = 
 

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -117,10 +117,13 @@ logencoding = auto
 enabled = false
 
 
+# "mode" defines the mode of the filter (see corresponding filter implementation for more info).
+mode = normal
+
 # "filter" defines the filter to use by the jail.
 #  By default jails have names matching their filter name
 #
-filter = %(__name__)s
+filter = %(__name__)s[mode=%(mode)s]
 
 
 #
@@ -237,8 +240,7 @@ action = %(action_)s
 # To use more aggressive sshd modes set filter parameter "mode" in jail.local:
 # normal (default), ddos, extra or aggressive (combines all).
 # See "tests/files/logs/sshd" or "filter.d/sshd.conf" for usage example and details.
-mode    = normal
-filter  = sshd[mode=%(mode)s]
+#mode   = normal
 port    = ssh
 logpath = %(sshd_log)s
 backend = %(sshd_backend)s
@@ -536,7 +538,6 @@ backend  = %(syslog_backend)s
 [postfix]
 # To use another modes set filter parameter "mode" in jail.local:
 mode    = more
-filter  = postfix[mode=%(mode)s]
 port    = smtp,465,submission
 logpath = %(postfix_log)s
 backend = %(postfix_backend)s
@@ -562,8 +563,7 @@ backend = %(syslog_backend)s
 # To use more aggressive modes set filter parameter "mode" in jail.local:
 # normal (default), extra or aggressive
 # See "tests/files/logs/sendmail-reject" or "filter.d/sendmail-reject.conf" for usage example and details.
-mode    = normal
-filter  = sendmail-reject[mode=%(mode)s]
+#mode    = normal
 port     = smtp,465,submission
 logpath  = %(syslog_mail)s
 backend  = %(syslog_backend)s
@@ -599,7 +599,8 @@ logpath = %(solidpop3d_log)s
 
 
 [exim]
-
+# see filter.d/exim.conf for further modes supported from filter:
+#mode = normal
 port   = smtp,465,submission
 logpath = %(exim_main_log)s
 
@@ -869,17 +870,14 @@ logpath  = /var/log/haproxy.log
 
 [slapd]
 port    = ldap,ldaps
-filter  = slapd
 logpath = /var/log/slapd.log
 
 [domino-smtp]
 port    = smtp,ssmtp
-filter  = domino-smtp
 logpath = /home/domino01/data/IBM_TECHNICAL_SUPPORT/console.log
 
 [phpmyadmin-syslog]
 port    = http,https
-filter  = phpmyadmin-syslog
 logpath = %(syslog_authpriv)s
 backend = %(syslog_backend)s
 

--- a/fail2ban/tests/files/logs/exim
+++ b/fail2ban/tests/files/logs/exim
@@ -83,3 +83,17 @@
 2017-11-28 14:14:31 SMTP protocol error in "aUtH lOgIn" H=(roxzgj) [192.0.2.5] AUTH command used when not advertised
 # failJSON: { "time": "2017-11-28T14:14:32", "match": true , "host": "192.0.2.6", "desc": "quoted injecting on AUTH command" }
 2017-11-28 14:14:32 SMTP protocol error in "aUtH lOgIn" H=(test) [8.8.8.8]" H=(roxzgj) [192.0.2.6] AUTH command used when not advertised
+
+## no matches with `mode = normal`:
+
+# failJSON: { "match": false , "desc": "aggressive mode only" }
+2017-12-03 08:32:00 no host name found for IP address 192.0.2.8
+# failJSON: { "match": false , "desc": "aggressive mode only" }
+2017-12-03 08:51:35 no IP address found for host test.example.com (during SMTP connection from [192.0.2.9])
+
+# filterOptions: [{"mode": "aggressive"}]
+
+# failJSON: { "time": "2017-12-03T08:32:00", "match": true , "host": "192.0.2.8", "desc": "no host found for IP" }
+2017-12-03 08:32:00 no host name found for IP address 192.0.2.8
+# failJSON: { "time": "2017-12-03T08:51:35", "match": true , "host": "192.0.2.9", "desc": "no IP found for host" }
+2017-12-03 08:51:35 no IP address found for host test.example.com (during SMTP connection from [192.0.2.9])


### PR DESCRIPTION
* filter.d/exim.conf: provides mode `aggressive` to ban flood resp. DDOS-similar failures;
Closes #1983
* jail.conf: extended with new parameter `mode` for the filters supporting it;
