### PR TITLE
Normalization of mailing actions

### DIFF
--- a/config/action.d/mail-whois-common.conf
+++ b/config/action.d/mail-whois-common.conf
@@ -17,7 +17,7 @@ _whois = whois <ip> || echo "missing whois program"
 # character set before sending it to a mail program
 # make sure you have 'file' and 'iconv' commands installed when opting for that
 _whois_target_charset = UTF-8
-_whois_convert_charset = whois <ip> |
+_whois_convert_charset = (%(_whois)s) |
                          { WHOIS_OUTPUT=$(cat) ; WHOIS_CHARSET=$(printf %%b "$WHOIS_OUTPUT" | file -b --mime-encoding -) ; printf %%b "$WHOIS_OUTPUT" | iconv -f $WHOIS_CHARSET -t %(_whois_target_charset)s//TRANSLIT - ; }
 
 # choose between _whois and _whois_convert_charset in mail-whois-common.local

--- a/config/action.d/sendmail-buffered.conf
+++ b/config/action.d/sendmail-buffered.conf
@@ -24,7 +24,7 @@ actionstart = printf %%b "Subject: [Fail2Ban] <name>: started on <fq-hostname>
               The jail <name> has been started successfully.\n
               Output will be buffered until <lines> lines are available.\n
               Regards,\n
-              Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+              Fail2Ban" | <mailcmd>
 
 # Option:  actionstop
 # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
@@ -38,7 +38,7 @@ actionstop = if [ -f <tmpfile> ]; then
                  These hosts have been banned by Fail2Ban.\n
                  `cat <tmpfile>`
                  Regards,\n
-                 Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+                 Fail2Ban" | <mailcmd>
                  rm <tmpfile>
              fi
              printf %%b "Subject: [Fail2Ban] <name>: stopped  on <fq-hostname>
@@ -47,7 +47,7 @@ actionstop = if [ -f <tmpfile> ]; then
              Hi,\n
              The jail <name> has been stopped.\n
              Regards,\n
-             Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+             Fail2Ban" | <mailcmd>
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command
@@ -71,7 +71,7 @@ actionban = printf %%b "`date`: <ip> (<failures> failures)\n" >> <tmpfile>
                 These hosts have been banned by Fail2Ban.\n
                 `cat <tmpfile>`
                 Regards,\n
-                Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+                Fail2Ban" | <mailcmd>
                 rm <tmpfile>
             fi
 

--- a/config/action.d/sendmail-common.conf
+++ b/config/action.d/sendmail-common.conf
@@ -21,7 +21,7 @@ actionstart = printf %%b "Subject: [Fail2Ban] <name>: started on <fq-hostname>
               Hi,\n
               The jail <name> has been started successfully.\n
               Regards,\n
-              Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+              Fail2Ban" | <mailcmd>
 
 # Option:  actionstop
 # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
@@ -34,7 +34,7 @@ actionstop = printf %%b "Subject: [Fail2Ban] <name>: stopped on <fq-hostname>
              Hi,\n
              The jail <name> has been stopped.\n
              Regards,\n
-             Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+             Fail2Ban" | <mailcmd>
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command
@@ -59,6 +59,10 @@ actionban =
 actionunban =
 
 [Init]
+
+# Your system mail command
+#
+mailcmd = /usr/sbin/sendmail -f "<sender>" "<dest>"
 
 # Recipient mail address
 #

--- a/config/action.d/sendmail-geoip-lines.conf
+++ b/config/action.d/sendmail-geoip-lines.conf
@@ -37,11 +37,11 @@ actionban = ( printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from <fq-hostn
             Country:`geoiplookup -f /usr/share/GeoIP/GeoIP.dat "<ip>" | cut -d':' -f2-`
             AS:`geoiplookup -f /usr/share/GeoIP/GeoIPASNum.dat "<ip>" | cut -d':' -f2-`
             hostname: <ip-host>\n\n
-            Lines containing failures of <ip>\n";
+            Lines containing failures of <ip> (max <grepmax>)\n";
             %(_grep_logs)s;
             printf %%b "\n
             Regards,\n
-            Fail2Ban" ) | /usr/sbin/sendmail -f <sender> <dest>
+            Fail2Ban" ) | <mailcmd>
 
 [Init]
 

--- a/config/action.d/sendmail-whois-ipjailmatches.conf
+++ b/config/action.d/sendmail-whois-ipjailmatches.conf
@@ -7,6 +7,7 @@
 [INCLUDES]
 
 before = sendmail-common.conf
+         mail-whois-common.conf
 
 [Definition]
 
@@ -27,11 +28,11 @@ actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from <fq-hostnam
             The IP <ip> has just been banned by Fail2Ban after
             <failures> attempts against <name>.\n\n
             Here is more information about <ip> :\n
-            `/usr/bin/whois <ip>`\n\n
+            `%(_whois_command)s`\n\n
             Matches for <name> with <ipjailfailures> failures IP:<ip>\n
             <ipjailmatches>\n\n
             Regards,\n
-            Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+            Fail2Ban" | <mailcmd>
 
 [Init]
 

--- a/config/action.d/sendmail-whois-ipmatches.conf
+++ b/config/action.d/sendmail-whois-ipmatches.conf
@@ -7,6 +7,7 @@
 [INCLUDES]
 
 before = sendmail-common.conf
+         mail-whois-common.conf
 
 [Definition]
 
@@ -27,11 +28,11 @@ actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from <fq-hostnam
             The IP <ip> has just been banned by Fail2Ban after
             <failures> attempts against <name>.\n\n
             Here is more information about <ip> :\n
-            `/usr/bin/whois <ip>`\n\n
+            `%(_whois_command)s`\n\n
             Matches with <ipfailures> failures IP:<ip>\n
             <ipmatches>\n\n
             Regards,\n
-            Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+            Fail2Ban" | <mailcmd>
 
 [Init]
 

--- a/config/action.d/sendmail-whois-lines.conf
+++ b/config/action.d/sendmail-whois-lines.conf
@@ -7,6 +7,7 @@
 [INCLUDES]
 
 before = sendmail-common.conf
+         mail-whois-common.conf
          helpers-common.conf
 
 [Definition]
@@ -27,13 +28,13 @@ actionban = ( printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from <fq-hostn
             Hi,\n
             The IP <ip> has just been banned by Fail2Ban after
             <failures> attempts against <name>.\n\n
-            Here is more information about <ip> :\n
-            `/usr/bin/whois <ip> || echo missing whois program`\n\n
-            Lines containing failures of <ip>\n";
+            Here is more information about <ip> :\n"
+            %(_whois_command)s;
+            printf %%b "\nLines containing failures of <ip> (max <grepmax>)\n";
             %(_grep_logs)s;
             printf %%b "\n
             Regards,\n
-            Fail2Ban" ) | /usr/sbin/sendmail -f <sender> <dest>
+            Fail2Ban" ) | <mailcmd>
 
 [Init]
 

--- a/config/action.d/sendmail-whois-matches.conf
+++ b/config/action.d/sendmail-whois-matches.conf
@@ -7,6 +7,7 @@
 [INCLUDES]
 
 before = sendmail-common.conf
+         mail-whois-common.conf
 
 [Definition]
 
@@ -27,11 +28,11 @@ actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from <fq-hostnam
             The IP <ip> has just been banned by Fail2Ban after
             <failures> attempts against <name>.\n\n
             Here is more information about <ip> :\n
-            `/usr/bin/whois <ip>`\n\n
+            `%(_whois_command)s`\n\n
             Matches:\n
             <matches>\n\n
             Regards,\n
-            Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+            Fail2Ban" | <mailcmd>
 
 [Init]
 

--- a/config/action.d/sendmail-whois.conf
+++ b/config/action.d/sendmail-whois.conf
@@ -7,6 +7,7 @@
 [INCLUDES]
 
 before = sendmail-common.conf
+         mail-whois-common.conf
 
 [Definition]
 
@@ -27,9 +28,9 @@ actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from <fq-hostnam
             The IP <ip> has just been banned by Fail2Ban after
             <failures> attempts against <name>.\n\n
             Here is more information about <ip> :\n
-            `/usr/bin/whois <ip> || echo missing whois program`\n
+            `%(_whois_command)s`\n
             Regards,\n
-            Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+            Fail2Ban" | <mailcmd>
 
 [Init]
 

--- a/config/action.d/sendmail.conf
+++ b/config/action.d/sendmail.conf
@@ -27,7 +27,7 @@ actionban = printf %%b "Subject: [Fail2Ban] <name>: banned <ip> from <fq-hostnam
             The IP <ip> has just been banned by Fail2Ban after
             <failures> attempts against <name>.\n
             Regards,\n
-            Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+            Fail2Ban" | <mailcmd>
 
 [Init]
 

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -1883,8 +1883,8 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 		cmd = realCmd
 		if isinstance(realCmd, list):
 			cmd = realCmd[0]
-		cmd = re.sub(r'\)\s*\|\s*mail\b([^\n]*)',
-			r') | cat; printf "\\n... | "; echo mail \1', cmd)
+		cmd = re.sub(r'\)\s*\|\s*(\S*mail\b[^\n]*)',
+			r') | cat; printf "\\n... | "; echo \1', cmd)
 		# replace abuse retrieving (possible no-network), just replace first occurrence of 'dig...':
 		cmd = re.sub(r'\bADDRESSES=\$\(dig\s[^\n]+',
 			lambda m: 'ADDRESSES="abuse-1@abuse-test-server, abuse-2@abuse-test-server"',
@@ -1912,6 +1912,26 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 				'ip4-ban': (
 					'The IP 87.142.124.10 has just been banned by Fail2Ban after',
 					'100 attempts against j-mail-whois-lines.',
+					'Here is more information about 87.142.124.10 :',
+					'-- information about 87.142.124.10 --',
+					'Lines containing failures of 87.142.124.10 (max 2)',
+					'testcase01.log:Dec 31 11:59:59 [sshd] error: PAM: Authentication failure for kevin from 87.142.124.10',
+					'testcase01a.log:Dec 31 11:55:01 [sshd] error: PAM: Authentication failure for test from 87.142.124.10',
+				),
+			}),
+			# sendmail-whois-lines --
+			('j-sendmail-whois-lines', 
+				'sendmail-whois-lines['
+				  '''name=%(__name__)s, grepopts="-m 1", grepmax=2, mailcmd='testmail -f "<sender>" "<dest>"', ''' +
+					# 2 logs to test grep from multiple logs:
+				  'logpath="' + os.path.join(TEST_FILES_DIR, "testcase01.log") + '\n' +
+			    '         ' + os.path.join(TEST_FILES_DIR, "testcase01a.log") + '", '
+				  '_whois_command="echo \'-- information about <ip> --\'"'
+				  ']',
+			{
+				'ip4-ban': (
+					'The IP 87.142.124.10 has just been banned by Fail2Ban after',
+					'100 attempts against j-sendmail-whois-lines.',
 					'Here is more information about 87.142.124.10 :',
 					'-- information about 87.142.124.10 --',
 					'Lines containing failures of 87.142.124.10 (max 2)',


### PR DESCRIPTION
Normalize, simplify and fix several mail actions:
- actions `mail` and `sendmail` are more similar now (and some derivatives using same includes and parameters);
- `sendmail` is configurable via parameter `mailcmd`;
- added test covering sendmail-whois-lines action;
