### PR TITLE
Improved blocklist_de action to not resend bans that were already reported

### DIFF
--- a/config/action.d/blocklist_de.conf
+++ b/config/action.d/blocklist_de.conf
@@ -57,7 +57,6 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-
 actionban = curl --fail --data-urlencode "server=<email>" --data "apikey=<apikey>" --data "service=<service>" --data "ip=<ip>" --data-urlencode "logs=<matches><br>" --data 'format=text' --user-agent "<agent>" "https://www.blocklist.de/en/httpreports.html"
 
 # Option:  actionunban

--- a/config/action.d/blocklist_de.conf
+++ b/config/action.d/blocklist_de.conf
@@ -30,6 +30,9 @@
 
 [Definition]
 
+# bypass reporting of restored (already reported) tickets:
+norestored = 1
+
 # Option:  actionstart
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
 # Values:  CMD
@@ -55,20 +58,7 @@ actioncheck =
 # Values:  CMD
 #
 
-tmpfile = "/var/run/fail2ban/last-log-<name>.time"
-
-actionban = if [ ! -e "<tmpfile>" ]
-            then
-                # if the file doesn't exist yet, create it
-                touch -d @<time> "<tmpfile>"
-                curl --fail --data-urlencode "server=<email>" --data "apikey=<apikey>" --data "service=<service>" --data "ip=<ip>" --data-urlencode "logs=<matches><br>" --data 'format=text' --user-agent "<agent>" "https://www.blocklist.de/en/httpreports.html"
-            fi
-            if [ $(stat -c %%X "<tmpfile>") -lt <time> ]
-            then
-                # If the time of the offense is later than the last ban, actually report it to blocklist.de
-                touch -d @<time> "<tmpfile>"
-                curl --fail --data-urlencode "server=<email>" --data "apikey=<apikey>" --data "service=<service>" --data "ip=<ip>" --data-urlencode "logs=<matches><br>" --data 'format=text' --user-agent "<agent>" "https://www.blocklist.de/en/httpreports.html"
-            fi
+actionban = curl --fail --data-urlencode "server=<email>" --data "apikey=<apikey>" --data "service=<service>" --data "ip=<ip>" --data-urlencode "logs=<matches><br>" --data 'format=text' --user-agent "<agent>" "https://www.blocklist.de/en/httpreports.html"
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the

--- a/config/action.d/blocklist_de.conf
+++ b/config/action.d/blocklist_de.conf
@@ -54,7 +54,21 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = curl --fail --data-urlencode "server=<email>" --data "apikey=<apikey>" --data "service=<service>" --data "ip=<ip>" --data-urlencode "logs=<matches><br>" --data 'format=text' --user-agent "<agent>" "https://www.blocklist.de/en/httpreports.html"
+
+tmpfile = "/var/run/fail2ban/last-log-<name>.time"
+
+actionban = if [ ! -e "<tmpfile>" ]
+            then
+                # if the file doesn't exist yet, create it
+                touch -d @<time> "<tmpfile>"
+                curl --fail --data-urlencode "server=<email>" --data "apikey=<apikey>" --data "service=<service>" --data "ip=<ip>" --data-urlencode "logs=<matches><br>" --data 'format=text' --user-agent "<agent>" "https://www.blocklist.de/en/httpreports.html"
+            fi
+            if [ $(stat -c %%X "<tmpfile>") -lt <time> ]
+            then
+                # If the time of the offense is later than the last ban, actually report it to blocklist.de
+                touch -d @<time> "<tmpfile>"
+                curl --fail --data-urlencode "server=<email>" --data "apikey=<apikey>" --data "service=<service>" --data "ip=<ip>" --data-urlencode "logs=<matches><br>" --data 'format=text' --user-agent "<agent>" "https://www.blocklist.de/en/httpreports.html"
+            fi
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the


### PR DESCRIPTION
This works fine except when two bans have the exact same time stamp. Solving that corner case would require a significantly more complex solution.
This PR solves the problem that fail2ban will report already reported attacks again when fail2ban is restarted and the bans are still active.