### PR TITLE
SSHd add Bad protocol version message

### DIFF
--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -64,6 +64,7 @@ mdre-normal =
 mdrp-normal-suff-onclosed = (?:%(__suff)s|\s*)$
 
 mdre-ddos = ^Did not receive identification string from <HOST>
+            ^Bad protocol version identification '.*' from <HOST>
             ^Connection <F-MLFFORGET>reset</F-MLFFORGET> by <HOST>
             ^Connection <F-MLFFORGET>closed</F-MLFFORGET> by%(__authng_user)s <HOST>%(__on_port_opt)s\s+\[preauth\]\s*$
             ^<F-NOFAIL>SSH: Server;Ltype:</F-NOFAIL> (?:Authname|Version|Kex);Remote: <HOST>-\d+;[A-Z]\w+:

--- a/fail2ban/tests/config/filter.d/zzz-sshd-obsolete-multiline.conf
+++ b/fail2ban/tests/config/filter.d/zzz-sshd-obsolete-multiline.conf
@@ -56,6 +56,7 @@ cmnfailre = ^%(__prefix_line_sl)s[aA]uthentication (?:failure|error|failed) for 
 mdre-normal =
 
 mdre-ddos =  ^%(__prefix_line_sl)sDid not receive identification string from <HOST>
+             ^%(__prefix_line_sl)sBad protocol version identification '.*' from <HOST>
              ^%(__prefix_line_sl)sConnection closed by%(__authng_user)s <HOST>%(__on_port_opt)s\s+\[preauth\]\s*$
              ^%(__prefix_line_sl)sConnection reset by <HOST>
              ^%(__prefix_line_ml1)sSSH: Server;Ltype: (?:Authname|Version|Kex);Remote: <HOST>-\d+;[A-Z]\w+:.*%(__prefix_line_ml2)sRead from socket failed: Connection reset by peer%(__suff)s$

--- a/fail2ban/tests/files/logs/sshd
+++ b/fail2ban/tests/files/logs/sshd
@@ -260,6 +260,8 @@ Mar  7 18:53:38 bar sshd[1559]: Connection closed by 192.0.2.116
 Jun 7 01:10:56 host sshd[5937]: Did not receive identification string from 69.61.56.114
 # failJSON: { "time": "2005-06-07T01:11:57", "match": true , "host": "192.0.2.5", "desc": "refactored message (with port now, gh-2062)" }
 Jun 7 01:11:57 host sshd[8782]: Did not receive identification string from 192.0.2.5 port 35836
+# failJSON: { "time": "2005-06-07T01:11:58", "match": true , "host": "69.61.56.115" }
+Jun 7 01:11:58 host sshd[8783]: Bad protocol version identification 'dummy string' from 69.61.56.115 port 31778
 
 # gh-864(1):
 # failJSON: { "match": false }

--- a/fail2ban/tests/files/logs/sshd
+++ b/fail2ban/tests/files/logs/sshd
@@ -260,8 +260,10 @@ Mar  7 18:53:38 bar sshd[1559]: Connection closed by 192.0.2.116
 Jun 7 01:10:56 host sshd[5937]: Did not receive identification string from 69.61.56.114
 # failJSON: { "time": "2005-06-07T01:11:57", "match": true , "host": "192.0.2.5", "desc": "refactored message (with port now, gh-2062)" }
 Jun 7 01:11:57 host sshd[8782]: Did not receive identification string from 192.0.2.5 port 35836
-# failJSON: { "time": "2005-06-07T01:11:58", "match": true , "host": "69.61.56.115" }
+# failJSON: { "time": "2005-06-07T01:11:58", "match": true , "host": "69.61.56.115", "desc": "bad protocol version, gh-2404" }
 Jun 7 01:11:58 host sshd[8783]: Bad protocol version identification 'dummy string' from 69.61.56.115 port 31778
+# failJSON: { "time": "2005-06-07T01:11:58", "match": true , "host": "69.61.56.115", "desc": "check inject on ident" }
+Jun 7 01:11:58 host sshd[8783]: Bad protocol version identification 'dummy string' from 192.0.2.1' from 69.61.56.115 port 31778
 
 # gh-864(1):
 # failJSON: { "match": false }


### PR DESCRIPTION
Hi,

This PR adds the `Bad protocol version identification '.........' from A.B.C.D port 1234` message to the SSHd filter, as discussed in #1284.

Thank you very much 👍 