### PR TITLE
recognize more sshd versions

### DIFF
--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -19,7 +19,7 @@ before = common.conf
 _daemon = sshd
 
 # optional prefix (logged from several ssh versions) like "error: ", "error: PAM: " or "fatal: "
-__pref = (?:(?:error|fatal): (?:PAM: )?)?
+__pref = ((?:(?:error|fatal): )?(?:PAM: )?)?
 # optional suffix (logged from several ssh versions) like " [preauth]"
 #__suff = (?: port \d+)?(?: \[preauth\])?\s*
 __suff = (?: (?:port \d+|on \S+|\[preauth\])){0,3}\s*


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
  - None known.
- [ ] **MAKE SURE** this PR doesn't break existing tests
  - Don't know how to do that.
- [x] **KEEP PR small** so it could be easily reviewed.
- [X] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
  - Didn't change `failregex`.

This fixes finding the third line in the following output:
> Apr 29 19:15:35 sabayon sshd[26876]: pam_tally2(sshd:auth): Tally overflowed for user root
Apr 29 19:15:36 sabayon sshd[26876]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty=ssh ruser= rhost=61.177.172.157  user=root                                                                                                                         
Apr 29 19:15:38 sabayon sshd[888]: PAM: Authentication failure for root from 61.177.172.157
Apr 29 19:15:38 sabayon sshd[888]: Received disconnect from 61.177.172.157 port 52321:11:  [preauth]
Apr 29 19:15:38 sabayon sshd[888]: Disconnected from authenticating user root 61.177.172.157 port 52321 [preauth]

The log output is from a freshly installed Sabayon Linux amd64 19.01 and using Fail2Ban v0.10.4.
