### PR TITLE
Sent sender for %(mta)s-whois for asterisk and freeswitch jails

### DIFF
--- a/config/jail.conf
+++ b/config/jail.conf
@@ -701,7 +701,7 @@ logpath = /var/log/nsd.log
 port     = 5060,5061
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
-           %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
+           %(mta)s-whois[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", chain="%(chain)s"]
 logpath  = /var/log/asterisk/messages
 maxretry = 10
 
@@ -711,7 +711,7 @@ maxretry = 10
 port     = 5060,5061
 action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
            %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
-           %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
+           %(mta)s-whois[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", chain="%(chain)s"]
 logpath  = /var/log/freeswitch.log
 maxretry = 10
 


### PR DESCRIPTION
In response to Fedora bug report - https://bugzilla.redhat.com/show_bug.cgi?id=1666855

Provided configuration for Asterisk jail does not use the proper sender. In my installation this is causing the messages to be queued and never delivered as the default sender it is using is a bare username with no domain.