### PR TITLE
Fixed spelling error: nonexistAnt -> nonexistent

### DIFF
--- a/fail2ban/tests/actionstestcase.py
+++ b/fail2ban/tests/actionstestcase.py
@@ -66,7 +66,7 @@ class ExecuteActions(LogCaptureTestCase):
 		self.__actions.add('test')
 		self.assertTrue(self.__actions['test'])
 		self.assertIn('test', self.__actions)
-		self.assertNotIn('nonexistant action', self.__actions)
+		self.assertNotIn('nonexistent action', self.__actions)
 		self.__actions.add('test1')
 		del self.__actions['test']
 		del self.__actions['test1']

--- a/fail2ban/tests/files/logs/postfix
+++ b/fail2ban/tests/files/logs/postfix
@@ -25,7 +25,7 @@ Dec 18 02:05:46 platypus postfix/smtpd[16349]: improper command pipelining after
 Dec 21 21:17:29 xxx postfix/smtpd[7150]: NOQUEUE: reject: RCPT from badserver.example.com[93.184.216.34]: 450 4.7.1 Client host rejected: cannot find your hostname, [93.184.216.34]; from=<badactor@example.com> to=<goodguy@example.com> proto=ESMTP helo=<badserver.example.com>
 
 # failJSON: { "time": "2004-11-22T22:33:44", "match": true , "host": "1.2.3.4" }
-Nov 22 22:33:44 xxx postfix/smtpd[11111]: NOQUEUE: reject: RCPT from 1-2-3-4.example.com[1.2.3.4]: 450 4.1.8 <some@nonexistant.tld>: Sender address rejected: Domain not found; from=<some@nonexistant.tld> to=<goodguy@example.com> proto=ESMTP helo=<1-2-3-4.example.com>
+Nov 22 22:33:44 xxx postfix/smtpd[11111]: NOQUEUE: reject: RCPT from 1-2-3-4.example.com[1.2.3.4]: 450 4.1.8 <some@nonexistent.tld>: Sender address rejected: Domain not found; from=<some@nonexistent.tld> to=<goodguy@example.com> proto=ESMTP helo=<1-2-3-4.example.com>
 
 # failJSON: { "time": "2005-01-31T13:55:24", "match": true , "host": "78.107.251.238" }
 Jan 31 13:55:24 xxx postfix/smtpd[3462]: NOQUEUE: reject: EHLO from s271272.static.corbina.ru[78.107.251.238]: 504 5.5.2 <User>: Helo command rejected: need fully-qualified hostname; proto=SMTP helo=<User>


### PR DESCRIPTION
Just some small modifications, based on the Debian lintian's spell checking.
Please approve it for the new Debian branch.