### PR TITLE
Create filter for Dante SOCKS server

### DIFF
--- a/config/filter.d/dante.conf
+++ b/config/filter.d/dante.conf
@@ -9,7 +9,7 @@ before = common.conf
 [Definition]
 _daemon = danted
 
-failregex = ^%(__prefix_line)sinfo: block\(1\): tcp/accept \]: <HOST>\.\d+ [\d.]+: error after reading \d+ bytes in \d+ seconds: (could not access user "\w+"'s records in the system password file: no system error|system password authentication failed for user "\w+")$
+failregex = ^%(__prefix_line)sinfo: block\(1\): tcp/accept \]: <HOST>\.\d+ [\d.]+: error after reading \d+ bytes? in \d+ seconds?: (could not access user "\w+"'s records in the system password file: no system error|system password authentication failed for user "\w+")$
 
 [Init]
 journalmatch = _SYSTEMD_UNIT=danted.service

--- a/config/filter.d/dante.conf
+++ b/config/filter.d/dante.conf
@@ -1,0 +1,16 @@
+# Fail2Ban filter for dante
+#
+# Make sure you have "log: error" set in your "client pass" directive
+#
+
+[INCLUDES]
+before = common.conf
+
+[Definition]
+_daemon = danted
+
+failregex = ^%(__prefix_line)sinfo: block\(1\): tcp/accept \]: <HOST>\.\d+ [\d.]+: error after reading \d+ bytes in \d+ seconds: (could not access user "\w+"'s records in the system password file: no system error|system password authentication failed for user "\w+")$
+
+[Init]
+journalmatch = _SYSTEMD_UNIT=danted.service
+

--- a/config/filter.d/dante.conf
+++ b/config/filter.d/dante.conf
@@ -9,7 +9,7 @@ before = common.conf
 [Definition]
 _daemon = danted
 
-failregex = ^%(__prefix_line)sinfo: block\(1\): tcp/accept \]: <HOST>\.\d+ [\d.]+: error after reading \d+ bytes? in \d+ seconds?: (could not access |system password authentication failed for )user "<F-USER>[^"]+</F-USER>"
+failregex = ^%(__prefix_line)sinfo: block\(1\): tcp/accept \]: <HOST>\.\d+ [\d.]+: error after reading \d+ bytes? in \d+ seconds?: (?:could not access |system password authentication failed for )user "<F-USER>[^"]+</F-USER>"
 
 [Init]
 journalmatch = _SYSTEMD_UNIT=danted.service

--- a/config/filter.d/dante.conf
+++ b/config/filter.d/dante.conf
@@ -9,7 +9,7 @@ before = common.conf
 [Definition]
 _daemon = danted
 
-failregex = ^%(__prefix_line)sinfo: block\(1\): tcp/accept \]: <HOST>\.\d+ [\d.]+: error after reading \d+ bytes? in \d+ seconds?: (could not access user "\w+"'s records in the system password file: no system error|system password authentication failed for user "\w+")$
+failregex = ^%(__prefix_line)sinfo: block\(1\): tcp/accept \]: <HOST>\.\d+ [\d.]+: error after reading \d+ bytes? in \d+ seconds?: (could not access |system password authentication failed for )user "<F-USER>[^"]+</F-USER>"
 
 [Init]
 journalmatch = _SYSTEMD_UNIT=danted.service

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -978,3 +978,8 @@ banaction = %(banaction_allports)s
 [monitorix]
 port	= 8080
 logpath = /var/log/monitorix-httpd
+
+[dante]
+port    = 1080
+logpath = %(syslog_daemon)s
+

--- a/fail2ban/tests/files/logs/dante
+++ b/fail2ban/tests/files/logs/dante
@@ -2,3 +2,5 @@
 Apr 14 15:35:03 vps111111 danted[17969]: info: block(1): tcp/accept ]: 1.2.3.4.50550 0.0.0.0.1080: error after reading 35 bytes in 0 seconds: could not access user "roooooooot"'s records in the system password file: no system error
 # failJSON: { "time": "2005-04-14T15:44:26", "match": true , "host": "1.2.3.4" }
 Apr 14 15:44:26 vps111111 danted[1846]: info: block(1): tcp/accept ]: 1.2.3.4.57178 0.0.0.0.1080: error after reading 18 bytes in 0 seconds: system password authentication failed for user "aland"
+# failJSON: { "time": "2005-04-14T15:44:26", "match": true , "host": "1.2.3.4" }
+Apr 14 15:44:26 vps111111 danted[1846]: info: block(1): tcp/accept ]: 1.2.3.4.57178 0.0.0.0.1080: error after reading 1 byte in 1 second: system password authentication failed for user "aland"

--- a/fail2ban/tests/files/logs/dante
+++ b/fail2ban/tests/files/logs/dante
@@ -1,0 +1,4 @@
+# failJSON: { "time": "2005-04-14T15:35:03", "match": true , "host": "1.2.3.4" }
+Apr 14 15:35:03 vps111111 danted[17969]: info: block(1): tcp/accept ]: 1.2.3.4.50550 0.0.0.0.1080: error after reading 35 bytes in 0 seconds: could not access user "roooooooot"'s records in the system password file: no system error
+# failJSON: { "time": "2005-04-14T15:44:26", "match": true , "host": "1.2.3.4" }
+Apr 14 15:44:26 vps111111 danted[1846]: info: block(1): tcp/accept ]: 1.2.3.4.57178 0.0.0.0.1080: error after reading 18 bytes in 0 seconds: system password authentication failed for user "aland"


### PR DESCRIPTION
Creates filter for [Dante](https://www.inet.no/dante/index.html) server.

Limitations: I only tested it with "username" authentication mode and Dante 1.4.1 (from Debian 9), as this is the configuration I have running.

Before submitting your PR, please review the following checklist:

- [X] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch: selected **master**
- [X] **CONSIDER adding a unit test** if your PR resolves an issue: does not resolve any issues
- [X] **LIST ISSUES** this PR resolves: does not resolve any issues
- [X] **MAKE SURE** this PR doesn't break existing tests: tests pass on my machine
- [X] **KEEP PR small** so it could be easily reviewed
- [X] **AVOID** making unnecessary stylistic changes in unrelated code
- [X] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file

