### PR TITLE
Password Mismatch failregex should check for capital letter

### DIFF
--- a/config/filter.d/apache-auth.conf
+++ b/config/filter.d/apache-auth.conf
@@ -17,7 +17,7 @@ auth_type = ([A-Z]\w+: )?
 failregex = ^client (?:denied by server configuration|used wrong authentication scheme)\b
             ^user (?!`)<F-USER>(?:\S*|.*?)</F-USER> (?:auth(?:oriz|entic)ation failure|not found|denied by provider)\b
             ^Authorization of user <F-USER>(?:\S*|.*?)</F-USER> to access .*? failed\b
-            ^%(auth_type)suser <F-USER>(?:\S*|.*?)</F-USER>: password mismatch\b
+            ^%(auth_type)suser <F-USER>(?:\S*|.*?)</F-USER>: [Pp]assword [Mm]ismatch\b
             ^%(auth_type)suser `<F-USER>(?:[^']*|.*?)</F-USER>' in realm `.+' (auth(?:oriz|entic)ation failure|not found|denied by provider)\b
             ^%(auth_type)sinvalid nonce .* received - length is not\b
             ^%(auth_type)srealm mismatch - got `(?:[^']*|.*?)' but expected\b


### PR DESCRIPTION
Apache error.log on Ubuntu 18.04
`[Thu Jul 18 09:22:44.478380 2019] [auth_basic:error] [pid 30211:tid 140698783291136] [client 213.95.148.172:53661] AH01617: user someone: authentication failure for "/some/path": Password Mismatch`
gets missed by the current failregex.
