### PR TITLE
systemd-backend: switched default flags to SYSTEM_ONLY(4)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,8 @@ ver. 0.10.5-dev-1 (20??/??/??) - development edition
 -----------
 
 ### Fixes
+* [compatibility] systemd backend: default flags changed to SYSTEM_ONLY(4), fixed in gh-2444 in order to ignore
+  user session files per default, so could prevent "Too many open files" errors on a lot of user sessions (see gh-2392)
 * [grave] fixed parsing of multi-line filters (`maxlines` > 1) together with systemd backend,
   now systemd-filter replaces newlines in message from systemd journal with `\n` (otherwise 
   multi-line parsing may be broken, because removal of matched string from multi-line buffer window

--- a/fail2ban/server/filtersystemd.py
+++ b/fail2ban/server/filtersystemd.py
@@ -86,10 +86,12 @@ class FilterSystemd(JournalFilter): # pragma: systemd no cover
 				files.extend(glob.glob(p))
 			args['files'] = list(set(files))
 
+		# Default flags is SYSTEM_ONLY(4). This would lead to ignore user session files,
+		# so can prevent "Too many open files" errors on a lot of user sessions (see gh-2392):
 		try:
 			args['flags'] = int(kwargs.pop('journalflags'))
 		except KeyError:
-			pass
+			args['flags'] = 4
 
 		return args
 


### PR DESCRIPTION
Default `journalflags` is set to SYSTEM_ONLY(4). This conforms to following settings:
```ini
backend = systemd[journalflags=4]
```
This default setting should avoid to open the user session files, so could prevent "Too many open files" errors (like #2208) on a lot of user sessions;
(following @opoplawski's proposal in #2392).

Since default journal reader flag seems to be LOCAL_ONLY(1), this is not backwards-compatible change, to switch back to original value use:
```ini
backend = systemd[journalflags=1]
```

Note also the source code of python-systemd module, e. g.:
https://github.com/systemd/python-systemd/blob/5d3be8ccba5fe48b09e2a4e816f21c39038adfd0/systemd/_reader.c#L227-L232