### PR TITLE
new filter: znc-adminlog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -50,6 +50,7 @@ ver. 0.11.0-dev-0 (20??/??/??) - development nightly edition
 * Introduced new action command `actionprolong` to prolong ban-time (e. g. set new timeout if expected);
   Several actions (like ipset, etc.) rewritten using net logic with `actionprolong`.
   Note: because ban-time is dynamic, it was removed from jail.conf as timeout argument (check jail.local).
+* A filter for ZNC (IRC bouncer); requires the adminlog module to be loaded
 
 ### Enhancements
 * algorithm of restore current bans after restart changed: update the restored ban-time (and therefore 

--- a/config/filter.d/znc-adminlog.conf
+++ b/config/filter.d/znc-adminlog.conf
@@ -1,0 +1,18 @@
+# Fail2Ban filter for ZNC (requires adminlog module)
+#
+# to use this module, enable the adminlog module from within ZNC and point
+# logpath to its logfile (e.g. /var/lib/znc/moddata/adminlog/znc.log).
+
+[Definition]
+
+failregex = ^\[\] \[[^]]+\] failed to login from <HOST>$
+
+ignoreregex = 
+
+# DEV Notes:
+# Log format is: [<DATE+TIME>] [<USERNAME>] <ACTION> from <HOST>
+# [2018-10-27 01:40:17] [girst] connected to ZNC from 1.2.3.4
+# [2018-10-27 01:40:21] [girst] disconnected from ZNC from 1.2.3.4
+# [2018-10-27 01:40:55] [girst] failed to login from 1.2.3.4
+#
+# Author: Tobias Girstmair (//gir.st/)

--- a/config/filter.d/znc-adminlog.conf
+++ b/config/filter.d/znc-adminlog.conf
@@ -5,12 +5,12 @@
 
 [Definition]
 
-failregex = ^\[\] \[[^]]+\] failed to login from <HOST>$
+failregex = ^\[\] \[[^]]+\] failed to login from <ADDR>$
 
 ignoreregex = 
 
 # DEV Notes:
-# Log format is: [<DATE+TIME>] [<USERNAME>] <ACTION> from <HOST>
+# Log format is: [<DATE+TIME>] [<USERNAME>] <ACTION> from <ADDR>
 # [2018-10-27 01:40:17] [girst] connected to ZNC from 1.2.3.4
 # [2018-10-27 01:40:21] [girst] disconnected from ZNC from 1.2.3.4
 # [2018-10-27 01:40:55] [girst] failed to login from 1.2.3.4

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -768,6 +768,13 @@ logpath  = /var/log/freeswitch.log
 maxretry = 10
 
 
+# enable adminlog; it will log to a file inside znc's directory by default.
+[znc-adminlog]
+
+port     = 6667
+logpath  = /var/lib/znc/moddata/adminlog/znc.log
+
+
 # To log wrong MySQL access attempts add to /etc/my.cnf in [mysqld] or
 # equivalent section:
 # log-warning = 2

--- a/fail2ban/tests/files/logs/znc-adminlog
+++ b/fail2ban/tests/files/logs/znc-adminlog
@@ -1,0 +1,7 @@
+# failJSON: { "time": "2018-10-27T01:40:55", "match": true , "host": "1.2.3.4" }
+[2018-10-27 01:40:55] [girst] failed to login from 1.2.3.4
+
+# failJSON: { "match": false }
+[2018-10-27 01:40:17] [girst] connected to ZNC from 1.2.3.4
+# failJSON: { "match": false }
+[2018-10-27 01:40:21] [girst] disconnected from ZNC from 1.2.3.4


### PR DESCRIPTION
[ZNC](https://wiki.znc.in) is an IRC bouncer (used for keeping logs while you are away). I've written a filter that will ban users who failed to log in. It requires the adminlog module (comes with ZNC) to be loaded, as ZNC keeps silent about failed login attempts otherwise. 

I'm using it myself with this jail configuration:
```
[znc-adminlog]
enabled = true
filter = znc-adminlog
action = iptables[name=IRC, port=ircd, protocol=tcp]
logpath = /home/znc/.znc/moddata/adminlog/znc.log
maxretry = 5
```

