### PR TITLE
Update DEVELOP reg. ipdns.py as successor for dnsutils.py

### DIFF
--- a/DEVELOP
+++ b/DEVELOP
@@ -262,12 +262,16 @@ FileContainer
     Keeps the position pointer
 
 
-dnsutils.py
-~~~~~~~~~~~
+ipdns.py
+~~~~~~~~
 
 DNSUtils
 
-  Utility class for DNS and IP handling
+  Utility class for DNS handling
+
+IPAddr
+
+  Object-class for IP address handling
 
 
 filter*.py


### PR DESCRIPTION
Just spotted the mentioning of dnsutils.py which is not valid anymore.
There is not much to explain for this pull req.