### PR TITLE
Add 'any' badips.py bancategory

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,7 @@ ver. 0.10.3-dev-1 (20??/??/??) - development edition
 * possibility to specify own regex-pattern to match epoch date-time, e. g. `^\[{EPOCH}\]` or `^\[{LEPOCH}\]` (gh-2038);
   the epoch-pattern similar to `{DATE}` patterns does the capture and cuts out the match of whole pattern from the log-line,
   e. g. date-pattern `^\[{LEPOCH}\]\s+:` will match and cut out `[1516469849551000] :` from begin of the log-line.
+* add support for "any" badips.py bancategory, to be able to retrieve IPs from all categories with a desired score (gh-2056);
 
 
 ver. 0.10.2 (2018/01/18) - nothing-burns-like-the-cold

--- a/config/action.d/badips.py
+++ b/config/action.d/badips.py
@@ -219,7 +219,7 @@ class BadIPsAction(ActionBase): # pragma: no cover - may be unavailable
 
 	@bancategory.setter
 	def bancategory(self, bancategory):
-		if bancategory not in self.getCategories(incParents=True):
+		if bancategory != "any" and bancategory not in self.getCategories(incParents=True):
 			self._logSys.error("Category name '%s' not valid. "
 				"see badips.com for list of valid categories",
 				bancategory)


### PR DESCRIPTION
Hi,

This PR adds the `any` badips bancategory, which can be useful, for example to add all IPs of a desired score, in a global firewall lookup table.

Thank you 👍 

Ben