### PR TITLE
iptables-allports should not care about protocol

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,7 @@ ver. 0.10.3-dev-1 (20??/??/??) - development edition
 * possibility to specify own regex-pattern to match epoch date-time, e. g. `^\[{EPOCH}\]` or `^\[{LEPOCH}\]` (gh-2038);
   the epoch-pattern similar to `{DATE}` patterns does the capture and cuts out the match of whole pattern from the log-line,
   e. g. date-pattern `^\[{LEPOCH}\]\s+:` will match and cut out `[1516469849551000] :` from begin of the log-line.
+* iptables-allports does not care anymore about protocol (and thus ban all protocols) (gh-2058);
 
 
 ver. 0.10.2 (2018/01/18) - nothing-burns-like-the-cold

--- a/config/action.d/iptables-allports.conf
+++ b/config/action.d/iptables-allports.conf
@@ -19,13 +19,13 @@ before = iptables-common.conf
 #
 actionstart = <iptables> -N f2b-<name>
               <iptables> -A f2b-<name> -j <returntype>
-              <iptables> -I <chain> -p <protocol> -j f2b-<name>
+              <iptables> -I <chain> -j f2b-<name>
 
 # Option:  actionstop
 # Notes.:  command executed once at the end of Fail2Ban
 # Values:  CMD
 #
-actionstop = <iptables> -D <chain> -p <protocol> -j f2b-<name>
+actionstop = <iptables> -D <chain> -j f2b-<name>
              <actionflush>
              <iptables> -X f2b-<name>
 


### PR DESCRIPTION
Hi,

As with other firewall actions on all ports, `iptables` should not care about protocol when banning on all ports.

Thank you 👍 

Ben