### PR TITLE
Add override for dovecot failed logins on debian

### DIFF
--- a/config/paths-debian.conf
+++ b/config/paths-debian.conf
@@ -31,6 +31,8 @@ apache_error_log = /var/log/apache2/*error.log
 apache_access_log = /var/log/apache2/*access.log
 
 
+dovecot_log = /var/log/mail.log
+
 # was in debian squeezy but not in wheezy
 # /etc/proftpd/proftpd.conf (SystemLog)
 proftpd_log = /var/log/proftpd/proftpd.log

--- a/config/paths-debian.conf
+++ b/config/paths-debian.conf
@@ -31,7 +31,7 @@ apache_error_log = /var/log/apache2/*error.log
 apache_access_log = /var/log/apache2/*access.log
 
 
-dovecot_log = /var/log/mail.log
+dovecot_log = %(syslog_mail)s
 
 # was in debian squeezy but not in wheezy
 # /etc/proftpd/proftpd.conf (SystemLog)


### PR DESCRIPTION
On Debian 9 (stretch), by default failed login attempts for Dovecot are logged in `/var/log/auth.log` rather than `/var/log/mail.warn`. This override corrects for this behavior.

This behavior should probably be independently verified for:
 - Other Debian releases (both older and newer if possible)
 - Independent Debian installations to entirely ensure this **really** is default behavior for Dovecot.

(Time permitting, I will do both of these things soon. But if any other Debian users have noticed this behavior too, please let us know.)