### PR TITLE
debian-initd: exit with non-0 if fail, account that 255 is "Ok" exit code, use 255 explicitly instead of -1

### DIFF
--- a/fail2ban/client/fail2banclient.py
+++ b/fail2ban/client/fail2banclient.py
@@ -69,7 +69,7 @@ class Fail2banClient(Fail2banCmdLine, Thread):
 		# Print a new line because we probably come from wait
 		output("")
 		logSys.warning("Caught signal %d. Exiting" % signum)
-		exit(-1)
+		exit(255)
 
 	def __ping(self, timeout=0.1):
 		return self.__processCmd([["ping"] + ([timeout] if timeout != -1 else [])],
@@ -500,5 +500,5 @@ def exec_command_line(argv):
 	if client.start(argv):
 		exit(0)
 	else:
-		exit(-1)
+		exit(255)
 

--- a/fail2ban/client/fail2banregex.py
+++ b/fail2ban/client/fail2banregex.py
@@ -668,7 +668,7 @@ def exec_command_line(*args):
 	if errors:
 		sys.stderr.write("\n".join(errors) + "\n\n")
 		parser.print_help()
-		sys.exit(-1)
+		sys.exit(255)
 
 	output( "" )
 	output( "Running tests" )
@@ -696,4 +696,4 @@ def exec_command_line(*args):
 
 	fail2banRegex = Fail2banRegex(opts)
 	if not fail2banRegex.start(args):
-		sys.exit(-1)
+		sys.exit(255)

--- a/fail2ban/client/fail2banserver.py
+++ b/fail2ban/client/fail2banserver.py
@@ -212,7 +212,7 @@ class Fail2banServer(Fail2banCmdLine):
 				if not phase.get('done', False):
 					if server: # pragma: no cover
 						server.quit()
-					exit(-1)
+					exit(255)
 				if background:
 					logSys.debug('Starting server done')
 
@@ -223,7 +223,7 @@ class Fail2banServer(Fail2banCmdLine):
 				logSys.error(e)
 			if server: # pragma: no cover
 				server.quit()
-			exit(-1)
+			exit(255)
 
 		return True
 
@@ -238,4 +238,4 @@ def exec_command_line(argv):
 	if server.start(argv):
 		exit(0)
 	else:
-		exit(-1)
+		exit(255)

--- a/fail2ban/tests/fail2banclienttestcase.py
+++ b/fail2ban/tests/fail2banclienttestcase.py
@@ -581,7 +581,7 @@ class Fail2banClientTest(Fail2banClientServerBase):
 			# test reload missing jail (direct):
 			self.execCmd(FAILED, startparams, "reload", "~~unknown~jail~fail~~")
 			self.assertLogged("Failed during configuration: No section: '~~unknown~jail~fail~~'")
-			self.assertLogged("Exit with code -1")
+			self.assertLogged("Exit with code 255")
 			self.pruneLog()
 		finally:
 			self.pruneLog()

--- a/files/debian-initd
+++ b/files/debian-initd
@@ -180,11 +180,17 @@ do_reload() {
 #
 log_end_msg_wrapper()
 {
-	[ $1 -lt $2 ] && value=0 || value=1
+	if [ $1 != 0 ] && [ $1 != $2 ]; then
+		value=1
+	else
+		value=0
+	fi
 	if [ "$3" != "no" ]; then
 		log_end_msg $value
 	fi
-	exit $value
+	if [ $code != 0 ]; then
+		exit $1
+	fi
 }
 
 command="$1"
@@ -192,13 +198,13 @@ case "$command" in
 	start|force-start)
 		[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
 		do_start "$command"
-		log_end_msg_wrapper $? 2 "$VERBOSE"
+		log_end_msg_wrapper $? 255 "$VERBOSE"
 		;;
 
 	stop)
 		[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
 		do_stop
-		log_end_msg_wrapper $? 2 "$VERBOSE"
+		log_end_msg_wrapper $? 255 "$VERBOSE"
 		;;
 
 	restart|force-reload)
@@ -207,7 +213,7 @@ case "$command" in
 		case "$?" in
 			0|1)
 				do_start
-				log_end_msg_wrapper $? 1 "always"
+				log_end_msg_wrapper $? 0 "always"
 				;;
 			*)
 				# Failed to stop

--- a/files/debian-initd
+++ b/files/debian-initd
@@ -180,10 +180,11 @@ do_reload() {
 #
 log_end_msg_wrapper()
 {
+	[ $1 -lt $2 ] && value=0 || value=1
 	if [ "$3" != "no" ]; then
-		[ $1 -lt $2 ] && value=0 || value=1
 		log_end_msg $value
 	fi
+	exit $value
 }
 
 command="$1"

--- a/files/debian-initd
+++ b/files/debian-initd
@@ -188,7 +188,7 @@ log_end_msg_wrapper()
 	if [ "$3" != "no" ]; then
 		log_end_msg $value
 	fi
-	if [ $code != 0 ]; then
+	if [ $value != "0" ]; then
 		exit $1
 	fi
 }


### PR DESCRIPTION
Proposed changes fixes #2187 (hopefully, yet to test in the docker)

Note that, after spending some time grepping for `exit.*255` decided to actually make it possible ;)