### PR TITLE
New filter `nginx-noscript`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -50,6 +50,8 @@ ver. 0.11.0-dev-0 (20??/??/??) - development nightly edition
 * Introduced new action command `actionprolong` to prolong ban-time (e. g. set new timeout if expected);
   Several actions (like ipset, etc.) rewritten using net logic with `actionprolong`.
   Note: because ban-time is dynamic, it was removed from jail.conf as timeout argument (check jail.local).
+* `filter.d/nginx-noscript.conf`: used to ban script sniffing, which is not captured by nginx-botsearch.
+
 
 ### Enhancements
 * algorithm of restore current bans after restart changed: update the restored ban-time (and therefore 

--- a/config/filter.d/nginx-noscript.conf
+++ b/config/filter.d/nginx-noscript.conf
@@ -1,0 +1,20 @@
+# Fail2Ban filter to match web requests for selected URLs that don't exist
+#
+
+[Definition]
+
+block = .*\/?(\.php|\.aspx?|\.jsp|\.exe)(\?.+)?
+
+failregex = ^ \[error\] \d+#\d+: \*\d+ (\S+ )?FastCGI sent in stderr\: "[pP]rimary script unknown" while reading response header from upstream, client\: <HOST>\, server\: \S*\, request: \"(GET|POST|HEAD) \/<block> \S+\"\, .*?$
+
+ignoreregex = 
+
+datepattern = {^LN-BEG}%%ExY(?P<_sep>[-/.])%%m(?P=_sep)%%d[T ]%%H:%%M:%%S(?:[.,]%%f)?(?:\s*%%z)?
+              ^[^\[]*\[({DATE})
+              {^LN-BEG}
+
+# DEV Notes:
+# example: 2019/03/01 22:53:49 [error] 3202#0: *136 FastCGI sent in stderr: "Primary script unknown" while reading response header from upstream, client: 1.2.3.4, server: example.com, request: "GET /robots1.php HTTP/1.1", upstream: "fastcgi://127.0.0.1:9000", host: "example.com", referrer: "https://example.com/robots1.php"
+
+# 
+# Author: zhangciwu

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -391,6 +391,11 @@ port     = http,https
 logpath  = %(nginx_error_log)s
 maxretry = 2
 
+[nginx-noscript]
+
+port     = http,https
+logpath  = %(nginx_error_log)s
+
 
 # Ban attackers that try to use PHP's URL-fopen() functionality
 # through GET/POST variables. - Experimental, with more than a year

--- a/fail2ban/tests/files/logs/nginx-noscript
+++ b/fail2ban/tests/files/logs/nginx-noscript
@@ -1,0 +1,2 @@
+# failJSON: { "time": "2019/03/01T22:53:49", "match": true , "host": "1.2.3.4" }
+2019/03/01 22:53:49 [error] 3202#0: *136 FastCGI sent in stderr: "Primary script unknown" while reading response header from upstream, client: 1.2.3.4, server: example.com, request: "GET /robots1.php HTTP/1.1", upstream: "fastcgi://127.0.0.1:9000", host: "example.com", referrer: "https://example.com/robots1.php"


### PR DESCRIPTION
My server got some annoying script sniffing, so I wrote a filter to detect and ban.
`nginx-noscript` is used to ban script sniffing, which is not captured by nginx-botsearch.

log file and changelog provided