### PR TITLE
fix: correct spelling category

### DIFF
--- a/config/action.d/abuseipdb.conf
+++ b/config/action.d/abuseipdb.conf
@@ -101,5 +101,5 @@ actionunban =
 # Notes    Your API key from abuseipdb.com
 # Values:  STRING  Default: None
 # Register for abuseipdb [https://www.abuseipdb.com], get api key and set below.
-# You will need to set the catagory in the action call.
+# You will need to set the category in the action call.
 abuseipdb_apikey =


### PR DESCRIPTION
Correct spelling of category in comments for abuseipdb.conf file.

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
