### PR TITLE
Updated regex to work with more verbose logging

### DIFF
--- a/config/filter.d/dovecot.conf
+++ b/config/filter.d/dovecot.conf
@@ -15,7 +15,7 @@ prefregex = ^%(__prefix_line)s(?:%(_auth_worker)s(?:\([^\)]+\))?: )?(?:%(__pam_a
 failregex = ^authentication failure; logname=<F-ALT_USER1>\S*</F-ALT_USER1> uid=\S* euid=\S* tty=dovecot ruser=<F-USER>\S*</F-USER> rhost=<HOST>(?:\s+user=<F-ALT_USER>\S*</F-ALT_USER>)?\s*$
             ^(?:Aborted login|Disconnected)(?::(?: [^ \(]+)+)? \((?:auth failed, \d+ attempts(?: in \d+ secs)?|tried to use (?:disabled|disallowed) \S+ auth|proxy dest auth failed)\):(?: user=<<F-USER>[^>]*</F-USER>>,)?(?: method=\S+,)? rip=<HOST>(?:[^>]*(?:, session=<\S+>)?)\s*$
             ^pam\(\S+,<HOST>(?:,\S*)?\): pam_authenticate\(\) failed: (?:User not known to the underlying authentication module: \d+ Time\(s\)|Authentication failure \(password mismatch\?\)|Permission denied)\s*$
-            ^[a-z\-]{3,15}\(\S*,<HOST>(?:,\S*)?\): (?:unknown user|invalid credentials|Password mismatch)\s*$
+            ^[a-z\-]{3,15}\(\S*,<HOST>(?:,\S*)?\): (?:unknown user|invalid credentials|Password mismatch)\s.*$
             <mdre-<mode>>
 
 mdre-aggressive = ^(?:Aborted login|Disconnected)(?::(?: [^ \(]+)+)? \((?:no auth attempts|disconnected before auth was ready,|client didn't finish \S+ auth,)(?: (?:in|waited) \d+ secs)?\):(?: user=<[^>]*>,)?(?: method=\S+,)? rip=<HOST>(?:[^>]*(?:, session=<\S+>)?)\s*$

--- a/fail2ban/tests/files/logs/dovecot
+++ b/fail2ban/tests/files/logs/dovecot
@@ -43,8 +43,14 @@ Jan 29 05:13:50 mail dovecot: auth: passwd-file(username,1.2.3.4): unknown user
 # failJSON: { "time": "2005-01-29T13:54:06", "match": true , "host": "192.0.2.5" }
 Jan 29 13:54:06 auth-worker(22401): Info: sql(admin@example.de,192.0.2.5,<n4JLdHNVngZGpV2j>): unknown user
 
+#failJSON: { "time": "2005-06-11T13:57:17", "match": true, "host": "192.168.178.25" }
+Jun 11 13:57:17 main dovecot: auth: ldap(user@server.org,192.168.178.25,<LZmGp6mZaMrAqLIZ>): unknown user (SHA1 of given password: f638ff)
+
 #failJSON: { "time": "2005-06-11T13:57:17", "match": true, "host": "192.168.144.226" }
 Jun 11 13:57:17 main dovecot: auth: sql(admin@example.ru,192.168.144.226,<6rXunFtu493AqJDi>): Password mismatch
+
+#failJSON: { "time": "2005-06-11T13:57:17", "match": true, "host": "192.168.178.25" }
+Jun 11 13:57:17 main dovecot: auth: ldap(user@server.org,192.168.178.25,<LZmGp6mZaMrAqLIZ>): Password mismatch (for LDAP bind) (SHA1 of given password: f638ff)
 
 # failJSON: { "time": "2005-01-29T14:38:51", "match": true , "host": "192.0.2.6", "desc": "PAM Permission denied (gh-1897)" }
 Jan 29 14:38:51 example.com dovecot[24941]: auth-worker(30165): pam(user@example.com,192.0.2.6,<PNHQq8pZhqIKAQGd>): pam_authenticate() failed: Permission denied


### PR DESCRIPTION
Now it covers also the cases like
```
Dec 14 14:07:20 server dovecot[24444]: auth: ldap(user2@server.org,192.168.0.25,<l+CXqKmZasrAqLIZ>): Password mismatch (for LDAP bind) (SHA1 of given password: f638ff)
Dec 14 14:07:20 kngnt dovecot[24444]: auth: ldap(user2@server.org,192.168.0.25,<l+CXqKmZasrAqLIZ>): unknown user (SHA1 of given password: f638ff)
```
Where there is extra information after the matching regexp

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
