### PR TITLE
badips.py, solve a str() issue - expected string, IPAddr found

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,7 @@ ver. 0.10.3-dev-1 (20??/??/??) - development edition
 * possibility to specify own regex-pattern to match epoch date-time, e. g. `^\[{EPOCH}\]` or `^\[{LEPOCH}\]` (gh-2038);
   the epoch-pattern similar to `{DATE}` patterns does the capture and cuts out the match of whole pattern from the log-line,
   e. g. date-pattern `^\[{LEPOCH}\]\s+:` will match and cut out `[1516469849551000] :` from begin of the log-line.
+* `action.d/badips.py`: implicit convert IPAddr to str, solves an issue "expected string, IPAddr found" (gh-2059);
 
 
 ver. 0.10.2 (2018/01/18) - nothing-burns-like-the-cold

--- a/config/action.d/badips.py
+++ b/config/action.d/badips.py
@@ -368,7 +368,7 @@ class BadIPsAction(ActionBase): # pragma: no cover - may be unavailable
 			Any issues with badips.com request.
 		"""
 		try:
-			url = "/".join([self._badips, "add", self.category, aInfo['ip']])
+			url = "/".join([self._badips, "add", self.category, str(aInfo['ip'])])
 			if self.key:
 				url = "?".join([url, urlencode({'key': self.key})])
 			response = urlopen(self._Request(url), timeout=self.timeout)

--- a/config/action.d/badips.py
+++ b/config/action.d/badips.py
@@ -186,6 +186,7 @@ class BadIPsAction(ActionBase): # pragma: no cover - may be unavailable
 				urlencode({'age': age})])
 			if key:
 				url = "&".join([url, urlencode({'key': key})])
+			self._logSys.debug('badips.com: get list, url: %r', url)
 			response = urlopen(self._Request(url), timeout=self.timeout)
 		except HTTPError as response:
 			messages = json.loads(response.read().decode('utf-8'))
@@ -371,6 +372,7 @@ class BadIPsAction(ActionBase): # pragma: no cover - may be unavailable
 			url = "/".join([self._badips, "add", self.category, str(aInfo['ip'])])
 			if self.key:
 				url = "?".join([url, urlencode({'key': self.key})])
+			self._logSys.debug('badips.com: ban, url: %r', url)
 			response = urlopen(self._Request(url), timeout=self.timeout)
 		except HTTPError as response:
 			messages = json.loads(response.read().decode('utf-8'))

--- a/fail2ban/tests/action_d/test_badips.py
+++ b/fail2ban/tests/action_d/test_badips.py
@@ -52,6 +52,9 @@ if sys.version_info >= (2,7): # pragma: no cover - may be unavailable
 			self.jail.actions.add("badips", pythonModule, initOpts={
 				'category': "ssh",
 				'banaction': "test",
+				'score': 5,
+				'key': "fail2ban-test-suite",
+				#'bankey': "fail2ban-test-suite",
 				'timeout': (3 if unittest.F2B.fast else 30),
 				})
 			self.action = self.jail.actions["badips"]
@@ -80,8 +83,8 @@ if sys.version_info >= (2,7): # pragma: no cover - may be unavailable
 
 		def testScore(self):
 			self.assertRaises(ValueError, setattr, self.action, "score", -5)
-			self.action.score = 5
-			self.action.score = "5"
+			self.action.score = 3
+			self.action.score = "3"
 
 		def testBanaction(self):
 			self.assertRaises(
@@ -97,11 +100,9 @@ if sys.version_info >= (2,7): # pragma: no cover - may be unavailable
 			self.action.updateperiod = 900
 			self.action.updateperiod = "900"
 
-		def testStart(self):
+		def testStartStop(self):
 			self.action.start()
-			self.assertTrue(len(self.action._bannedips) > 10)
-
-		def testStop(self):
-			self.testStart()
+			self.assertTrue(len(self.action._bannedips) > 10,
+				"%s is fewer as 10: %r" % (len(self.action._bannedips), self.action._bannedips))
 			self.action.stop()
 			self.assertTrue(len(self.action._bannedips) == 0)


### PR DESCRIPTION
Hi,

When banning, `badips.py` leads to the following error under FreeBSD :
```
'ActionInfo(...)': sequence item 3: expected string or Unicode, IPAddr found
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/fail2ban/server/actions.py", line 399, in __checkBan
    action.ban(aInfo)
  File "/usr/local/etc/fail2ban/action.d/badips2.py", line 371, in ban
    url = "/".join([self._badips, "add", self.category, aInfo['ip']])
```

This PR then solves this issue.

Thx 👍 

Ben