### PR TITLE
firewallcmd-new actioncheck Error

### DIFF
--- a/config/action.d/firewallcmd-new.conf
+++ b/config/action.d/firewallcmd-new.conf
@@ -16,7 +16,7 @@ actionstop = firewall-cmd --direct --remove-rule <family> filter <chain> 0 -m st
              firewall-cmd --direct --remove-rules <family> filter f2b-<name>
              firewall-cmd --direct --remove-chain <family> filter f2b-<name>
 
-actioncheck = firewall-cmd --direct --get-chains <family> filter | grep -q 'f2b-<name>$'
+actioncheck = firewall-cmd --direct --get-chains ipv4 filter | sed -e 's, ,\n,g' | grep -q 'f2b-<name>$'
 
 actionban = firewall-cmd --direct --add-rule <family> filter f2b-<name> 0 -s <ip> -j <blocktype>
 

--- a/config/action.d/firewallcmd-new.conf
+++ b/config/action.d/firewallcmd-new.conf
@@ -16,7 +16,7 @@ actionstop = firewall-cmd --direct --remove-rule <family> filter <chain> 0 -m st
              firewall-cmd --direct --remove-rules <family> filter f2b-<name>
              firewall-cmd --direct --remove-chain <family> filter f2b-<name>
 
-actioncheck = firewall-cmd --direct --get-chains ipv4 filter | sed -e 's, ,\n,g' | grep -q 'f2b-<name>$'
+actioncheck = firewall-cmd --direct --get-chains <family> filter | sed -e 's, ,\n,g' | grep -q 'f2b-<name>$'
 
 actionban = firewall-cmd --direct --add-rule <family> filter f2b-<name> 0 -s <ip> -j <blocktype>
 


### PR DESCRIPTION
Using firewallcmd-new in CentOS 7 and EPEL environment will result in an error.

```
fail2ban.actions        [13906]: NOTICE  [dovecot] Ban XXX.XXX.XXX.XXX
fail2ban.action         [13906]: ERROR   firewall-cmd --direct --get-chains ipv4 filter | grep -q 'f2b-dovecot$' -- stdout: ''
fail2ban.action         [13906]: ERROR   firewall-cmd --direct --get-chains ipv4 filter | grep -q 'f2b-dovecot$' -- stderr: ''
fail2ban.action         [13906]: ERROR   firewall-cmd --direct --get-chains ipv4 filter | grep -q 'f2b-dovecot$' -- returned 1
fail2ban.CommandAction  [13906]: ERROR   Invariant check failed. Trying to restore a sane environment
```

It is a problem that the result of firewall-cmd is one line, so we made it to multi-line
(reference to firewallcmd-multiport.conf)