### PR TITLE
filter.d/postfix.conf: allow to configure "mode = auth2"

### DIFF
--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -24,9 +24,10 @@ mdre-normal=^RCPT from [^[]*\[<HOST>\]%(_port)s: 55[04] 5\.7\.1\s
             ^RCPT from [^[]*\[<HOST>\]%(_port)s: 450 4\.1\.8 (<[^>]*>)?: Sender address rejected: Domain not found\b
             ^from [^[]*\[<HOST>\]%(_port)s:?
 
-mdpr-auth = warning:
-mdre-auth = ^[^[]*\[<HOST>\]%(_port)s: SASL ((?i)LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed:(?! Connection lost to authentication server| Invalid authentication mechanism)
-mdre-auth2= ^[^[]*\[<HOST>\]%(_port)s: SASL ((?i)LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed:(?! Connection lost to authentication server)
+mdpr-auth  = warning:
+mdre-auth  = ^[^[]*\[<HOST>\]%(_port)s: SASL ((?i)LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed:(?! Connection lost to authentication server| Invalid authentication mechanism)
+mdpr-auth2 = %(mdpr-auth)s
+mdre-auth2 = ^[^[]*\[<HOST>\]%(_port)s: SASL ((?i)LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed:(?! Connection lost to authentication server)
 # todo: check/remove "Invalid authentication mechanism" from ignore list, if gh-1243 will get finished (see gh-1297).
 
 # Mode "rbl" currently included in mode "normal", but if needed for jail "postfix-rbl" only:
@@ -52,7 +53,7 @@ mdre-aggressive = %(mdre-auth2)s
 
 failregex = <mdre-<mode>>
 
-# Parameter "mode": more (default combines normal and rbl), auth, normal, rbl, ddos, extra or aggressive (combines all)
+# Parameter "mode": more (default combines normal and rbl), auth, auth2, normal, rbl, ddos, extra or aggressive (combines all)
 # Usage example (for jail.local):
 #   [postfix]
 #   mode = aggressive


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [ ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [ ] **KEEP PR small** so it could be easily reviewed.
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
