### PR TITLE
Fix data type for journal flags (systemd backend)

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,11 @@
+FROM python:alpine
+
+RUN apk --update add bash
+RUN pip install dnspython3
+
+WORKDIR /fail2ban
+COPY . /fail2ban
+RUN ./fail2ban-2to3
+
+ENV PATH="${PATH}:/fail2ban/bin"
+ENTRYPOINT ["fail2ban-testcases", "--verbosity=2"]

--- a/fail2ban/server/filtersystemd.py
+++ b/fail2ban/server/filtersystemd.py
@@ -87,7 +87,7 @@ class FilterSystemd(JournalFilter): # pragma: systemd no cover
 			args['files'] = list(set(files))
 
 		try:
-			args['flags'] = kwargs.pop('journalflags')
+			args['flags'] = int(kwargs.pop('journalflags'))
 		except KeyError:
 			pass
 

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -803,6 +803,28 @@ class Transmitter(TransmitterBase):
 		result = self.transm.proceed(
 			["set", jailName, "deljournalmatch", value])
 		self.assertTrue(isinstance(result[1], ValueError))
+	
+	def testJournalFlagsMatch(self):
+		if not filtersystemd: # pragma: no cover
+			raise unittest.SkipTest("systemd python interface not available")
+		self.assertTrue(True)
+		jailName = "TestJail3"
+		self.server.addJail(jailName, "systemd[journalflags=2]")
+		values = [
+			"_SYSTEMD_UNIT=sshd.service",
+			"TEST_FIELD1=ABC",
+			"_HOSTNAME=example.com",
+		]
+		for n, value in enumerate(values):
+			self.assertEqual(
+				self.transm.proceed(
+					["set", jailName, "addjournalmatch", value]),
+				(0, [[val] for val in values[:n+1]]))
+		for n, value in enumerate(values):
+			self.assertEqual(
+				self.transm.proceed(
+					["set", jailName, "deljournalmatch", value]),
+				(0, [[val] for val in values[n+1:]]))
 
 
 class TransmitterLogging(TransmitterBase):


### PR DESCRIPTION
List of changes:
- Added test to prove bug when specifying journal flags to systemd backend
- Fixed data type of journal flags from str to int (which then applies to python-systemd)
- Added Dockerfile for running tests

---
- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code