### PR TITLE
add reading of firewallcmd-common.local

### DIFF
--- a/config/action.d/firewallcmd-common.conf
+++ b/config/action.d/firewallcmd-common.conf
@@ -2,6 +2,12 @@
 #
 # Author: Donald Yandt
 #
+# The user can override the defaults in firewallcmd-common.local
+#
+
+[INCLUDES]
+
+after = firewallcmd-common.local
 
 [Init]
 


### PR DESCRIPTION
config/action.d/firewallcmd-common.conf is missing the [INCLUDES] section known from other action.d files. (e.g. iptables-common.conf / nftables-common.conf ) to read a .local file for modification of the defaults.