### PR TITLE
(Free)BSD IPFW does not allow 2 identical rules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,7 @@ ver. 0.10.3-dev-1 (20??/??/??) - development edition
 
 ### Fixes
 * `filter.d/exim.conf`: failregex extended - SMTP call dropped: too many syntax or protocol errors (gh-2048);
+* (Free)BSD ipfw actionban fixed to allow same rule added several times (gh-2054);
 
 ### New Features
 

--- a/config/action.d/bsd-ipfw.conf
+++ b/config/action.d/bsd-ipfw.conf
@@ -38,7 +38,7 @@ actioncheck =
 # Values:  CMD
 #
 # requires an ipfw rule like "deny ip from table(1) to me"
-actionban = e=`ipfw table <table> add <ip> 2>&1`; x=$?; [ $x -eq 0 -o "$e" = 'ipfw: setsockopt(IP_FW_TABLE_XADD): File exists' ] || { echo "$e" 1>&2; exit $x; }
+actionban = e=`ipfw table <table> add <ip> 2>&1`; x=$?; [ $x -eq 0 -o "$e" = 'ipfw: setsockopt(IP_FW_TABLE_XADD): File exists' ] || echo "$e" | grep -q "record already exists" || { echo "$e" 1>&2; exit $x; }
 
 
 # Option:  actionunban
@@ -47,7 +47,7 @@ actionban = e=`ipfw table <table> add <ip> 2>&1`; x=$?; [ $x -eq 0 -o "$e" = 'ip
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionunban = e=`ipfw table <table> delete <ip> 2>&1`; x=$?; [ $x -eq 0 -o "$e" = 'ipfw: setsockopt(IP_FW_TABLE_XDEL): No such process' ] || { echo "$e" 1>&2; exit $x; }
+actionunban = e=`ipfw table <table> delete <ip> 2>&1`; x=$?; [ $x -eq 0 -o "$e" = 'ipfw: setsockopt(IP_FW_TABLE_XDEL): No such process' ] || echo "$e" | grep -q "record not found" || { echo "$e" 1>&2; exit $x; }
 
 [Init]
 # Option:  table


### PR DESCRIPTION
Hi,

On Linux, `iptables` allows to have same rule added multiple times.
However, on (Free)BSD, `ipfw` does not allow this.

This PR then handles this.
It will make `actionban` to succeed if rule already exists.
And as a result, `actionunban` to succeed if rule does not exist anymore.

Thank you 👍 

Ben