### PR TITLE
New server logging options

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -68,6 +68,13 @@ ver. 0.10.2-dev-1 (2017/??/??) - development edition
 ### Enhancements
 * jail.conf: extended with new parameter `mode` for the filters supporting it (gh-1988);
 * action.d/pf.conf: extended with bulk-unban, command `actionflush` in order to flush all bans at once.
+* Introduced new parameters for logging within fail2ban-server (gh-1980).
+  Usage `logtarget = target[facility=..., datetime=on|off, format="..."]`:
+  - `facility` - specify syslog facility (default `daemon`, see https://docs.python.org/2/library/logging.handlers.html#sysloghandler
+     for the list of facilities);
+  - `datetime` - add date-time to the message (default on, ignored if `format` specified);
+  - `format` - specify own format how it will be logged, for example for short-log into STDOUT:
+      `fail2ban-server -f --logtarget 'stdout[format="%(relativeCreated)5d | %(message)s"]' start`;
 
 
 ver. 0.10.1 (2017/10/12) - succeeded-before-friday-the-13th

--- a/fail2ban/client/fail2banregex.py
+++ b/fail2ban/client/fail2banregex.py
@@ -46,12 +46,12 @@ except ImportError:
 	FilterSystemd = None
 
 from ..version import version
-from .jailreader import JailReader
 from .filterreader import FilterReader
 from ..server.filter import Filter, FileContainer
 from ..server.failregex import Regex, RegexException
 
-from ..helpers import str2LogLevel, getVerbosityFormat, FormatterWithTraceBack, getLogger, PREFER_ENC
+from ..helpers import str2LogLevel, getVerbosityFormat, FormatterWithTraceBack, getLogger, \
+  extractOptions, PREFER_ENC
 # Gets the instance of the logger.
 logSys = getLogger("fail2ban")
 
@@ -287,7 +287,7 @@ class Fail2banRegex(object):
 		fltFile = None
 		fltOpt = {}
 		if regextype == 'fail':
-			fltName, fltOpt = JailReader.extractOptions(value)
+			fltName, fltOpt = extractOptions(value)
 			if fltName is not None:
 				if "." in fltName[~5:]:
 					tryNames = (fltName,)
@@ -606,7 +606,7 @@ class Fail2banRegex(object):
 				return False
 			output( "Use         systemd journal" )
 			output( "Use         encoding : %s" % self._encoding )
-			backend, beArgs = JailReader.extractOptions(cmd_log)
+			backend, beArgs = extractOptions(cmd_log)
 			flt = FilterSystemd(None, **beArgs)
 			flt.setLogEncoding(self._encoding)
 			myjournal = flt.getJournalReader()

--- a/fail2ban/helpers.py
+++ b/fail2ban/helpers.py
@@ -238,6 +238,34 @@ else:
 
 
 #
+# Following function used for parse options from parameter (e.g. `name[p1=0, p2="..."][p3='...']`).
+#
+
+# regex, to extract list of options:
+OPTION_CRE = re.compile(r"^([^\[]+)(?:\[(.*)\])?\s*$", re.DOTALL)
+# regex, to iterate over single option in option list, syntax:
+# `action = act[p1="...", p2='...', p3=...]`, where the p3=... not contains `,` or ']'
+# since v0.10 separator extended with `]\s*[` for support of multiple option groups, syntax 
+# `action = act[p1=...][p2=...]`
+OPTION_EXTRACT_CRE = re.compile(
+	r'([\w\-_\.]+)=(?:"([^"]*)"|\'([^\']*)\'|([^,\]]*))(?:,|\]\s*\[|$)', re.DOTALL)
+
+def extractOptions(option):
+	match = OPTION_CRE.match(option)
+	if not match:
+		# TODO proper error handling
+		return None, None
+	option_name, optstr = match.groups()
+	option_opts = dict()
+	if optstr:
+		for optmatch in OPTION_EXTRACT_CRE.finditer(optstr):
+			opt = optmatch.group(1)
+			value = [
+				val for val in optmatch.group(2,3,4) if val is not None][0]
+			option_opts[opt.strip()] = value.strip()
+	return option_name, option_opts
+
+#
 # Following facilities used for safe recursive interpolation of
 # tags (<tag>) in tagged options.
 #

--- a/fail2ban/server/jail.py
+++ b/fail2ban/server/jail.py
@@ -27,8 +27,7 @@ import logging
 import Queue
 
 from .actions import Actions
-from ..client.jailreader import JailReader
-from ..helpers import getLogger, MyTime
+from ..helpers import getLogger, extractOptions, MyTime
 
 # Gets the instance of the logger.
 logSys = getLogger(__name__)
@@ -85,7 +84,7 @@ class Jail(object):
 		return "%s(%r)" % (self.__class__.__name__, self.name)
 
 	def _setBackend(self, backend):
-		backend, beArgs = JailReader.extractOptions(backend)
+		backend, beArgs = extractOptions(backend)
 		backend = backend.lower()		# to assure consistent matching
 
 		backends = self._BACKENDS

--- a/fail2ban/tests/fail2banclienttestcase.py
+++ b/fail2ban/tests/fail2banclienttestcase.py
@@ -171,7 +171,7 @@ def _start_params(tmp, use_stock=False, use_stock_cfg=None,
 		_write_file(pjoin(cfg, "fail2ban.conf"), "w",
 			"[Definition]",
 			"loglevel = INFO",
-			"logtarget = " + logtarget,
+			"logtarget = " + logtarget.replace('%', '%%'),
 			"syslogsocket = auto",
 			"socket = " + pjoin(tmp, "f2b.sock"),
 			"pidfile = " + pjoin(tmp, "f2b.pid"),
@@ -735,7 +735,8 @@ class Fail2banServerTest(Fail2banClientServerBase):
 	def testKillAfterStart(self, tmp):
 		try:
 			# to prevent fork of test-cases process, start server in background via command:
-			startparams = _start_params(tmp, logtarget=pjoin(tmp, "f2b.log"))
+			startparams = _start_params(tmp, logtarget=pjoin(tmp,
+				'f2b.log[format="SRV: %(relativeCreated)3d | %(message)s", datetime=off]'))
 			# start (in new process, using the same python version):
 			cmd = (sys.executable, pjoin(BIN, SERVER))
 			logSys.debug('Start %s ...', cmd)

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -831,8 +831,8 @@ class TransmitterLogging(TransmitterBase):
 		for logTarget in logTargets:
 			os.remove(logTarget)
 
-		self.setGetTest("logtarget", "STDOUT")
-		self.setGetTest("logtarget", "STDERR")
+		self.setGetTest("logtarget", 'STDOUT[format="%(message)s"]', 'STDOUT')
+		self.setGetTest("logtarget", 'STDERR[datetime=off]', 'STDERR')
 
 	def testLogTargetSYSLOG(self):
 		if not os.path.exists("/dev/log"):

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -42,7 +42,7 @@ from ..server.ticket import BanTicket
 from ..server.utils import Utils
 from .dummyjail import DummyJail
 from .utils import LogCaptureTestCase
-from ..helpers import getLogger, PREFER_ENC
+from ..helpers import getLogger, extractOptions, PREFER_ENC
 from .. import version
 
 try:
@@ -1034,7 +1034,7 @@ class LoggingTests(LogCaptureTestCase):
 					os.remove(f)
 
 
-from clientreadertestcase import ActionReader, JailReader, JailsReader, CONFIG_DIR, STOCK
+from clientreadertestcase import ActionReader, JailsReader, CONFIG_DIR, STOCK
 
 class ServerConfigReaderTests(LogCaptureTestCase):
 
@@ -1145,7 +1145,7 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 
 		def getDefaultJailStream(self, jail, act):
 			act = act.replace('%(__name__)s', jail)
-			actName, actOpt = JailReader.extractOptions(act)
+			actName, actOpt = extractOptions(act)
 			stream = [
 				['add', jail, 'polling'],
 				# ['set', jail, 'addfailregex', 'DUMMY-REGEX <HOST>'],


### PR DESCRIPTION
Introduced new parameters for logging within fail2ban-server.
Usage `logtarget = target[facility=..., datetime=on|off, format="..."]`:
  - `facility` - specify syslog facility (default `daemon`, see https://docs.python.org/2/library/logging.handlers.html#sysloghandler for the list of facilities);
  - `datetime` - add date-time to the message (default on, ignored if `format` specified);
  - `format` - specify own format how it will be logged, for example for short-log into STDOUT:
```bash
fail2ban-server -f --logtarget 'stdout[format="%(relativeCreated)5d | %(message)s"]' start
```
Closes gh-1980