### PR TITLE
filter.d/apache-noscript.conf: extended to match "Primary script unknown", got from php-fpm module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -48,6 +48,7 @@ ver. 0.10.3-dev-1 (20??/??/??) - development edition
 ### New Features
 
 ### Enhancements
+* `filter.d/apache-noscript.conf`: extend failregex to match "Primary script unknown", e. g. from php-fpm (gh-2073);
 * date-detector extended with long epoch (`LEPOCH`) to parse milliseconds/microseconds posix-dates (gh-2029);
 * possibility to specify own regex-pattern to match epoch date-time, e. g. `^\[{EPOCH}\]` or `^\[{LEPOCH}\]` (gh-2038);
   the epoch-pattern similar to `{DATE}` patterns does the capture and cuts out the match of whole pattern from the log-line,

--- a/config/filter.d/apache-noscript.conf
+++ b/config/filter.d/apache-noscript.conf
@@ -19,11 +19,11 @@ before = apache-common.conf
 
 script = /\S*(?:php(?:[45]|[.-]cgi)?|\.asp|\.exe|\.pl)
 
-prefregex = ^%(_apache_error_client)s <F-CONTENT>.+</F-CONTENT>$
+prefregex = ^%(_apache_error_client)s <F-CONTENT>(?:(?:AH0(?:01(?:28|30)|1(?:264|071)): )|(?:(?:[Ff]ile|script|[Gg]ot) )).+</F-CONTENT>$
 
-failregex = ^(?:(?:AH001(?:28|30): )?File does not exist|(AH01264: )?script not found or unable to stat): <script>\b
+failregex = ^(?:(?:AH001(?:28|30): )?[Ff]ile does not exist|(AH01264: )?script not found or unable to stat): <script>\b
             ^script '<script>\S*' not found or unable to stat
-            ^(?:AH01071: )?Got error 'Primary script unknown\\n'
+            ^(?:AH01071: )?[Gg]ot error '[Pp]rimary script unknown\\n'
 
 ignoreregex = 
 

--- a/config/filter.d/apache-noscript.conf
+++ b/config/filter.d/apache-noscript.conf
@@ -19,11 +19,11 @@ before = apache-common.conf
 
 script = /\S*(?:php(?:[45]|[.-]cgi)?|\.asp|\.exe|\.pl)
 
-prefregex = ^%(_apache_error_client)s <F-CONTENT>(?:(?:AH0(?:01(?:28|30)|1(?:264|071)): )|(?:(?:[Ff]ile|script|[Gg]ot) )).+</F-CONTENT>$
+prefregex = ^%(_apache_error_client)s (?:AH0(?:01(?:28|30)|1(?:264|071)): )?(?:(?:[Ff]ile|script|[Gg]ot) )<F-CONTENT>.+</F-CONTENT>$
 
-failregex = ^(?:(?:AH001(?:28|30): )?[Ff]ile does not exist|(AH01264: )?script not found or unable to stat): <script>\b
-            ^script '<script>\S*' not found or unable to stat
-            ^(?:AH01071: )?[Gg]ot error '[Pp]rimary script unknown\\n'
+failregex = ^(?:does not exist|not found or unable to stat): <script>\b
+            ^'<script>\S*' not found or unable to stat
+            ^error '[Pp]rimary script unknown\\n'
 
 ignoreregex = 
 

--- a/config/filter.d/apache-noscript.conf
+++ b/config/filter.d/apache-noscript.conf
@@ -17,8 +17,13 @@ before = apache-common.conf
 
 [Definition]
 
-failregex = ^%(_apache_error_client)s ((AH001(28|30): )?File does not exist|(AH01264: )?script not found or unable to stat): /\S*(php([45]|[.-]cgi)?|\.asp|\.exe|\.pl)(, referer: \S+)?\s*$
-            ^%(_apache_error_client)s script '/\S*(php([45]|[.-]cgi)?|\.asp|\.exe|\.pl)\S*' not found or unable to stat(, referer: \S+)?\s*$
+script = /\S*(?:php(?:[45]|[.-]cgi)?|\.asp|\.exe|\.pl)
+
+prefregex = ^%(_apache_error_client)s <F-CONTENT>.+</F-CONTENT>$
+
+failregex = ^(?:(?:AH001(?:28|30): )?File does not exist|(AH01264: )?script not found or unable to stat): <script>\b
+            ^script '<script>\S*' not found or unable to stat
+            ^(?:AH01071: )?Got error 'Primary script unknown\\n'
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/apache-noscript
+++ b/fail2ban/tests/files/logs/apache-noscript
@@ -16,3 +16,5 @@
 # apache 2.4
 # failJSON: { "time": "2013-12-23T07:49:01", "match": true , "host": "204.232.202.107" }
 [Mon Dec 23 07:49:01.981912 2013] [:error] [pid 3790] [client 204.232.202.107:46301] script '/var/www/timthumb.php' not found or unable to stat
+# failJSON: { "time": "2018-03-11T08:56:20", "match": true , "host": "192.0.2.106", "desc": "php-fpm error" }
+[Sun Mar 11 08:56:20.913548 2018] [proxy_fcgi:error] [pid 742:tid 140142593419008] [client 192.0.2.106:50900] AH01071: Got error 'Primary script unknown\n'


### PR DESCRIPTION
filter.d/apache-noscript.conf: extended to match "Primary script unknown", got from php-fpm module;
closes #2073 