### PR TITLE
filter.d/sshd.conf: fixed ddos-mode regex (extended with port)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,7 +37,9 @@ ver. 0.10.3-dev-1 (20??/??/??) - development edition
 ### Fixes
 * `filter.d/asterisk.conf`: fixed failregex prefix by log over remote syslog server (gh-2060);
 * `filter.d/exim.conf`: failregex extended - SMTP call dropped: too many syntax or protocol errors (gh-2048);
-* `filter.d/sshd.conf`: failregex got an optional space in order to match new log-format (see gh-2061);
+* `filter.d/sshd.conf`:
+  - failregex got an optional space in order to match new log-format (see gh-2061);
+  - fixed ddos-mode regex to match refactored message (some versions can contain port now, see gh-2062);
 * `action.d/badips.py`: implicit convert IPAddr to str, solves an issue "expected string, IPAddr found" (gh-2059);
 * (Free)BSD ipfw actionban fixed to allow same rule added several times (gh-2054);
 

--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -55,7 +55,7 @@ cmnfailre = ^[aA]uthentication (?:failure|error|failed) for <F-USER>.*</F-USER> 
 
 mdre-normal =
 
-mdre-ddos = ^Did not receive identification string from <HOST>%(__suff)s$
+mdre-ddos = ^Did not receive identification string from <HOST>%(__on_port_opt)s
             ^Connection <F-MLFFORGET>reset</F-MLFFORGET> by <HOST>%(__on_port_opt)s%(__suff)s
             ^<F-NOFAIL>SSH: Server;Ltype:</F-NOFAIL> (?:Authname|Version|Kex);Remote: <HOST>-\d+;[A-Z]\w+:
             ^Read from socket failed: Connection <F-MLFFORGET>reset</F-MLFFORGET> by peer%(__suff)s

--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -55,7 +55,7 @@ cmnfailre = ^[aA]uthentication (?:failure|error|failed) for <F-USER>.*</F-USER> 
 
 mdre-normal =
 
-mdre-ddos = ^Did not receive identification string from <HOST>%(__on_port_opt)s
+mdre-ddos = ^Did not receive identification string from <HOST>%(__on_port_opt)s%(__suff)s
             ^Connection <F-MLFFORGET>reset</F-MLFFORGET> by <HOST>%(__on_port_opt)s%(__suff)s
             ^<F-NOFAIL>SSH: Server;Ltype:</F-NOFAIL> (?:Authname|Version|Kex);Remote: <HOST>-\d+;[A-Z]\w+:
             ^Read from socket failed: Connection <F-MLFFORGET>reset</F-MLFFORGET> by peer%(__suff)s

--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -49,7 +49,7 @@ cmnfailre = ^[aA]uthentication (?:failure|error|failed) for <F-USER>.*</F-USER> 
             ^(error: )?maximum authentication attempts exceeded for <F-USER>.*</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?%(__suff)s$
             ^User <F-USER>.+</F-USER> not allowed because account is locked%(__suff)s
             ^<F-MLFFORGET>Disconnecting</F-MLFFORGET>: Too many authentication failures(?: for <F-USER>.+?</F-USER>)?%(__suff)s
-            ^<F-NOFAIL>Received <F-MLFFORGET>disconnect</F-MLFFORGET></F-NOFAIL> from <HOST>:\s*11:
+            ^<F-NOFAIL>Received <F-MLFFORGET>disconnect</F-MLFFORGET></F-NOFAIL> from <HOST>%(__on_port_opt)s:\s*11:
             ^<F-NOFAIL>Connection <F-MLFFORGET>closed</F-MLFFORGET></F-NOFAIL> by <HOST>%(__suff)s$
             ^<F-MLFFORGET><F-NOFAIL>Accepted publickey</F-NOFAIL></F-MLFFORGET> for \S+ from <HOST>(?:\s|$)
 

--- a/fail2ban/tests/config/filter.d/zzz-sshd-obsolete-multiline.conf
+++ b/fail2ban/tests/config/filter.d/zzz-sshd-obsolete-multiline.conf
@@ -50,7 +50,7 @@ cmnfailre = ^%(__prefix_line_sl)s[aA]uthentication (?:failure|error|failed) for 
 
 mdre-normal =
 
-mdre-ddos =  ^%(__prefix_line_sl)sDid not receive identification string from <HOST>%(__suff)s$
+mdre-ddos =  ^%(__prefix_line_sl)sDid not receive identification string from <HOST>%(__on_port_opt)s%(__suff)s
              ^%(__prefix_line_sl)sConnection reset by <HOST>%(__on_port_opt)s%(__suff)s
              ^%(__prefix_line_ml1)sSSH: Server;Ltype: (?:Authname|Version|Kex);Remote: <HOST>-\d+;[A-Z]\w+:.*%(__prefix_line_ml2)sRead from socket failed: Connection reset by peer%(__suff)s$
 

--- a/fail2ban/tests/config/filter.d/zzz-sshd-obsolete-multiline.conf
+++ b/fail2ban/tests/config/filter.d/zzz-sshd-obsolete-multiline.conf
@@ -44,7 +44,7 @@ cmnfailre = ^%(__prefix_line_sl)s[aA]uthentication (?:failure|error|failed) for 
          ^%(__prefix_line_sl)sUser .+ from <HOST> not allowed because none of user's groups are listed in AllowGroups\s*%(__suff)s$
          ^%(__prefix_line_sl)spam_unix\(sshd:auth\):\s+authentication failure;\s*logname=\S*\s*uid=\d*\s*euid=\d*\s*tty=\S*\s*ruser=\S*\s*rhost=<HOST>\s.*%(__suff)s$
          ^%(__prefix_line_sl)s(error: )?maximum authentication attempts exceeded for .* from <HOST>%(__on_port_opt)s(?: ssh\d*)? \[preauth\]$
-         ^%(__prefix_line_ml1)sUser .+ not allowed because account is locked%(__prefix_line_ml2)sReceived disconnect from <HOST>:\s*11: .+%(__suff)s$
+         ^%(__prefix_line_ml1)sUser .+ not allowed because account is locked%(__prefix_line_ml2)sReceived disconnect from <HOST>%(__on_port_opt)s:\s*11: .+%(__suff)s$
          ^%(__prefix_line_ml1)sDisconnecting: Too many authentication failures(?: for .+?)?%(__suff)s%(__prefix_line_ml2)sConnection closed by <HOST>%(__suff)s$
          ^%(__prefix_line_ml1)sConnection from <HOST>%(__on_port_opt)s%(__prefix_line_ml2)sDisconnecting: Too many authentication failures(?: for .+?)?%(__suff)s$
 

--- a/fail2ban/tests/files/logs/sshd
+++ b/fail2ban/tests/files/logs/sshd
@@ -219,6 +219,8 @@ Apr 27 13:02:04 host sshd[29116]: Received disconnect from 1.2.3.4: 11: Normal S
 # http://forums.powervps.com/showthread.php?t=1667
 # failJSON: { "time": "2005-06-07T01:10:56", "match": true , "host": "69.61.56.114" }
 Jun 7 01:10:56 host sshd[5937]: Did not receive identification string from 69.61.56.114
+# failJSON: { "time": "2005-06-07T01:11:57", "match": true , "host": "192.0.2.5", "desc": "refactored message (with port now, gh-2062)" }
+Jun 7 01:11:57 host sshd[8782]: Did not receive identification string from 192.0.2.5 port 35836
 
 # gh-864(1):
 # failJSON: { "match": false }

--- a/fail2ban/tests/files/logs/sshd
+++ b/fail2ban/tests/files/logs/sshd
@@ -110,7 +110,7 @@ May 27 00:16:33 host sshd[2364]: User root not allowed because account is locked
 # failJSON: { "match": false }
 May 27 00:16:33 host sshd[2364]: input_userauth_request: invalid user root [preauth]
 # failJSON: { "time": "2005-05-27T00:16:33", "match": true , "host": "198.51.100.76" }
-May 27 00:16:33 host sshd[2364]: Received disconnect from 198.51.100.76:11: Bye Bye [preauth]
+May 27 00:16:33 host sshd[2364]: Received disconnect from 198.51.100.76 port 58846:11: Bye Bye [preauth]
 
 # failJSON: { "time": "2004-09-29T16:28:02", "match": true , "host": "127.0.0.1" }
 Sep 29 16:28:02 spaceman sshd[16699]: Failed password for dan from 127.0.0.1 port 45416 ssh1


### PR DESCRIPTION
in line 58, rule don't match with "%(__suff)s" but work fine if I replace with "%(__on_port_opt)s"
Debian 9 stretch : fail2ban 0.10.3