### PR TITLE
Use variable `__pam_auth` instead of `pam_unix`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -50,6 +50,7 @@ releases.
 * filter.d/kerio.conf - filter extended with new rules (see gh-1455)
 * filter.d/phpmyadmin-syslog.conf - new filter for phpMyAdmin using syslog for auth logging
 * filter.d/zoneminder.conf - new filter for ZoneMinder (gh-1376)
+* filter.d/sshd.conf - use variable `__pam_auth` instead of hard-coded `pam_unix`
 
 
 ver. 0.9.7 (2017/05/11) - awaiting-victory

--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -44,7 +44,7 @@ normal = ^%(__prefix_line_sl)s[aA]uthentication (?:failure|error|failed) for .* 
          ^%(__prefix_line_sl)sReceived disconnect from <HOST>%(__on_port_opt)s:\s*3: .*: Auth fail%(__suff)s$
          ^%(__prefix_line_sl)sUser .+ from <HOST> not allowed because a group is listed in DenyGroups\s*%(__suff)s$
          ^%(__prefix_line_sl)sUser .+ from <HOST> not allowed because none of user's groups are listed in AllowGroups\s*%(__suff)s$
-         ^%(__prefix_line_sl)spam_unix\(sshd:auth\):\s+authentication failure;\s*logname=\S*\s*uid=\d*\s*euid=\d*\s*tty=\S*\s*ruser=\S*\s*rhost=<HOST>\s.*%(__suff)s$
+         ^%(__prefix_line_sl)s%(__pam_auth)s\(sshd:auth\):\s+authentication failure;\s*logname=\S*\s*uid=\d*\s*euid=\d*\s*tty=\S*\s*ruser=\S*\s*rhost=<HOST>\s.*%(__suff)s$
          ^%(__prefix_line_sl)s(error: )?maximum authentication attempts exceeded for .* from <HOST>%(__on_port_opt)s(?: ssh\d*)? \[preauth\]$
          ^%(__prefix_line_ml1)sUser .+ not allowed because account is locked%(__prefix_line_ml2)sReceived disconnect from <HOST>: 11: .+%(__suff)s$
          ^%(__prefix_line_ml1)sDisconnecting: Too many authentication failures for .+?%(__prefix_line_ml2)sConnection closed by <HOST>%(__suff)s$


### PR DESCRIPTION
This will take into account the configured PAM backend in `filder.d/common.conf`

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file

**Issues this PR resolves:**

On Debian "Stretch" or Ubuntu "Xenial", when `pam_unix` and `pam_ldap` are used in combination, a successful `ssh` authentication against `pam_ldap` will cause a filter detection because the PAM stack first tries `pam_unix`:

```
Mar  7 18:53:20 bar sshd[1556]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=1.2.3.4  user=rda
Mar  7 18:53:20 bar sshd[1556]: Accepted password for rda from 1.2.3.4 port 52100 ssh2
Mar  7 18:53:20 bar sshd[1556]: pam_unix(sshd:session): session opened for user rda by (uid=0)
```

Using this patch and configuring `pam_ldap` backend in `filter.d/common.conf`:

```
__pam_auth = pam_ldap
```

fixes the issue.

Failed password-based authentication against a local-only user is still registered in this case:

```
==> auth.log <==
Mar  7 19:12:59 bar sshd[3615]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=1.2.3.4  user=rdalocal
Mar  7 19:13:02 bar sshd[3615]: Failed password for rdalocal from 1.2.3.4 port 52132 ssh2
==> fail2ban.log <==
2018-03-07 19:13:02,351 fail2ban.filter         [3601]: INFO    [sshd] Found 1.2.3.4
```