### PR TITLE
Ubuntu specific log-files paths

### DIFF
--- a/config/paths-ubuntu.conf
+++ b/config/paths-ubuntu.conf
@@ -1,0 +1,24 @@
+# Ubuntu log-file locations
+
+[INCLUDES]
+
+before = paths-common.conf
+
+after  = paths-overrides.local
+
+
+[DEFAULT]
+syslog_local0 = /var/log/syslog
+syslog_mail = /var/log/mail.log
+
+# control the `mail.warn` setting, see `/etc/rsyslog.d/50-default.conf` (if commented `mail.*` wins).
+# syslog_mail_warn = /var/log/mail.warn
+syslog_mail_warn = %(syslog_mail)s
+
+exim_main_log = /var/log/exim4/mainlog
+
+mysql_log = /var/log/mysql/error.log
+
+postfix_log = %(syslog_mail)s
+
+proftpd_log = /var/log/proftpd/proftpd.log


### PR DESCRIPTION
Considering that Debian and Ubuntu doesn't have the same log files I propose a separate path config file for Ubuntu.

I discovered that mainly the system logs differs while application logs seems mostly to be the same. I compared on a base of Ubuntu-Mate 16.04/18.04 and Rasperian (Debian).