### PR TITLE
Automatically recover or recreate corrupt persistent database

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -80,6 +80,7 @@ ver. 0.10.2-dev-1 (2017/??/??) - development edition
   'database disk image is malformed'). Fail2ban will create a backup, try to repair the database,
   if repair fails - recreate new database (gh-1465, gh-2004).
 
+
 ver. 0.10.1 (2017/10/12) - succeeded-before-friday-the-13th
 -----------
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -76,7 +76,9 @@ ver. 0.10.2-dev-1 (2017/??/??) - development edition
   - `datetime` - add date-time to the message (default on, ignored if `format` specified);
   - `format` - specify own format how it will be logged, for example for short-log into STDOUT:
       `fail2ban-server -f --logtarget 'stdout[format="%(relativeCreated)5d | %(message)s"]' start`;
-
+* Automatically recover or recreate corrupt persistent database (e. g. if failed to open with 
+  'database disk image is malformed'). Fail2ban will create a backup, try to repair the database,
+  if repair fails - recreate new database (gh-1465, gh-2004).
 
 ver. 0.10.1 (2017/10/12) - succeeded-before-friday-the-13th
 -----------


### PR DESCRIPTION
Automatically recover or recreate corrupt persistent database (e. g. if failed to open with 'database disk image is malformed').
Fail2ban will create a backup, try to repair the database, if repair fails - recreate new database.
Covered using test-database that will be truncated in order to produce corrupt database for both cases (repair/recreate).

Closes #1465
