### PR TITLE
Long epoch and epoch pattern

### DIFF
--- a/fail2ban/server/datetemplate.py
+++ b/fail2ban/server/datetemplate.py
@@ -204,7 +204,7 @@ class DateEpoch(DateTemplate):
 			self.name = "LongEpoch";
 			epochRE = r"\d{10,11}(?:\d{3}(?:\d{3})?)?"
 		if pattern:
-			regex = RE_EPOCH_PATTERN.sub("(%s)" % epochRE, pattern)
+			regex = RE_EPOCH_PATTERN.sub(lambda v: "(%s)" % epochRE, pattern)
 			self.setRegex(regex)
 		elif not lineBeginOnly:
 			regex = r"((?:^|(?P<square>(?<=^\[))|(?P<selinux>(?<=\baudit\()))%s)(?:(?(selinux)(?=:\d+\)))|(?(square)(?=\])))" % epochRE

--- a/fail2ban/server/datetemplate.py
+++ b/fail2ban/server/datetemplate.py
@@ -199,12 +199,15 @@ class DateEpoch(DateTemplate):
 		DateTemplate.__init__(self)
 		self.name = "Epoch"
 		self._longFrm = longFrm;
+		self._grpIdx = 1
 		epochRE = r"\d{10,11}\b(?:\.\d{3,6})?"
 		if longFrm:
 			self.name = "LongEpoch";
-			epochRE = r"\d{10,11}(?:\d{3}(?:\d{3})?)?"
+			epochRE = r"\d{10,11}(?:\d{3}(?:\.\d{1,6}|\d{3})?)?"
 		if pattern:
-			regex = RE_EPOCH_PATTERN.sub(lambda v: "(%s)" % epochRE, pattern)
+			# pattern should capture/cut out the whole match:
+			regex = "(" + RE_EPOCH_PATTERN.sub(lambda v: "(%s)" % epochRE, pattern) + ")"
+			self._grpIdx = 2
 			self.setRegex(regex)
 		elif not lineBeginOnly:
 			regex = r"((?:^|(?P<square>(?<=^\[))|(?P<selinux>(?<=\baudit\()))%s)(?:(?(selinux)(?=:\d+\)))|(?(square)(?=\])))" % epochRE
@@ -231,10 +234,10 @@ class DateEpoch(DateTemplate):
 		if not dateMatch:
 			dateMatch = self.matchDate(line)
 		if dateMatch:
-			v = dateMatch.group(1)
+			v = dateMatch.group(self._grpIdx)
 			# extract part of format which represents seconds since epoch
 			if self._longFrm and len(v) >= 13:
-				if len(v) >= 16:
+				if len(v) >= 16 and '.' not in v:
 					v = float(v) / 1000000
 				else:
 					v = float(v) / 1000

--- a/fail2ban/tests/datedetectortestcase.py
+++ b/fail2ban/tests/datedetectortestcase.py
@@ -77,6 +77,48 @@ class DateDetectorTest(LogCaptureTestCase):
 				log = date + " [sshd] error: PAM: Authentication failure"
 				datelog = self.datedetector.getTime(log)
 				self.assertFalse(datelog)
+
+	def testGetEpochMsTime(self):
+		self.__datedetector = DateDetector()
+		self.__datedetector.appendTemplate('LEPOCH')
+		# correct short/long epoch time, using all variants:
+		for fact in (1, 1000, 1000000):
+			for dateUnix in (1138049999, 32535244799):
+				for date in ("%s", "[%s]", "[%s]", "audit(%s:101)"):
+					dateLong = dateUnix * fact
+					date = date % dateLong
+					log = date + " [sshd] error: PAM: Authentication failure"
+					datelog = self.datedetector.getTime(log)
+					self.assertTrue(datelog, "Parse epoch time for %s failed" % (date,))
+					( datelog, matchlog ) = datelog
+					self.assertEqual(int(datelog), dateUnix)
+					self.assertEqual(matchlog.group(1), str(dateLong))
+		# wrong, no epoch time (< 10 digits, more as 17 digits, begin/end of word) :
+		for dateUnix in ('123456789', '999999999999999999', '1138049999A', 'A1138049999'):
+			for date in ("%s", "[%s]", "[%s.555]", "audit(%s.555:101)"):
+				date = date % dateUnix
+				log = date + " [sshd] error: PAM: Authentication failure"
+				datelog = self.datedetector.getTime(log)
+				self.assertFalse(datelog)
+
+	def testGetEpochPattern(self):
+		self.__datedetector = DateDetector()
+		self.__datedetector.appendTemplate('\|\s{LEPOCH}(?=\s\|)')
+		# correct short/long epoch time, using all variants:
+		for fact in (1, 1000, 1000000):
+			for dateUnix in (1138049999, 32535244799):
+				dateLong = dateUnix * fact
+				log = "auth-error | %s | invalid password" % dateLong
+				datelog = self.datedetector.getTime(log)
+				self.assertTrue(datelog, "Parse epoch time failed: %r" % (log,))
+				( datelog, matchlog ) = datelog
+				self.assertEqual(int(datelog), dateUnix)
+				self.assertEqual(matchlog.group(1), str(dateLong))
+		# wrong epoch time format (does not match pattern):
+		for log in ("test%s123", "test-right | %stest", "test%s | test-left"):
+			log = log % dateLong
+			datelog = self.datedetector.getTime(log)
+			self.assertFalse(datelog)
 	
 	def testGetTime(self):
 		log = "Jan 23 21:59:59 [sshd] error: PAM: Authentication failure"

--- a/fail2ban/tests/datedetectortestcase.py
+++ b/fail2ban/tests/datedetectortestcase.py
@@ -103,7 +103,7 @@ class DateDetectorTest(LogCaptureTestCase):
 
 	def testGetEpochPattern(self):
 		self.__datedetector = DateDetector()
-		self.__datedetector.appendTemplate('\|\s{LEPOCH}(?=\s\|)')
+		self.__datedetector.appendTemplate('(?<=\|\s){LEPOCH}(?=\s\|)')
 		# correct short/long epoch time, using all variants:
 		for fact in (1, 1000, 1000000):
 			for dateUnix in (1138049999, 32535244799):

--- a/fail2ban/tests/fail2banregextestcase.py
+++ b/fail2ban/tests/fail2banregextestcase.py
@@ -290,6 +290,17 @@ class Fail2banRegexTest(LogCaptureTestCase):
 		self.assertTrue(fail2banRegex.start(args))
 		self.assertLogged('Lines: 1 lines, 0 ignored, 1 matched, 0 missed')
 
+	def testRegexEpochPatterns(self):
+		(opts, args, fail2banRegex) = _Fail2banRegex(
+			"-r", "-d", "^\[{LEPOCH}\]\s+", "--maxlines", "5",
+			"[1516469849] 192.0.2.1 FAIL: failure\n"
+			"[1516469849551] 192.0.2.2 FAIL: failure\n"
+			"[1516469849551000] 192.0.2.3 FAIL: failure\n"
+			"[1516469849551.000] 192.0.2.4 FAIL: failure",
+			r"^<HOST> FAIL\b"
+		)
+		self.assertTrue(fail2banRegex.start(args))
+		self.assertLogged('Lines: 4 lines, 0 ignored, 4 matched, 0 missed')
 
 	def testWrongFilterFile(self):
 		# use test log as filter file to cover eror cases...


### PR DESCRIPTION
* extends date-detector with long epoch (`LEPOCH`) to parse milliseconds/microseconds posix-dates;
provides possibility to specify own regex-pattern to match epoch date-time, e. g. `^\[{EPOCH}\]` or `^\[{LEPOCH}\]`;
closes gh-2029
* the epoch-pattern similar to `{DATE}` patterns does the capture and cuts out the match of whole pattern from the log-line, e.  g. date-pattern `^\[{LEPOCH}\]\s+:` will match and cut out `[1516469849551000] :` from begin of the log-line.
