### PR TITLE
filter.d/recidive.conf: fixed if logging into systemd-journal (SYSLOG)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,7 @@ ver. 0.10.3-dev-1 (20??/??/??) - development edition
 ### Fixes
 * `filter.d/asterisk.conf`: fixed failregex prefix by log over remote syslog server (gh-2060);
 * `filter.d/exim.conf`: failregex extended - SMTP call dropped: too many syntax or protocol errors (gh-2048);
+* `filter.d/recidive.conf`: fixed if logging into systemd-journal (SYSLOG) with daemon name in prefix, gh-2069;
 * `filter.d/sshd.conf`:
   - failregex got an optional space in order to match new log-format (see gh-2061);
   - fixed ddos-mode regex to match refactored message (some versions can contain port now, see gh-2062);

--- a/config/filter.d/recidive.conf
+++ b/config/filter.d/recidive.conf
@@ -21,17 +21,17 @@ before = common.conf
 
 [Definition]
 
-_daemon = fail2ban\.actions\s*
+_daemon = (?:fail2ban(?:-server|\.actions)\s*)
 
-# The name of the jail that this filter is used for. In jail.conf, name the 
-# jail using this filter 'recidive', or change this line!
+# The name of the jail that this filter is used for. In jail.conf, name the jail using
+# this filter 'recidive', or supply another name with `filter = recidive[_jailname="jail"]`
 _jailname = recidive
 
-failregex = ^(%(__prefix_line)s| %(_daemon)s%(__pid_re)s?:\s+)NOTICE\s+\[(?!%(_jailname)s\])(?:.*)\]\s+Ban\s+<HOST>\s*$
+failregex = ^%(__prefix_line)s(?:\s*fail2ban\.actions\s*%(__pid_re)s?:\s+)?NOTICE\s+\[(?!%(_jailname)s\])(?:.*)\]\s+Ban\s+<HOST>\s*$
+
+datepattern = ^{DATE}
 
 ignoreregex = 
-
-[Init]
 
 journalmatch = _SYSTEMD_UNIT=fail2ban.service PRIORITY=5
 

--- a/fail2ban/tests/files/logs/recidive
+++ b/fail2ban/tests/files/logs/recidive
@@ -12,3 +12,8 @@ Sep 16 00:44:55 spaceman fail2ban.actions: NOTICE [jail] Ban 10.0.0.7
 
 # failJSON: { "time": "2006-02-13T15:52:30", "match": true , "host": "1.2.3.4", "desc": "Extended with [PID] and padding" }
 2006-02-13 15:52:30,388 fail2ban.actions        [123]: NOTICE  [sendmail] Ban 1.2.3.4
+
+# failJSON: { "time": "2005-01-16T17:11:25", "match": true , "host": "192.0.2.1", "desc": "SYSLOG / systemd-journal without daemon-name" }
+Jan 16 17:11:25 testorg fail2ban.actions[6605]: NOTICE [postfix-auth] Ban 192.0.2.1
+# failJSON: { "time": "2005-03-05T08:41:28", "match": true , "host": "192.0.2.2", "desc": "SYSLOG / systemd-journal with daemon-name" }
+Mar 05 08:41:28 test.org fail2ban-server[11524]: fail2ban.actions        [11524]: NOTICE  [postfix-auth] Ban 192.0.2.2


### PR DESCRIPTION
filter.d/recidive.conf: fixed if logging into systemd-journal (SYSLOG) with daemon name in prefix;
closes gh-2069

