### PR TITLE
nginx-http-auth: match usernames with spaces

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -40,6 +40,7 @@ releases.
       input SMTP command (lower/mixed case auth command, prevent injection) (gh-1979)
 * filter.d/postfix-*.conf - added optional port regex (gh-1902)
 * filter.d/sendmail-auth.conf - extended daemon for Fedora 24/RHEL - the daemon name is "sendmail" (gh-1632)
+* filter.d/nginx-http-auth.conf - match usernames with spaces (gh-2015)
 
 ### New Features
 

--- a/config/filter.d/nginx-http-auth.conf
+++ b/config/filter.d/nginx-http-auth.conf
@@ -4,7 +4,7 @@
 [Definition]
 
 
-failregex = ^ \[error\] \d+#\d+: \*\d+ user "\S+":? (password mismatch|was not found in ".*"), client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"(, referrer: "\S+")?\s*$
+failregex = ^ \[error\] \d+#\d+: \*\d+ user "[^"]+":? (password mismatch|was not found in ".*"), client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"(, referrer: "\S+")?\s*$
 
 ignoreregex = 
 

--- a/config/filter.d/nginx-http-auth.conf
+++ b/config/filter.d/nginx-http-auth.conf
@@ -4,7 +4,7 @@
 [Definition]
 
 
-failregex = ^ \[error\] \d+#\d+: \*\d+ user "[^"]+":? (password mismatch|was not found in ".*"), client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"(, referrer: "\S+")?\s*$
+failregex = ^ \[error\] \d+#\d+: \*\d+ user "(?:[^"]+|.*?)":? (?:password mismatch|was not found in "[^\"]*"), client: <HOST>, server: \S*, request: "\S+ \S+ HTTP/\d+\.\d+", host: "\S+"(?:, referrer: "\S+")?\s*$
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/nginx-http-auth
+++ b/fail2ban/tests/files/logs/nginx-http-auth
@@ -7,4 +7,6 @@
 2014/04/01 22:20:38 [error] 30708#0: *3 user "scribendio": password mismatch, client: 10.0.2.2, server: , request: "GET / HTTP/1.1", host: "localhost:8443"
 # failJSON: { "time": "2014-04-02T12:37:58", "match": true, "host": "10.0.2.2" }
 2014/04/02 12:37:58 [error] 6563#0: *1861 user "scribendio": password mismatch, client: 10.0.2.2, server: scribend.io, request: "GET /admin HTTP/1.1", host: "scribend.io", referrer: "https://scribend.io/admin"
+# failJSON: { "time": "2014-04-01T22:20:38", "match": true, "host": "10.0.2.2" }
+2014/04/01 22:20:38 [error] 30708#0: *3 user "scriben dio": password mismatch, client: 10.0.2.2, server: , request: "GET / HTTP/1.1", host: "localhost:8443"
 

--- a/fail2ban/tests/files/logs/nginx-http-auth
+++ b/fail2ban/tests/files/logs/nginx-http-auth
@@ -7,6 +7,7 @@
 2014/04/01 22:20:38 [error] 30708#0: *3 user "scribendio": password mismatch, client: 10.0.2.2, server: , request: "GET / HTTP/1.1", host: "localhost:8443"
 # failJSON: { "time": "2014-04-02T12:37:58", "match": true, "host": "10.0.2.2" }
 2014/04/02 12:37:58 [error] 6563#0: *1861 user "scribendio": password mismatch, client: 10.0.2.2, server: scribend.io, request: "GET /admin HTTP/1.1", host: "scribend.io", referrer: "https://scribend.io/admin"
-# failJSON: { "time": "2014-04-01T22:20:38", "match": true, "host": "10.0.2.2" }
-2014/04/01 22:20:38 [error] 30708#0: *3 user "scriben dio": password mismatch, client: 10.0.2.2, server: , request: "GET / HTTP/1.1", host: "localhost:8443"
-
+# failJSON: { "time": "2014-04-03T22:20:38", "match": true, "host": "192.0.2.1", "desc": "user name with space" }
+2014/04/03 22:20:38 [error] 30708#0: *3 user "scriben dio": password mismatch, client: 192.0.2.1, server: , request: "GET / HTTP/1.1", host: "localhost:8443"
+# failJSON: { "time": "2014-04-03T22:20:40", "match": true, "host": "192.0.2.2", "desc": "trying injection on user name"}
+2014/04/03 22:20:40 [error] 30708#0: *3 user "test": password mismatch, client: 127.0.0.1, server: test, request: "GET / HTTP/1.1", host: "localhost:8443"": was not found in "/etc/nginx/.htpasswd", client: 192.0.2.2, server: , request: "GET / HTTP/1.1", host: "localhost:8443"


### PR DESCRIPTION
> - [ ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
>      against 0.9.x series, choose `master` branch

not sure about this one. this could also be backported to other versions, the rest of your checklist should be ok.

I'm not a regex expert, I hope `.+` is not a dangerous operation in this context?