### PR TITLE
setup.py: fixing /var/run installation when crosscompiling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ from os.path import isfile, join, isdir, realpath
 import re
 import sys
 import warnings
+import pkg_resources
 from glob import glob
 
 from fail2ban.setup import updatePyExec
@@ -199,11 +200,12 @@ else:
 	setup_extra = {}
 
 data_files_extra = []
-if os.path.exists('/var/run'):
+if os.path.exists(pkg_resources.resource_filename('fail2ban', '/var/run')):
 	# if we are on the system with /var/run -- we are to use it for having fail2ban/
 	# directory there for socket file etc.
-	# realpath is used to possibly resolve /var/run -> /run symlink
-	data_files_extra += [(realpath('/var/run/fail2ban'), '')]
+	data_files_extra.append(
+		('/var/run/fail2ban', '')
+	)
 
 # Installing documentation files only under Linux or other GNU/ systems
 # (e.g. GNU/kFreeBSD), since others might have protective mechanisms forbidding


### PR DESCRIPTION
When crosscompiling, python root is different from the system one, thus
the path /var/run cannot be used as is.
To obtain the path where the resource file will be created, we use
therefore the pkg_resources.resource_filename function.
This patch removes also the check for /var/run to /run symlink:
setuptools is able to create the fail2ban folder both when the
destination is a directory or a symlink

Signed-off-by: Angelo Compagnucci <angelo@amarulasolutions.com>

Before submitting your PR, please review the following checklist:

- [ ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [ ] **KEEP PR small** so it could be easily reviewed.
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
