### PR TITLE
Load logpath only after findtime is configured

### DIFF
--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -90,12 +90,12 @@ class JailReader(ConfigReader):
 		opts1st = [["bool", "enabled", False],
 				["string", "filter", ""]]
 		opts = [["bool", "enabled", False],
-				["string", "logpath", None],
-				["string", "logtimezone", None],
-				["string", "logencoding", None],
 				["string", "backend", "auto"],
 				["int",    "maxretry", None],
 				["string", "findtime", None],
+				["string", "logpath", None],
+				["string", "logtimezone", None],
+				["string", "logencoding", None],
 				["string", "bantime", None],
 				["string", "usedns", None], # be sure usedns is before all regex(s) in stream
 				["string", "failregex", None],

--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -93,9 +93,6 @@ class JailReader(ConfigReader):
 				["string", "backend", "auto"],
 				["int",    "maxretry", None],
 				["string", "findtime", None],
-				["string", "logpath", None],
-				["string", "logtimezone", None],
-				["string", "logencoding", None],
 				["string", "bantime", None],
 				["string", "usedns", None], # be sure usedns is before all regex(s) in stream
 				["string", "failregex", None],
@@ -105,6 +102,9 @@ class JailReader(ConfigReader):
 				["string", "ignoreip", None],
 				["string", "filter", ""],
 				["string", "datepattern", None],
+				["string", "logtimezone", None],
+				["string", "logencoding", None],
+				["string", "logpath", None], # logpath after all log-related data (backend, date-pattern, etc)
 				["string", "action", ""]]
 
 		# Before interpolation (substitution) add static options always available as default:

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -887,9 +887,6 @@ class FileFilter(Filter):
 			self.__logs[path] = log
 			logSys.info("Added logfile: %r (pos = %s, hash = %s)" , path, log.getPos(), log.getHash())
 			if autoSeek:
-				# if default, seek to "current time" - "find time":
-				if isinstance(autoSeek, bool):
-					autoSeek = MyTime.time() - self.getFindTime()
 				self.__autoSeek[path] = autoSeek
 			self._addLogPath(path)			# backend specific
 
@@ -999,18 +996,21 @@ class FileFilter(Filter):
 				return False
 
 			# seek to find time for first usage only (prevent performance decline with polling of big files)
-			if self.__autoSeek.get(filename):
-				startTime = self.__autoSeek[filename]
-				del self.__autoSeek[filename]
-				# prevent completely read of big files first time (after start of service), 
-				# initial seek to start time using half-interval search algorithm:
-				try:
-					self.seekToTime(log, startTime)
-				except Exception as e: # pragma: no cover
-					logSys.error("Error during seek to start time in \"%s\"", filename)
-					raise
-					logSys.exception(e)
-					return False
+			if self.__autoSeek:
+				startTime = self.__autoSeek.pop(filename, None)
+				if startTime:
+					# if default, seek to "current time" - "find time":
+					if isinstance(startTime, bool):
+						startTime = MyTime.time() - self.getFindTime()
+					# prevent completely read of big files first time (after start of service), 
+					# initial seek to start time using half-interval search algorithm:
+					try:
+						self.seekToTime(log, startTime)
+					except Exception as e: # pragma: no cover
+						logSys.error("Error during seek to start time in \"%s\"", filename)
+						raise
+						logSys.exception(e)
+						return False
 
 			if has_content:
 				while not self.idle:


### PR DESCRIPTION
### Commit Message
When new log paths are configured, their start offset is immediately determined
by a filter searching for (now - findTime).
But, since findTime is configured *after* the log is loaded and
searched, logs are only searched back by the default 10 minute findTime,
regardless of user configuration of jail settings.

So, findTime must be configured before logpath or else the default findtime
is used, which ignores any findtime time defined by the user.

This fixes new reads on startup for actual log files. The systemd filter
always performed as expected due to being setup after the jail's
findtime config submission.

### Story Time!
It took me probably 10 hours to track down this problem. Spent a long time thinking regexes were just broken for half my jails because lookback-on-load worked reliably on some jails, but not others. Turns out the reliable jails were all systemd and loading from files was kinda broken. Then took a while to figure out how configs actually get loaded.


### Additional Fixes Maybe
The newer config options `logtimezone` and `logencoding` are also loaded after the logfile is initially processed. If those are used to read the log, they should also be configured before `logpath` gets sent to the transmitter, otherwise default class values will always be used instead of configured values.

and, one minor change that may have helped cut hours off these debuggles: surfacing the initial lookback results in INFO mode instead of deep debug mode ([here](https://github.com/fail2ban/fail2ban/blob/ddff67acb3f529e6835c66954d64f8fd322eefa6/fail2ban/server/filter.py#L1039-L1041) and [here](https://github.com/fail2ban/fail2ban/blob/ddff67acb3f529e6835c66954d64f8fd322eefa6/fail2ban/server/filter.py#L1118-L1120)) would be nice for users to always know (since it's the start point for _actually_ searching for bad actions on startup).