### PR TITLE
Fix actions in ufw.conf

### DIFF
--- a/config/action.d/ufw.conf
+++ b/config/action.d/ufw.conf
@@ -1,6 +1,8 @@
 # Fail2Ban action configuration file for ufw
 #
 # You are required to run "ufw enable" before this will have any effect.
+# Please ensure `ss` program from the iproute2 package is installed
+# to close already established connections.
 #
 # The insert position should be appropriate to block the required traffic.
 # A number after an allow rule to the application won't be of much use.
@@ -13,11 +15,22 @@ actionstop =
 
 actioncheck = 
 
-actionban = [ -n "<application>" ] && app="app <application>"
-            ufw insert <insertpos> <blocktype> from <ip> to <destination> $app
+# ufw does "quickly process packets for which we already have a connection" in before.rules,
+# therefore all IPv4/IPv6 sockets should be closed - action is using `ss` to do so.
+actionban = if [ -n "<application>" ] && ufw app info "<application>"
+            then
+              ufw insert <insertpos> <blocktype> from <ip> to <destination> app "<application>" comment "<comment>"
+            else
+              ufw insert <insertpos> <blocktype> from <ip> to <destination> comment "<comment>"
+            fi
+            ss -K dst <ip>
 
-actionunban = [ -n "<application>" ] && app="app <application>"
-              ufw delete <blocktype> from <ip> to <destination> $app
+actionunban = if [ -n "<application>" ] && ufw app info "<application>"
+              then
+                ufw delete <blocktype> from <ip> to <destination> app "<application>"
+              else
+                ufw delete <blocktype> from <ip> to <destination>
+              fi
 
 [Init]
 # Option: insertpos
@@ -35,6 +48,10 @@ destination = any
 # Option: application
 # Notes.: application from sudo ufw app list
 application = 
+
+# Option: comment
+# Notes.: comment for rule added by fail2ban
+comment = by Fail2Ban after <failures> attempts against <name>
 
 # DEV NOTES:
 # 


### PR DESCRIPTION
ban bug/security issue using ufw:
--> `-A ufw-before-forward -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT` 
is *before* the ufw users rules. Therefore blocking only takes place *after* a disconnect. (this is a problem for web pages, e.g. nginx-http-auth).

Commit Summary:

- ufw does "quickly process packets for which we already have a connection" in before.rules,
  therefore all IPv4/IPv6 sockets should be closed, otherwise the action
  inserted by fail2ban will be by passed. This is done by the `ss` utility
  from the iproute2 package.

- ufw application can contain spaces (e.g. WWW Full)

- add ufw comment to easily identify rules added by fail2ban

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against 0.9.x series, choose `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
