### PR TITLE
Add Apprise Support (50+ Notifications)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,6 +3,7 @@ bin/fail2ban-regex
 bin/fail2ban-server
 bin/fail2ban-testcases
 ChangeLog
+config/action.d/apprise.conf
 config/action.d/abuseipdb.conf
 config/action.d/apf.conf
 config/action.d/badips.conf

--- a/config/action.d/apprise.conf
+++ b/config/action.d/apprise.conf
@@ -10,13 +10,13 @@
 # Notes.:  command executed once at the start of Fail2Ban.
 # Values:  CMD
 #
-actionstart = printf %%b "The jail <name> as been started successfully." |apprise -t "[Fail2Ban] <name>: started on `uname -n`" -c /etc/fail2ban/apprise.conf
+actionstart = printf %%b "The jail <name> as been started successfully." | <apprise> -t "[Fail2Ban] <name>: started on `uname -n`"
 
 # Option:  actionstop
 # Notes.:  command executed once at the end of Fail2Ban
 # Values:  CMD
 #
-actionstop = printf %%b "The jail <name> has been stopped." |apprise -t "[Fail2Ban] <name>: stopped on `uname -n`" -c /etc/fail2ban/apprise.conf
+actionstop = printf %%b "The jail <name> has been stopped." | <apprise> -t "[Fail2Ban] <name>: stopped on `uname -n`"
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command
@@ -30,7 +30,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = printf %%b "The IP <ip> has just been banned by Fail2Ban after <failures> attempts against <name>" | apprise -n "warning" -t "[Fail2Ban] <name>: banned <ip>$
+actionban = printf %%b "The IP <ip> has just been banned by Fail2Ban after <failures> attempts against <name>" | <apprise> -n "warning" -t "[Fail2Ban] <name>: banned <ip> from `uname -n`"
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -45,3 +45,5 @@ actionunban =
 # Define location of the default apprise configuration file to use
 #
 config = /etc/fail2ban/apprise.conf
+#
+apprise = apprise -c "<config>"

--- a/config/action.d/apprise.conf
+++ b/config/action.d/apprise.conf
@@ -1,0 +1,47 @@
+# Fail2Ban configuration file
+#
+# Author: Chris Caron <lead2gold@gmail.com>
+#
+#
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed once at the start of Fail2Ban.
+# Values:  CMD
+#
+actionstart = printf %%b "The jail <name> as been started successfully." |apprise -t "[Fail2Ban] <name>: started on `uname -n`" -c /etc/fail2ban/apprise.conf
+
+# Option:  actionstop
+# Notes.:  command executed once at the end of Fail2Ban
+# Values:  CMD
+#
+actionstop = printf %%b "The jail <name> has been stopped." |apprise -t "[Fail2Ban] <name>: stopped on `uname -n`" -c /etc/fail2ban/apprise.conf
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+actioncheck =
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionban = printf %%b "The IP <ip> has just been banned by Fail2Ban after <failures> attempts against <name>" | apprise -n "warning" -t "[Fail2Ban] <name>: banned <ip>$
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionunban =
+
+[Init]
+
+# Define location of the default apprise configuration file to use
+#
+config = /etc/fail2ban/apprise.conf

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -227,6 +227,15 @@ action_mwl = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(proto
 action_xarf = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
              xarf-login-attack[service=%(__name__)s, sender="%(sender)s", logpath="%(logpath)s", port="%(port)s"]
 
+# ban & send a notification to one or more of the 50+ services supported by Apprise.
+# See https://github.com/caronc/apprise/wiki for details on what is supported.
+#
+# You may optionally over-ride the default configuration line (containing the Apprise URLs)
+# by using 'apprise[name=%(__name__)s, config="/alternate/path/to/apprise.cfg"]' otherwise
+# /etc/fail2ban/apprise.conf is sourced for your supported notification configuration.
+action_apprise = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+                 apprise[name=%(__name__)s]
+
 # ban IP on CloudFlare & send an e-mail with whois report and relevant log lines
 # to the destemail.
 action_cf_mwl = cloudflare[cfuser="%(cfemail)s", cftoken="%(cfapikey)s"]

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -231,10 +231,10 @@ action_xarf = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(prot
 # See https://github.com/caronc/apprise/wiki for details on what is supported.
 #
 # You may optionally over-ride the default configuration line (containing the Apprise URLs)
-# by using 'apprise[name=%(__name__)s, config="/alternate/path/to/apprise.cfg"]' otherwise
+# by using 'apprise[config="/alternate/path/to/apprise.cfg"]' otherwise
 # /etc/fail2ban/apprise.conf is sourced for your supported notification configuration.
-action_apprise = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
-                 apprise[name=%(__name__)s]
+# action = %(action_)s
+#          apprise
 
 # ban IP on CloudFlare & send an e-mail with whois report and relevant log lines
 # to the destemail.


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code

## Details
[Apprise](https://github.com/caronc/apprise) supports more then 50+ push notification services.  This just extends fail2ban so that it can notify you through more end-points when an action takes place.

It's based on [this ticket](https://github.com/caronc/apprise/issues/171) created not to long ago.

### Installation
```bash
# dependencies:
pip install apprise
```

**FILE:** `/etc/fail2ban/jail.conf`
```bash
#... look for the action_ definitions and add this one:
action_apprise = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
                 apprise[name=%(__name__)s]

# Scroll down a little bit farther so you can find the `action` default (comment it out)
#action = %(action_)s

# and add a new default instead:
action = %(action_apprise)s
```

An apprise configuration file allows you to identify 1 or more services you want to notify.  They're all [well documented here](https://github.com/caronc/apprise/wiki). An example of one might look like:
```bash
# Default config location: /etc/fail2ban/apprise.cfg

# Place your Apprise URLs here you want to be notified:
slack://TokenA/TokenB/TokenC

# There is no limit...
mailto://user:pass@gmail.com

kodi://my.kodi.server
#...
```
