### PR TITLE
Adjusted default exim main log path in Arch

### DIFF
--- a/config/paths-arch.conf
+++ b/config/paths-arch.conf
@@ -13,7 +13,7 @@ apache_error_log = /var/log/httpd/*error_log
 
 apache_access_log = /var/log/httpd/*access_log
 
-exim_main_log = /var/log/exim/main.log
+exim_main_log = /var/log/exim/mainlog
 
 mysql_log = /var/log/mariadb/mariadb.log
             /var/log/mysqld.log


### PR DESCRIPTION
Arch uses a slightly different path for Exim's main log file. This fix prevents fail2ban from failing during startup.