### PR TITLE
added apf-multiport action

### DIFF
--- a/config/action.d/apf-multiport.conf
+++ b/config/action.d/apf-multiport.conf
@@ -1,0 +1,40 @@
+# Fail2Ban configuration file
+#
+# multiport ban action for APF
+#  - https://www.rfxn.com/projects/advanced-policy-firewall/
+#
+# Author: David Gabriel <b2c@dest-unreachable.net>
+#
+# apf config hint: add something like this to apf/postroute.rules 
+#
+# if pgrep -f '^\/usr\/bin\/python.*fail2ban-server' 2>&1 >/dev/null; then
+#   eout "{glob} restarting fail2ban"
+#   /usr/bin/fail2ban-client reload || true
+# fi
+
+
+[Init]
+chain      = INPUT
+name       = f2b-apf-multiport
+protocol   = tcp
+blocktype  = REJECT --reject-with icmp-port-unreachable
+returntype = RETURN
+lockingopt = -w
+iptables   = iptables <lockingopt>
+
+[Definition]
+actionstart = <iptables> -n -L <chain> | grep -q '<name>[ \t]' || {
+                <iptables> -N <name>
+                <iptables> -A <name>  -j <returntype>
+                <iptables> -I <chain> -j <name>
+              }
+
+actionstop  = <iptables> -n -L <chain> | grep -q '<name>[ \t]' || {
+              <iptables> -D <chain> -j <name> 2>/dev/null || true
+              <iptables> -F <name> 2>/dev/null || true
+              <iptables> -X <name> 2>/dev/null || true
+              }
+
+actioncheck = <iptables> -n -L <chain> | grep -q '<name>[ \t]'
+actionban   = <iptables> -I <name> 1 -s <ip> -p <protocol> -m multiport --dport <port> -j <blocktype>
+actionunban = <iptables> -D <name>   -s <ip> -p <protocol> -m multiport --dport <port> -j <blocktype>


### PR DESCRIPTION
The existing APF action bans IPs without the possibility to only block access to specific ports. Therefore I would like to propose to add a new action `apf-multiport` which takes care of ports too. It also doesn't rely on the apf command line binary at all which seems to get installed in varying location depending on the linux distribution in use which seems to have led to problems in the past.

This action works by:
 - on start: creating the chain "f2b-apf-multiport"
 - inserting jump-to rule at the start of the INPUT chain to divert all traffic to the chain "f2b-apf-multiport"
 - adding blocked IPs with "-s <ip> -m multiport --dport <port>" to the chain "f2b-apf-multiport" (defaults to tcp if not specified otherwise)
 - removing unblocked IPs in the same manner
 - on stop: delete the chain "f2b-apf-multiport" and remove the jump-to rule from INPUT

regards && thx