### PR TITLE
action.d/hostdeny.conf: fixes IPv6 syntax

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,7 @@ ver. 0.10.3-dev-1 (20??/??/??) - development edition
   - failregex got an optional space in order to match new log-format (see gh-2061);
   - fixed ddos-mode regex to match refactored message (some versions can contain port now, see gh-2062);
 * `action.d/badips.py`: implicit convert IPAddr to str, solves an issue "expected string, IPAddr found" (gh-2059);
+* `action.d/hostsdeny.conf`: fixed IPv6 syntax (enclosed in square brackets, gh-2066);
 * (Free)BSD ipfw actionban fixed to allow same rule added several times (gh-2054);
 
 ### New Features

--- a/config/action.d/hostsdeny.conf
+++ b/config/action.d/hostsdeny.conf
@@ -31,7 +31,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = IP=<ip> && printf %%b "<daemon_list>: $IP\n" >> <file>
+actionban = printf %%b "<daemon_list>: <_ip_value>\n" >> <file>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -39,7 +39,7 @@ actionban = IP=<ip> && printf %%b "<daemon_list>: $IP\n" >> <file>
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionunban = IP=$(echo <ip> | sed 's/\./\\./g') && sed -i "/^<daemon_list>: $IP$/d" <file>
+actionunban = IP=$(echo "<_ip_value>" | sed 's/[][\.]/\\\0/g') && sed -i "/^<daemon_list>: $IP$/d" <file>
 
 [Init]
 
@@ -54,3 +54,9 @@ file = /etc/hosts.deny
 #          for hosts.deny/hosts_access. Default is all services.
 # Values:  STR  Default: ALL
 daemon_list = ALL
+
+# internal variable IP (to differentiate the IPv4 and IPv6 syntax, where it is enclosed in brackets):
+_ip_value = <ip>
+
+[Init?family=inet6]
+_ip_value = [<ip>]


### PR DESCRIPTION
differentiate the IPv4 and IPv6 syntax (where it is enclosed in square brackets)

closes gh-2066