### PR TITLE
filter.d/squid.conf: Improve existing failregexes against bot crawlers

### DIFF
--- a/config/filter.d/squid.conf
+++ b/config/filter.d/squid.conf
@@ -4,8 +4,9 @@
 
 [Definition]
 
-failregex = ^\s+\d\s<HOST>\s+[A-Z_]+_DENIED/403 .*$
-            ^\s+\d\s<HOST>\s+NONE/405 .*$
+failregex = ^\s+\d+ <HOST> [A-Z_]+_DENIED/403 .*$
+            ^\s+\d+ <HOST> NONE/405 .*$
+            ^\s+\d+ <HOST> TAG_NONE/400 .*$
 
 ignoreregex =
 

--- a/fail2ban/tests/files/logs/squid
+++ b/fail2ban/tests/files/logs/squid
@@ -11,3 +11,12 @@
 
 # failJSON: { "time": "2013-12-09T00:09:06.000", "match": true , "host": "175.42.91.151" }
 1386544146.000      1 175.42.91.151 TCP_DENIED/403 3745 GET http://pkfsp.ru/wp-content/uploads/proxyc/engine.php - HIER_NONE/- text/html
+
+# failJSON: { "time": "2018-11-11T20:57:18.107", "match": true , "host": "71.6.200.217" }
+1541969838.107      0 71.6.200.217 TAG_NONE/400 4134 GET /cf_scripts/scripts/ajax/ckeditor/plugins/filemanager/filemanager.cfc?method=getfmfiles&returnformat=plain&path=. - HIER_NONE/- text/html
+
+# failJSON: { "time": "2018-11-11T20:08:11.248", "match": true , "host": "41.221.158.74" }
+1541966891.248      0 41.221.158.74 TAG_NONE/400 3895 GET / - HIER_NONE/- text/html
+
+# failJSON: { "time": "2018-11-11T12:08:56.727", "match": true , "host": "180.76.157.155" }
+1541938136.727      1 180.76.157.155 TAG_NONE/400 3910 GET /webdav/ - HIER_NONE/- text/html


### PR DESCRIPTION
- improve existing failregexes
- recognize failures from bot crawlers (eg. HTTP error code 400)

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file

Current filter for Squid Proxy does not detect failures from bots trying to crawl on the proxy itself. This mostly happens if the proxy is set to listen on ports normally used for web servers (eg: port 80 and 443).