### PR TITLE
Update sendmail-reject with TLSMTA & MSA port IDs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -43,7 +43,7 @@ ver. 0.10.5-dev-1 (20??/??/??) - development edition
 * `filter.d/mysqld-auth.conf`: 
   - MYSQL 8.0.13 compatibility (log-error-verbosity = 3), log-format contains few additional words
     enclosed in brackets after "[Note]" (gh-2314)
-* `filter.d/sshd.conf`:
+* `filter.d/sendmail-reject.conf`:
   - `mode=extra` now captures port IDs of `TLSMTA` and `MSA` (defaults for ports 465 and 587 on some distros)
 
 * `files/fail2ban.service.in`: fixed systemd-unit template - missing nftables dependency (gh-2313)

--- a/ChangeLog
+++ b/ChangeLog
@@ -43,6 +43,9 @@ ver. 0.10.5-dev-1 (20??/??/??) - development edition
 * `filter.d/mysqld-auth.conf`: 
   - MYSQL 8.0.13 compatibility (log-error-verbosity = 3), log-format contains few additional words
     enclosed in brackets after "[Note]" (gh-2314)
+* `filter.d/sshd.conf`:
+  - `mode=extra` now captures port IDs of `TLSMTA` and `MSA` (defaults for ports 465 and 587 on some distros)
+
 * `files/fail2ban.service.in`: fixed systemd-unit template - missing nftables dependency (gh-2313)
 * several `action.d/mail*`: fixed usage with multiple log files (ultimate fix for gh-976, gh-2341)
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -45,7 +45,6 @@ ver. 0.10.5-dev-1 (20??/??/??) - development edition
     enclosed in brackets after "[Note]" (gh-2314)
 * `filter.d/sendmail-reject.conf`:
   - `mode=extra` now captures port IDs of `TLSMTA` and `MSA` (defaults for ports 465 and 587 on some distros)
-
 * `files/fail2ban.service.in`: fixed systemd-unit template - missing nftables dependency (gh-2313)
 * several `action.d/mail*`: fixed usage with multiple log files (ultimate fix for gh-976, gh-2341)
 

--- a/config/filter.d/sendmail-reject.conf
+++ b/config/filter.d/sendmail-reject.conf
@@ -32,7 +32,7 @@ cmnfailre = ^ruleset=check_rcpt, arg1=(?P<email><\S+@\S+>), relay=(\S+ )?\[(?:IP
 
 mdre-normal =
 
-mdre-extra = ^(?:\S+ )?\[(?:IPv6:<IP6>|<IP4>)\](?: \(may be forged\))? did not issue (?:[A-Z]{4}[/ ]?)+during connection to M(?:TA|SP)(?:-\w+)?$
+mdre-extra = ^(?:\S+ )?\[(?:IPv6:<IP6>|<IP4>)\](?: \(may be forged\))? did not issue (?:[A-Z]{4}[/ ]?)+during connection to (?:TLS)?M(?:TA|SP|SA)(?:-\w+)?$
 
 mdre-aggressive = %(mdre-extra)s
 

--- a/config/filter.d/sendmail-reject.conf
+++ b/config/filter.d/sendmail-reject.conf
@@ -32,7 +32,7 @@ cmnfailre = ^ruleset=check_rcpt, arg1=(?P<email><\S+@\S+>), relay=(\S+ )?\[(?:IP
 
 mdre-normal =
 
-mdre-extra = ^(?:\S+ )?\[(?:IPv6:<IP6>|<IP4>)\](?: \(may be forged\))? did not issue (?:[A-Z]{4}[/ ]?)+during connection to (?:TLS)?M(?:TA|SP|SA)(?:-\w+)?$
+mdre-extra = ^(?:\S+ )?\[(?:IPv6:<IP6>|<IP4>)\](?: \(may be forged\))? did not issue (?:[A-Z]{4}[/ ]?)+during connection to (?:TLS)?M(?:TA|S[PA])(?:-\w+)?$
 
 mdre-aggressive = %(mdre-extra)s
 

--- a/fail2ban/tests/files/logs/sendmail-reject
+++ b/fail2ban/tests/files/logs/sendmail-reject
@@ -96,7 +96,7 @@ Mar  6 16:55:28 s192-168-0-1 sm-mta[20949]: v26LtRA0020949: some-host-24.example
 # failJSON: { "time": "2005-03-07T15:04:37", "match": true , "host": "192.0.2.195", "desc": "wrong resp. non RFC compiant (ddos prelude?), MSP-mode, (may be forged)" }
 Mar  7 15:04:37 s192-168-0-1 sm-mta[18624]: v27K4Vj8018624: some-host-24.example.org [192.0.2.195] (may be forged) did not issue MAIL/EXPN/VRFY/ETRN during connection to MSP-v4
 
-# failJSON: { "time": "2019-03-29T22:33:47", "match": true , "host": "104.152.52.29", "desc": "wrong resp. non RFC compiant (ddos prelude?), TLSMTA-mode" }
+# failJSON: { "time": "2005-03-29T22:33:47", "match": true , "host": "104.152.52.29", "desc": "wrong resp. non RFC compiant (ddos prelude?), TLSMTA-mode" }
 Mar 29 22:33:47 kismet sm-mta[23221]: x2TMXH7Y023221: internettl.org [104.152.52.29] (may be forged) did not issue MAIL/EXPN/VRFY/ETRN during connection to TLSMTA
-# failJSON: { "time": "2019-03-29T22:51:42", "match": true , "host": "104.152.52.29", "desc": "wrong resp. non RFC compiant (ddos prelude?), MSA-mode" }
+# failJSON: { "time": "2005-03-29T22:51:42", "match": true , "host": "104.152.52.29", "desc": "wrong resp. non RFC compiant (ddos prelude?), MSA-mode" }
 Mar 29 22:51:42 kismet sm-mta[24202]: x2TMpAlI024202: internettl.org [104.152.52.29] (may be forged) did not issue MAIL/EXPN/VRFY/ETRN during connection to MSA

--- a/fail2ban/tests/files/logs/sendmail-reject
+++ b/fail2ban/tests/files/logs/sendmail-reject
@@ -95,3 +95,8 @@ Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026255: from=<anton@domain.co
 Mar  6 16:55:28 s192-168-0-1 sm-mta[20949]: v26LtRA0020949: some-host-24.example.org [192.0.2.194] did not issue MAIL/EXPN/VRFY/ETRN during connection to MTA
 # failJSON: { "time": "2005-03-07T15:04:37", "match": true , "host": "192.0.2.195", "desc": "wrong resp. non RFC compiant (ddos prelude?), MSP-mode, (may be forged)" }
 Mar  7 15:04:37 s192-168-0-1 sm-mta[18624]: v27K4Vj8018624: some-host-24.example.org [192.0.2.195] (may be forged) did not issue MAIL/EXPN/VRFY/ETRN during connection to MSP-v4
+
+# failJSON: { "time": "2019-03-29T22:33:47", "match": true , "host": "104.152.52.29", "desc": "wrong resp. non RFC compiant (ddos prelude?), TLSMTA-mode" }
+Mar 29 22:33:47 kismet sm-mta[23221]: x2TMXH7Y023221: internettl.org [104.152.52.29] (may be forged) did not issue MAIL/EXPN/VRFY/ETRN during connection to TLSMTA
+# failJSON: { "time": "2019-03-29T22:51:42", "match": true , "host": "104.152.52.29", "desc": "wrong resp. non RFC compiant (ddos prelude?), MSA-mode" }
+Mar 29 22:51:42 kismet sm-mta[24202]: x2TMpAlI024202: internettl.org [104.152.52.29] (may be forged) did not issue MAIL/EXPN/VRFY/ETRN during connection to MSA


### PR DESCRIPTION
Updates `sendmail-reject` filter and associated test files to accommodate port IDs of TLSMTA and MSA, which are default for ports 465 and 587 (respectively) on some distros (e.g., RHEL/CentOS).