### PR TITLE
Add link to https://fail2ban.readthedocs.io in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ mechanisms if you really want to protect services.
 ------|------
 
 This README is a quick introduction to Fail2Ban. More documentation, FAQ, and HOWTOs
-to be found on fail2ban(1) manpage, [Documentation](https://fail2ban.readthedocs.io/), [Wiki](https://github.com/fail2ban/fail2ban/wiki)
+to be found on fail2ban(1) manpage, [Wiki](https://github.com/fail2ban/fail2ban/wiki),
+[Developers documentation](https://fail2ban.readthedocs.io/)
 and the website: https://www.fail2ban.org
 
 Installation:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ mechanisms if you really want to protect services.
 ------|------
 
 This README is a quick introduction to Fail2Ban. More documentation, FAQ, and HOWTOs
-to be found on fail2ban(1) manpage, [Wiki](https://github.com/fail2ban/fail2ban/wiki)
+to be found on fail2ban(1) manpage, [Documentation](https://fail2ban.readthedocs.io/), [Wiki](https://github.com/fail2ban/fail2ban/wiki)
 and the website: https://www.fail2ban.org
 
 Installation:


### PR DESCRIPTION
It's hard to find https://fail2ban.readthedocs.io because it's not linked somewhere, isn't it?

IMHO it's also good to link it on https://www.fail2ban.org/ in a **well visible, prominent place**!