### PR TITLE
Improve regex in proftpd.conf

### DIFF
--- a/config/filter.d/proftpd.conf
+++ b/config/filter.d/proftpd.conf
@@ -18,7 +18,7 @@ __suffix_failed_login = (User not authorized for login|No such user found|Incorr
 
 failregex = ^%(__prefix_line)s%(__hostname)s \(\S+\[<HOST>\]\)[: -]+ USER .*: no such user found from \S+ \[\S+\] to \S+:\S+ *$
             ^%(__prefix_line)s%(__hostname)s \(\S+\[<HOST>\]\)[: -]+ USER .* \(Login failed\): %(__suffix_failed_login)s\s*$
-            ^%(__prefix_line)s%(__hostname)s \(\S+\[<HOST>\]\)[: -]+ SECURITY VIOLATION: .* login attempted\. *$
+            ^%(__prefix_line)s%(__hostname)s \(\S+\[<HOST>\]\)[: -]+ SECURITY VIOLATION: .* login attempted\.? *$
             ^%(__prefix_line)s%(__hostname)s \(\S+\[<HOST>\]\)[: -]+ Maximum login attempts \(\d+\) exceeded *$
 
 ignoreregex = 


### PR DESCRIPTION
proftpd 1.3.5e can leave inconsistent error message if ftp or mod_sftp is used
```
Oct  2 15:45:31 ftp01 proftpd[5516]: 10.10.2.13 (10.10.2.189[10.10.2.189]) - SECURITY VIOLATION: Root login attempted
Oct  2 15:45:44 ftp01 proftpd[5517]: 10.10.2.13 (10.10.2.189[10.10.2.189]) - SECURITY VIOLATION: Root login attempted.
```
Fix regex to make trailing period optional, otherwise brute force attacks against root account using ftp are not blocked correctly.

Before submitting your PR, please review the following checklist:

