### PR TITLE
setup.py: adding option to ignore tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,9 +119,11 @@ class install_scripts_f2b(install_scripts):
 class install_command_f2b(install):
 	user_options = install.user_options + [
 		('disable-2to3', None, 'Specify to deactivate 2to3, e.g. if the install runs from fail2ban test-cases.'),
+		('without-tests', None, 'without tests files installation'),
 	]
 	def initialize_options(self):
 		self.disable_2to3 = None
+		self.without_tests = None
 		install.initialize_options(self)
 	def finalize_options(self):
 		global _2to3
@@ -132,6 +134,28 @@ class install_command_f2b(install):
 			cmdclass = self.distribution.cmdclass
 			cmdclass['build_py'] = build_py_2to3
 			cmdclass['build_scripts'] = build_scripts_2to3
+		if self.without_tests is None:
+			self.distribution.scripts += [
+				'bin/fail2ban-testcases',
+			]
+
+			self.distribution.packages += [
+				'fail2ban.tests',
+				'fail2ban.tests.action_d',
+			]
+
+			self.distribution.package_data = {
+				'fail2ban.tests':
+					[ join(w[0], f).replace("fail2ban/tests/", "", 1)
+						for w in os.walk('fail2ban/tests/files')
+						for f in w[2]] +
+					[ join(w[0], f).replace("fail2ban/tests/", "", 1)
+						for w in os.walk('fail2ban/tests/config')
+						for f in w[2]] +
+					[ join(w[0], f).replace("fail2ban/tests/", "", 1)
+						for w in os.walk('fail2ban/tests/action_d')
+						for f in w[2]]
+			}
 		install.finalize_options(self)
 	def run(self):
 		install.run(self)
@@ -208,35 +232,20 @@ setup(
 	license = "GPL",
 	platforms = "Posix",
 	cmdclass = {
-		'build_py': build_py, 'build_scripts': build_scripts, 
+		'build_py': build_py, 'build_scripts': build_scripts,
 		'install_scripts': install_scripts_f2b, 'install': install_command_f2b
 	},
 	scripts = [
 		'bin/fail2ban-client',
 		'bin/fail2ban-server',
 		'bin/fail2ban-regex',
-		'bin/fail2ban-testcases',
 		# 'bin/fail2ban-python', -- link (binary), will be installed via install_scripts_f2b wrapper
 	],
 	packages = [
 		'fail2ban',
 		'fail2ban.client',
 		'fail2ban.server',
-		'fail2ban.tests',
-		'fail2ban.tests.action_d',
 	],
-	package_data = {
-		'fail2ban.tests':
-			[ join(w[0], f).replace("fail2ban/tests/", "", 1)
-				for w in os.walk('fail2ban/tests/files')
-				for f in w[2]] +
-			[ join(w[0], f).replace("fail2ban/tests/", "", 1)
-				for w in os.walk('fail2ban/tests/config')
-				for f in w[2]] +
-			[ join(w[0], f).replace("fail2ban/tests/", "", 1)
-				for w in os.walk('fail2ban/tests/action_d')
-				for f in w[2]]
-	},
 	data_files = [
 		('/etc/fail2ban',
 			glob("config/*.conf")


### PR DESCRIPTION
Tests files are not always needed especially when installing on low
resource systems like an embedded one.
This patch adds the `--without-tests` option to skip building and
installing of tests files.
