### PR TITLE
Updated sendmail-auth.conf for longer mail IDs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -77,6 +77,8 @@ ver. 0.10.5-dev-1 (20??/??/??) - development edition
 * `filter.d/named-refused.conf`:
     - support BIND 9.11.0 log format (includes an additional field @0xXXX..., gh-2406);
     - `prefregex` extended, more selective now (denied/NOTAUTH suffix moved from failregex, so no catch-all there anymore)
+* `filter.d/sendmail-auth.conf`, `filter.d/sendmail-reject.conf` :
+  - ID in prefix can be longer as 14 characters (gh-2563);
 
 ### New Features
 * new failregex-flag tag `<F-MLFGAINED>` for failregex, signaled that the access to service was gained

--- a/config/filter.d/sendmail-auth.conf
+++ b/config/filter.d/sendmail-auth.conf
@@ -9,7 +9,8 @@ before = common.conf
 
 _daemon = (?:sendmail|sm-(?:mta|acceptingconnections))
 
-failregex = ^%(__prefix_line)s\w{14}: (\S+ )?\[(?:IPv6:<IP6>|<IP4>)\]( \(may be forged\))?: possible SMTP attack: command=AUTH, count=\d+$
+# "w{14,20}" will give support for IDs from 14 up to 20 characters long
+failregex = ^%(__prefix_line)s\w{14,20}: (\S+ )?\[(?:IPv6:<IP6>|<IP4>)\]( \(may be forged\))?: possible SMTP attack: command=AUTH, count=\d+$
 
 ignoreregex =
 

--- a/config/filter.d/sendmail-auth.conf
+++ b/config/filter.d/sendmail-auth.conf
@@ -8,9 +8,10 @@ before = common.conf
 [Definition]
 
 _daemon = (?:sendmail|sm-(?:mta|acceptingconnections))
+__prefix_line = %(known/__prefix_line)s(?:\w{14,20}: )?
 
 # "w{14,20}" will give support for IDs from 14 up to 20 characters long
-failregex = ^%(__prefix_line)s\w{14,20}: (\S+ )?\[(?:IPv6:<IP6>|<IP4>)\]( \(may be forged\))?: possible SMTP attack: command=AUTH, count=\d+$
+failregex = ^%(__prefix_line)s(\S+ )?\[(?:IPv6:<IP6>|<IP4>)\]( \(may be forged\))?: possible SMTP attack: command=AUTH, count=\d+$
 
 ignoreregex =
 

--- a/config/filter.d/sendmail-reject.conf
+++ b/config/filter.d/sendmail-reject.conf
@@ -20,8 +20,9 @@ before = common.conf
 [Definition]
 
 _daemon = (?:(sm-(mta|acceptingconnections)|sendmail))
+__prefix_line = %(known/__prefix_line)s(?:\w{14,20}: )?
 
-prefregex = ^<F-MLFID>%(__prefix_line)s(?:\w{14}: )?</F-MLFID><F-CONTENT>.+</F-CONTENT>$
+prefregex = ^<F-MLFID>%(__prefix_line)s</F-MLFID><F-CONTENT>.+</F-CONTENT>$
 
 cmnfailre = ^ruleset=check_rcpt, arg1=(?P<email><\S+@\S+>), relay=(\S+ )?\[(?:IPv6:<IP6>|<IP4>)\](?: \(may be forged\))?, reject=(550 5\.7\.1 (?P=email)\.\.\. Relaying denied\. (IP name possibly forged \[(\d+\.){3}\d+\]|Proper authentication required\.|IP name lookup failed \[(\d+\.){3}\d+\])|553 5\.1\.8 (?P=email)\.\.\. Domain of sender address \S+ does not exist|550 5\.[71]\.1 (?P=email)\.\.\. (Rejected: .*|User unknown))$
             ^ruleset=check_relay, arg1=(?P<dom>\S+), arg2=(?:IPv6:<IP6>|<IP4>), relay=((?P=dom) )?\[(\d+\.){3}\d+\](?: \(may be forged\))?, reject=421 4\.3\.2 (Connection rate limit exceeded\.|Too many open connections\.)$

--- a/fail2ban/tests/files/logs/sendmail-auth
+++ b/fail2ban/tests/files/logs/sendmail-auth
@@ -14,3 +14,7 @@ Feb 24 13:00:17 kismet sm-acceptingconnections[1499]: s1OHxxSn001499: 192.241.70
 # gh-1632, Fedora 24/RHEL - the daemon name is "sendmail":
 # failJSON: { "time": "2005-02-24T14:00:00", "match": true , "host": "192.0.2.1" }
 Feb 24 14:00:00 server sendmail[26592]: u0CB32qX026592: [192.0.2.1]: possible SMTP attack: command=AUTH, count=5
+
+# github pull request 2563: failing with IDs longer than 14 characters (15 in this case):
+# failJSON: { "time": "2019-11-07T03:27:08", "match": true , "host": "156.156.156.156" }
+Nov  3 03:27:08 servername sendmail[3529565]: xA32R2PQ3529565: [156.156.156.156] did not issue MAIL/EXPN/VRFY/ETRN during connection to MTA

--- a/fail2ban/tests/files/logs/sendmail-auth
+++ b/fail2ban/tests/files/logs/sendmail-auth
@@ -15,6 +15,5 @@ Feb 24 13:00:17 kismet sm-acceptingconnections[1499]: s1OHxxSn001499: 192.241.70
 # failJSON: { "time": "2005-02-24T14:00:00", "match": true , "host": "192.0.2.1" }
 Feb 24 14:00:00 server sendmail[26592]: u0CB32qX026592: [192.0.2.1]: possible SMTP attack: command=AUTH, count=5
 
-# github pull request 2563: failing with IDs longer than 14 characters (15 in this case):
-# failJSON: { "time": "2019-11-07T03:27:08", "match": true , "host": "156.156.156.156" }
-Nov  3 03:27:08 servername sendmail[3529565]: xA32R2PQ3529565: [156.156.156.156] did not issue MAIL/EXPN/VRFY/ETRN during connection to MTA
+# failJSON: { "time": "2005-02-24T14:00:01", "match": true , "host": "192.0.2.2", "desc": "long PID, ID longer as 14 chars (gh-2563)" }
+Feb 24 14:00:01 server sendmail[3529566]: xA32R2PQ3529566: [192.0.2.2]: possible SMTP attack: command=AUTH, count=5

--- a/fail2ban/tests/files/logs/sendmail-reject
+++ b/fail2ban/tests/files/logs/sendmail-reject
@@ -100,3 +100,6 @@ Mar  7 15:04:37 s192-168-0-1 sm-mta[18624]: v27K4Vj8018624: some-host-24.example
 Mar 29 22:33:47 kismet sm-mta[23221]: x2TMXH7Y023221: internettl.org [104.152.52.29] (may be forged) did not issue MAIL/EXPN/VRFY/ETRN during connection to TLSMTA
 # failJSON: { "time": "2005-03-29T22:51:42", "match": true , "host": "104.152.52.29", "desc": "wrong resp. non RFC compiant (ddos prelude?), MSA-mode" }
 Mar 29 22:51:42 kismet sm-mta[24202]: x2TMpAlI024202: internettl.org [104.152.52.29] (may be forged) did not issue MAIL/EXPN/VRFY/ETRN during connection to MSA
+
+# failJSON: { "time": "2005-03-29T22:51:43", "match": true , "host": "192.0.2.2", "desc": "long PID, ID longer as 14 chars (gh-2563)" }
+Mar 29 22:51:43 server sendmail[3529565]: xA32R2PQ3529565: [192.0.2.2] did not issue MAIL/EXPN/VRFY/ETRN during connection to MTA


### PR DESCRIPTION
Updated the failregex in sendmail-auth.conf to support mail IDs up to 20 characters long as mentioned in https://github.com/fail2ban/fail2ban/issues/2562