### PR TITLE
Fixes abuseipdb curl cypher error and comment $f2bV_matches

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -47,6 +47,7 @@ ver. 0.10.3-dev-1 (20??/??/??) - development edition
   - amend to gh-1263 with better handling of multiple attempts (failures for different user-names recognized immediatelly);
   - mode `ddos` (and `aggressive`) extended to catch `Connection closed by ... [preauth]`, so in DDOS mode
     it counts failure on closing connection within preauth-stage (gh-2085);
+* `action.d/abuseipdb.conf`: fixed curl cypher errors and comment quote-issue (gh-2044, gh-2101);
 * `action.d/badips.py`: implicit convert IPAddr to str, solves an issue "expected string, IPAddr found" (gh-2059);
 * `action.d/hostsdeny.conf`: fixed IPv6 syntax (enclosed in square brackets, gh-2066);
 * (Free)BSD ipfw actionban fixed to allow same rule added several times (gh-2054);

--- a/config/action.d/abuseipdb.conf
+++ b/config/action.d/abuseipdb.conf
@@ -86,7 +86,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = curl --fail --ciphers ecdhe_ecdsa_aes_256_sha --data 'key=<abuseipdb_apikey>' --data-urlencode 'comment=<matches>' --data 'ip=<ip>' --data 'category=<abuseipdb_category>' "https://www.abuseipdb.com/report/json"
+actionban = lgm=$(printf '%%s\n...' "<matches>"); curl --fail --tlsv1.1 --data "key=<abuseipdb_apikey>" --data-urlencode "comment=$lgm" --data "ip=<ip>" --data "category=<abuseipdb_category>" "https://www.abuseipdb.com/report/json"
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the


### PR DESCRIPTION
Fixes issue #2044 curl cypher error  
and used #2039 to fix comment=<matches> resulting in abuseipdb.com only showing $f2bV_matches on the comment line.