### PR TITLE
Update config/filter.d/named-refused.conf

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -99,6 +99,9 @@ ver. 0.10.5-dev-1 (20??/??/??) - development edition
     - extended with new postfix filter mode `errors` to match "too many errors" (gh-2439),
       also included within modes `normal`, `more` (`extra` and `aggressive`), since postfix
       parameter `smtpd_hard_error_limit` is default 20 (additionally consider `maxretry`)
+* `filter.d/named-refused.conf`:
+    - support BIND 9.11.0 log format (includes an additional field @0xXXX..., gh-2406);
+    - `prefregex` extended, more selective now (denied/NOTAUTH suffix moved from failregex, so no catch-all there anymore)
 
 ### New Features
 * new failregex-flag tag `<F-MLFGAINED>` for failregex, signaled that the access to service was gained

--- a/config/filter.d/named-refused.conf
+++ b/config/filter.d/named-refused.conf
@@ -34,11 +34,11 @@ __daemon_combs_re=(?:%(__pid_re)s?:\s+%(__daemon_re)s|%(__daemon_re)s%(__pid_re)
 # this can be optional (for instance if we match named native log files)
 __line_prefix=(?:\s\S+ %(__daemon_combs_re)s\s+)?
 
-prefregex = ^%(__line_prefix)s( error:)?\s*client <HOST>#\S+( \([\S.]+\))?: <F-CONTENT>.+</F-CONTENT>$
+prefregex = ^%(__line_prefix)s(?: error:)?\s*client(?: @\S*)? <HOST>#\S+(?: \([\S.]+\))?: <F-CONTENT>.+</F-CONTENT>\s(?:denied|\(NOTAUTH\))\s*$
 
-failregex = ^(view (internal|external): )?query(?: \(cache\))? '.*' denied\s*$
-            ^zone transfer '\S+/AXFR/\w+' denied\s*$
-            ^bad zone transfer request: '\S+/IN': non-authoritative zone \(NOTAUTH\)\s*$
+failregex = ^(?:view (?:internal|external): )?query(?: \(cache\))?
+            ^zone transfer
+            ^bad zone transfer request: '\S+/IN': non-authoritative zone
 
 ignoreregex =
 

--- a/fail2ban/tests/files/logs/named-refused
+++ b/fail2ban/tests/files/logs/named-refused
@@ -23,3 +23,6 @@ Aug 17 08:20:22 catinthehat named[2954]: client 223.252.23.219#56275: zone trans
 27-Aug-2013 17:49:45.330 client 59.167.242.100#44281 (watt.kiev.ua): zone transfer 'watt.kiev.ua/AXFR/IN' denied
 # failJSON: { "time": "2004-08-27T16:58:31", "match": true , "host": "176.9.92.38" }
 Aug 27 16:58:31 vhost1-ua named[29206]: client 176.9.92.38#42592 (simmarket.com.ua): bad zone transfer request: 'simmarket.com.ua/IN': non-authoritative zone (NOTAUTH)
+
+# failJSON: { "time": "2004-08-27T16:59:00", "match": true , "host": "192.0.2.1", "desc": "new log format, 9.11.0 (#2406)" }
+Aug 27 16:59:00 host named[28098]: client @0x7f6450002ef0 192.0.2.1#23332 (example.com): bad zone transfer request: 'test.com/IN': non-authoritative zone (NOTAUTH)


### PR DESCRIPTION
Log format changed since ver. 9.11.0
Ref. ftp://ftp.isc.org/isc/bind9/9.11.0/RELEASE-NOTES-bind-9.11.0.html
"The logging format used for querylog has been altered. It now includes an additional field indicating the address in memory of the client object processing the query."
