### PR TITLE
SOGo filter not matching auth failures when behind a proxy.

### DIFF
--- a/config/filter.d/sogo-auth.conf
+++ b/config/filter.d/sogo-auth.conf
@@ -4,7 +4,7 @@
 
 [Definition]
 
-failregex = ^ sogod \[\d+\]: SOGoRootPage Login from '<HOST>' for user '.*' might not have worked( - password policy: \d*  grace: -?\d*  expire: -?\d*  bound: -?\d*)?\s*$
+failregex = ^ sogod \[\d+\]: SOGoRootPage Login from '<HOST>(?:,[^']*)?' for user '[^']*' might not have worked( - password policy: \d*  grace: -?\d*  expire: -?\d*  bound: -?\d*)?\s*$
 
 ignoreregex = "^<ADDR>"
 

--- a/fail2ban/tests/files/logs/sogo-auth
+++ b/fail2ban/tests/files/logs/sogo-auth
@@ -29,3 +29,6 @@ Mar 24 08:58:59 sogod [26818]: SOGoRootPage Login from '173.194.44.31' for user 
 Mar 24 08:59:04 sogod [26818]: <0x0xb8537990[LDAPSource]> <NSException: 0xb87bc088> NAME:LDAPException REASON:operation bind failed: Invalid credentials (0x31) INFO:{login = "uid=admin,ou=users,dc=mail,dc=example,dc=org"; }
 # failJSON: { "time": "2005-03-24T08:59:04", "match": true , "host": "173.194.44.31" }
 Mar 24 08:59:04 sogod [26818]: SOGoRootPage Login from '173.194.44.31' for user 'admin' might not have worked - password policy: 65535  grace: -1  expire: -1  bound: 0
+# failJSON: { "time": "2005-03-24T19:29:32", "match": true , "host": "192.0.2.16", "desc": "behind a proxy, gh-2289" }
+Mar 24 19:29:32 sogod [1526]: SOGoRootPage Login from '192.0.2.16, 10.0.0.1' for user 'admin' might not have worked - password policy: 65535  grace: -1  expire: -1  bound: 0
+


### PR DESCRIPTION
Fixes issue #2289