### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fail2ban (0.10.2-3) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 01:06:16 +0100
+
 fail2ban (0.10.2-2) unstable; urgency=medium
 
   [ Arturo Borrero Gonzalez ]

--- a/debian/control
+++ b/debian/control
@@ -11,8 +11,8 @@ Build-Depends:
  , python3-pyinotify
  , sqlite3
 Homepage: http://www.fail2ban.org
-Vcs-Git: git://github.com/fail2ban/fail2ban.git -b debian
-Vcs-Browser: http://github.com/fail2ban/fail2ban
+Vcs-Git: https://github.com/fail2ban/fail2ban.git -b debian
+Vcs-Browser: https://github.com/fail2ban/fail2ban
 Standards-Version: 4.1.3
 
 


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
