### PR TITLE
Provide visual feedback inside status

### DIFF
--- a/config/action.d/ufw.conf
+++ b/config/action.d/ufw.conf
@@ -14,7 +14,7 @@ actionstop =
 actioncheck = 
 
 actionban = [ -n "<application>" ] && app="app <application>"
-            ufw insert <insertpos> <blocktype> from <ip> to <destination> $app
+            ufw insert <insertpos> <blocktype> from <ip> to <destination> $app comment 'fail2ban'
 
 actionunban = [ -n "<application>" ] && app="app <application>"
               ufw delete <blocktype> from <ip> to <destination> $app


### PR DESCRIPTION
Adding a comment to the rule insertion allows fail2ban rules to be identified from the 'ufw status' command.