### PR TITLE
Add firehol.service to systemd unit PartOf and After directives

### DIFF
--- a/files/fail2ban.service.in
+++ b/files/fail2ban.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=Fail2Ban Service
 Documentation=man:fail2ban(1)
-After=network.target iptables.service firewalld.service ip6tables.service ipset.service
-PartOf=iptables.service firewalld.service ip6tables.service ipset.service
+After=network.target iptables.service firewalld.service ip6tables.service ipset.service firehol.service
+PartOf=iptables.service firewalld.service ip6tables.service ipset.service firehol.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
References https://github.com/firehol/firehol/wiki/fail2ban, https://github.com/firehol/firehol/issues/272, https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=881669

[FireHOL](https://github.com/firehol/firehol/) is a tool to create and managed stateful iptables firewall configurations. It is packaged for major Linux distributions. On startup/restart, FireHOL overwrites/clears all configured iptables rules, including fail2ban-generated rules. This often causes fail2ban iptables rules to be silently lost when restarting the `firehol`  service. The wiki page describes a way to add custom `PartOf`  and `After` directives to the fail2ban systemd unit file so that fail2ban is always stopped _before_ restarting `firehol.service`  (allowing it to remove its rules), and (re)started _after_ the firewall has finished starting up.

This patch removes the need to create a systemd override file, correctly removing/restoring fail2ban rules on firewall stop/start/restart.

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves: proper fix for https://github.com/firehol/firehol/issues/272, https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=881669
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [ ] **KEEP PR small** so it could be easily reviewed.
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
