### PR TITLE
Upgrade to AbuseIPDB API v2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -70,6 +70,7 @@ ver. 0.10.5-dev-1 (20??/??/??) - development edition
   message, see gh-2431)
 * fixed read of included config-files (`.local` overwrites options of `.conf` for config-files 
   included with before/after)
+* `action.d/abuseipdb.conf`: switched to use AbuseIPDB API v2 (gh-2302)
 * `action.d/helpers-common.conf`: rewritten grep arguments, now options `-wF` used to match only
   whole words and fixed string (not as pattern), gh-2298
 * `filter.d/sshd.conf`:

--- a/config/action.d/abuseipdb.conf
+++ b/config/action.d/abuseipdb.conf
@@ -83,13 +83,10 @@ actioncheck =
 #          wherever you install the helper script. For the PHP helper script, see
 #          <https://wiki.shaunc.com/wikka.php?wakka=ReportingToAbuseIPDBWithFail2Ban>
 #
-#          --ciphers ecdhe_ecdsa_aes_256_sha is used to workaround a
-#          "NSS error -12286" from curl as it attempts to connect using
-#          SSLv3. See https://www.centos.org/forums/viewtopic.php?t=52732
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = lgm=$(printf '%%s\n...' "<matches>"); curl --fail --tlsv1.1 --data "key=<abuseipdb_apikey>" --data-urlencode "comment=$lgm" --data "ip=<ip>" --data "category=<abuseipdb_category>" "https://www.abuseipdb.com/report/json"
+actionban = lgm=$(printf '%%.1000s\n...' "<matches>"); curl -sSf "https://api.abuseipdb.com/api/v2/report" -H "Accept: application/json" -H "Key: <abuseipdb_apikey>" --data-urlencode "comment=$lgm" --data-urlencode "ip=<ip>" --data "categories=<abuseipdb_category>"
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the


### PR DESCRIPTION
The IP value should be encoded because IPv6 addresses have colons.