### PR TITLE
grep command to include loglines in mail could not deal with Apache's error log

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -65,6 +65,8 @@ ver. 0.10.5-dev-1 (20??/??/??) - development edition
 ### Fixes
 * fixed read of included config-files (`.local` overwrites options of `.conf` for config-files 
   included with before/after)
+* `action.d/helpers-common.conf`: rewritten grep arguments, now options `-wF` used to match only
+  whole words and fixed string (not as pattern), gh-2298
 * `filter.d/sshd.conf`:
   - captures `Disconnecting ...: Change of username or service not allowed` (gh-2239, gh-2279)
   - captures `Disconnected from ... [preauth]` (`extra`/`aggressive` mode and preauth phase only, gh-2239, gh-2279)

--- a/config/action.d/helpers-common.conf
+++ b/config/action.d/helpers-common.conf
@@ -4,8 +4,9 @@
 #   _grep_logs_args = 'test'
 #   (printf %%b "Log-excerpt contains 'test':\n"; %(_grep_logs)s; printf %%b "Log-excerpt contains 'test':\n") | mail ...
 #
-_grep_logs = logpath="<logpath>"; grep <grepopts> -E %(_grep_logs_args)s $logpath | <greplimit>
-_grep_logs_args = "(^|[^0-9a-fA-F:])$(echo '<ip>' | sed 's/\./\\./g')([^0-9a-fA-F:]|$)"
+_grep_logs = logpath="<logpath>"; grep <grepopts> %(_grep_logs_args)s $logpath | <greplimit>
+# options `-wF` used to match only whole words and fixed string (not as pattern)
+_grep_logs_args = -wF "<ip>"
 
 # Used for actions, that should not by executed if ticket was restored:
 _bypass_if_restored = if [ '<restored>' = '1' ]; then exit 0; fi;


### PR DESCRIPTION
The error log from Apache appends the port number to the IP address, e.g. 
```
[Fri Dec 07 06:18:24.826187 2018] [php7:error] [pid 87678] [client 127.0.0.1:5196] script '/usr/local/www/apache24/data/test.php' not found or unable to stat
```
The grep command to search the log files for the given IP address could not deal with it and thus the mail did not include the lines.
