### PR TITLE
0.10 auto-reban, improved invariant check and conditional operations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -80,6 +80,10 @@ ver. 0.10.5-dev-1 (20??/??/??) - development edition
 * `filter.d/sendmail-auth.conf`, `filter.d/sendmail-reject.conf` :
   - ID in prefix can be longer as 14 characters (gh-2563);
 * all filters would accept square brackets around IPv4 addresses also (e. g. monit-filter, gh-2494)
+* avoids unhandled exception during flush (gh-2588)
+* fixes pass2allow-ftp jail - due to inverted handling, action should prohibit access per default for any IP,
+  therefore reset start on demand parameter for this action (it will be started immediately by repair);
+* auto-detection of IPv6 subsystem availability (important for not on-demand actions or jails, like pass2allow);
 
 ### New Features
 * new replacement tags for failregex to match subnets in form of IP-addresses with CIDR mask (gh-2559):
@@ -136,6 +140,18 @@ filter = flt[logtype=short]
 * samplestestcase.py (testSampleRegexsFactory) extended:
   - allow coverage of journal logtype;
   - new option `fileOptions` to set common filter/test options for whole test-file;
+* large enhancement: auto-reban, improved invariant check and conditional operations (gh-2588):
+  - improves invariant check and repair (avoid unhandled exception, consider family on conditional operations, etc),
+    prepared for bulk re-ban in repair case (if bulk-ban becomes implemented);
+  - automatic reban (repeat banning action) after repair/restore sane environment, if already logged ticket causes
+    new failures (via new action operation `actionreban` or `actionban` if still not defined in action);
+  * introduces banning epoch for actions and tickets (to distinguish or recognize removed set of the tickets);
+  * invariant check avoids repair by unban/stop (unless parameter `actionrepair_on_unban` set to `true`);
+  * better handling for all conditional operations (distinguish families for certain operations like 
+    repair/flush/stop, prepared for other families, e. g. if different handling for subnets expected, etc);
+  * partially implements gh-980 (more breakdown safe handling);
+  * closes gh-1680 (better as large-scale banning implementation with on-demand reban by failure, 
+    at least unless a bulk-ban gets implemented);
 
 
 ver. 0.10.4 (2018/10/04) - ten-four-on-due-date-ten-four

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -861,7 +861,8 @@ filter       = apache-pass[knocking_url="%(knocking_url)s"]
 logpath      = %(apache_access_log)s
 blocktype    = RETURN
 returntype   = DROP
-action       = %(action_)s[blocktype=%(blocktype)s, returntype=%(returntype)s]
+action       = %(action_)s[blocktype=%(blocktype)s, returntype=%(returntype)s,
+                        actionstart_on_demand=True, actionrepair_on_unban=True]
 bantime      = 1h
 maxretry     = 1
 findtime     = 1

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -862,7 +862,7 @@ logpath      = %(apache_access_log)s
 blocktype    = RETURN
 returntype   = DROP
 action       = %(action_)s[blocktype=%(blocktype)s, returntype=%(returntype)s,
-                        actionstart_on_demand=True, actionrepair_on_unban=True]
+                        actionstart_on_demand=false, actionrepair_on_unban=true]
 bantime      = 1h
 maxretry     = 1
 findtime     = 1

--- a/fail2ban/client/actionreader.py
+++ b/fail2ban/client/actionreader.py
@@ -46,6 +46,7 @@ class ActionReader(DefinitionInitConfigReader):
 		"actionrepair": ["string", None],
 		"actionrepair_on_unban": ["string", None],
 		"actionban": ["string", None],
+		"actionreban": ["string", None],
 		"actionunban": ["string", None],
 		"norestored": ["string", None],
 	}

--- a/fail2ban/client/actionreader.py
+++ b/fail2ban/client/actionreader.py
@@ -44,6 +44,7 @@ class ActionReader(DefinitionInitConfigReader):
 		"actionreload": ["string", None],
 		"actioncheck": ["string", None],
 		"actionrepair": ["string", None],
+		"actionrepair_on_unban": ["string", None],
 		"actionban": ["string", None],
 		"actionunban": ["string", None],
 		"norestored": ["string", None],
@@ -78,7 +79,7 @@ class ActionReader(DefinitionInitConfigReader):
 		opts = self.getCombined(
 			ignore=CommandAction._escapedTags | set(('timeout', 'bantime')))
 		# type-convert only after combined (otherwise boolean converting prevents substitution):
-		for o in ('norestored', 'actionstart_on_demand'):
+		for o in ('norestored', 'actionstart_on_demand', 'actionrepair_on_unban'):
 			if opts.get(o):
 				opts[o] = self._convert_to_boolean(opts[o])
 		

--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -33,7 +33,7 @@ from .configreader import ConfigReaderUnshared, ConfigReader
 from .filterreader import FilterReader
 from .actionreader import ActionReader
 from ..version import version
-from ..helpers import getLogger, extractOptions, splitwords
+from ..helpers import getLogger, extractOptions, splitWithOptions, splitwords
 
 # Gets the instance of the logger.
 logSys = getLogger(__name__)
@@ -164,21 +164,15 @@ class JailReader(ConfigReader):
 				self.__filter.getOptions(self.__opts)
 		
 			# Read action
-			prevln = ''
-			actlst = self.__opts["action"].split('\n')
-			for n, act in enumerate(actlst):
+			for act in splitWithOptions(self.__opts["action"]):
 				try:
+					act = act.strip()
 					if not act:			  # skip empty actions
 						continue
 					# join with previous line if needed (consider possible new-line):
-					if prevln: act = prevln + '\n' + act
 					actName, actOpt = extractOptions(act)
 					prevln = ''
 					if not actName:
-						# consider possible new-line, so repeat with joined next line's:
-						if n < len(actlst) - 1:
-							prevln = act
-							continue
 						raise JailDefError("Invalid action definition %r" % act)
 					if actName.endswith(".py"):
 						self.__actions.append([

--- a/fail2ban/server/action.py
+++ b/fail2ban/server/action.py
@@ -45,8 +45,8 @@ logSys = getLogger(__name__)
 # Create a lock for running system commands
 _cmd_lock = threading.Lock()
 
-# Todo: make it configurable resp. automatically set, ex.: `[ -f /proc/net/if_inet6 ] && echo 'yes' || echo 'no'`:
-allowed_ipv6 = True
+# Specifies whether IPv6 subsystem is available:
+allowed_ipv6 = DNSUtils.IPv6IsAllowed
 
 # capture groups from filter for map to ticket data:
 FCUSTAG_CRE = re.compile(r'<F-([A-Z0-9_\-]+)>'); # currently uppercase only
@@ -459,7 +459,7 @@ class CommandAction(ActionBase):
 			v = splitwords(v)
 		elif self._hasCondSection: # all conditional families:
 			# todo: check it is needed at all # common (resp. ipv4) + ipv6 if allowed:
-			v = ['inet4', 'inet6'] if allowed_ipv6 else ['inet4']
+			v = ['inet4', 'inet6'] if allowed_ipv6() else ['inet4']
 		else: # all action tags seems to be the same
 			v = ['']
 		self._properties['__families'] = v

--- a/fail2ban/server/action.py
+++ b/fail2ban/server/action.py
@@ -440,18 +440,14 @@ class CommandAction(ActionBase):
 	@property
 	def _hasCondSection(self):
 		v = self._properties.get('__hasCondSection')
-		if v is None:
-			v = False
-			famset = set()
-			for n in self._properties:
-				grp = CONDITIONAL_FAM_RE.match(n)
-				if grp:
-					self._properties['__hasCondSection'] = v = True
-					if self._properties.get('families') or self._startOnDemand:
-						break
-					famset.add(grp.group(2))
-			self._properties['__families'] = famset
-			self._properties['__hasCondSection'] = v
+		if v is not None:
+			return v
+		v = False
+		for n in self._properties:
+			if CONDITIONAL_FAM_RE.match(n):
+				v = True
+				break
+		self._properties['__hasCondSection'] = v
 		return v
 
 	@property

--- a/fail2ban/server/action.py
+++ b/fail2ban/server/action.py
@@ -33,7 +33,7 @@ from abc import ABCMeta
 from collections import MutableMapping
 
 from .failregex import mapTag2Opt
-from .ipdns import asip, DNSUtils
+from .ipdns import DNSUtils
 from .mytime import MyTime
 from .utils import Utils
 from ..helpers import getLogger, _merge_copy_dicts, \
@@ -175,7 +175,7 @@ class CallingMap(MutableMapping, object):
 	def __len__(self):
 		return len(self.data)
 
-	def copy(self): # pragma: no cover
+	def copy(self):
 		return self.__class__(_merge_copy_dicts(self.data, self.storage))
 
 

--- a/fail2ban/server/actions.py
+++ b/fail2ban/server/actions.py
@@ -493,8 +493,7 @@ class Actions(JailThread, Mapping):
 							(name, action) for name, action in self._actions.iteritems()
 								if action.banEpoch > bTicket.banEpoch)
 						cnt += self.__reBan(bTicket, actions=rebanacts)
-				else:
-					# pragma: no cover - unexpected: ticket is not banned for some reasons - reban using all actions:
+				else: # pragma: no cover - unexpected: ticket is not banned for some reasons - reban using all actions:
 					cnt += self.__reBan(bTicket)
 		if cnt:
 			logSys.debug("Banned %s / %s, %s ticket(s) in %r", cnt, 

--- a/fail2ban/server/actions.py
+++ b/fail2ban/server/actions.py
@@ -593,7 +593,7 @@ class Actions(JailThread, Mapping):
 		if db and self._jail.database is not None:
 			logSys.debug("  Flush jail in database")
 			self._jail.database.delBan(self._jail)
-		# unban each ticket with non-flasheable actions:
+		# unban each ticket with non-flusheable actions:
 		for ticket in lst:
 			# unban ip:
 			self.__unBan(ticket, actions=actions, log=log)

--- a/fail2ban/server/actions.py
+++ b/fail2ban/server/actions.py
@@ -214,10 +214,10 @@ class Actions(JailThread, Mapping):
 
 		if isinstance(ip, list):
 			# Multiple IPs:
-			tickets = (BanTicket(ip if isinstance(ip, IPAddr) else IPAddr(ip), unixTime) for ip in ip)
+			tickets = (BanTicket(ip, unixTime) for ip in ip)
 		else:
 			# Single IP:
-			tickets = (BanTicket(ip if isinstance(ip, IPAddr) else IPAddr(ip), unixTime),)
+			tickets = (BanTicket(ip, unixTime),)
 
 		return self.__checkBan(tickets)
 

--- a/fail2ban/server/ipdns.py
+++ b/fail2ban/server/ipdns.py
@@ -202,6 +202,11 @@ class DNSUtils:
 		DNSUtils.CACHE_nameToIp.set(key, ips)
 		return ips
 
+	@staticmethod
+	def IPv6IsAllowed():
+		# return os.path.exists("/proc/net/if_inet6") || any((':' in ip) for ip in DNSUtils.getSelfIPs())
+		return any((':' in ip.ntoa) for ip in DNSUtils.getSelfIPs())
+
 
 ##
 # Class for IP address handling.

--- a/fail2ban/server/ticket.py
+++ b/fail2ban/server/ticket.py
@@ -206,6 +206,13 @@ class Ticket(object):
 		# return single value of data:
 		return self._data.get(key, default)
 
+	@property
+	def banEpoch(self):
+		return getattr(self, '_banEpoch', 0)
+	@banEpoch.setter
+	def banEpoch(self, value):
+		self._banEpoch = value
+
 
 class FailTicket(Ticket):
 

--- a/fail2ban/tests/actionstestcase.py
+++ b/fail2ban/tests/actionstestcase.py
@@ -495,3 +495,10 @@ class ExecuteActions(LogCaptureTestCase):
 			'2001:db8::2 inet6 -- rebanned', all=True)
 		self.assertNotLogged('192.0.2.1 inet4 -- rebanned')
 
+		# coverage - intended error in reban (no unhandled exception, message logged):
+		act.actionreban = ''
+		act.actionban = 'exit 1'
+		self.assertEqual(self.__actions._Actions__reBan(FailTicket("192.0.2.1", 0)), 0)
+		self.assertLogged(
+			'Failed to execute reban',
+			'Error banning 192.0.2.1', all=True)

--- a/fail2ban/tests/actiontestcase.py
+++ b/fail2ban/tests/actiontestcase.py
@@ -587,6 +587,19 @@ class CommandActionTest(LogCaptureTestCase):
 		self.assertEqual(len(m), 3)
 		self.assertIn('c', m)
 		self.assertEqual((m['a'], m['b'], m['c']), (5, 11, 'test'))
+		# immutability of copy:
+		m['d'] = 'dddd'
+		m2 = m.copy()
+		m2['c'] = lambda self: self['a'] + 7
+		m2['a'] = 1
+		del m2['b']
+		del m2['d']
+		self.assertTrue('b' in m)
+		self.assertTrue('d' in m)
+		self.assertFalse('b' in m2)
+		self.assertFalse('d' in m2)
+		self.assertEqual((m['a'], m['b'], m['c'], m['d']), (5, 11, 'test', 'dddd'))
+		self.assertEqual((m2['a'], m2['c']), (1, 8))
 
 	def testCallingMapRep(self):
 		m = CallingMap({

--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -31,7 +31,7 @@ import unittest
 from ..client.configreader import ConfigReader, ConfigReaderUnshared, \
 	DefinitionInitConfigReader, NoSectionError
 from ..client import configparserinc
-from ..client.jailreader import JailReader, extractOptions
+from ..client.jailreader import JailReader, extractOptions, splitWithOptions
 from ..client.filterreader import FilterReader
 from ..client.jailsreader import JailsReader
 from ..client.actionreader import ActionReader, CommandAction
@@ -778,7 +778,7 @@ class JailsReaderTest(LogCaptureTestCase):
 
 			# somewhat duplicating here what is done in JailsReader if
 			# the jail is enabled
-			for act in actions.split('\n'):
+			for act in splitWithOptions(actions):
 				actName, actOpt = extractOptions(act)
 				self.assertTrue(len(actName))
 				self.assertTrue(isinstance(actOpt, dict))

--- a/fail2ban/tests/fail2banclienttestcase.py
+++ b/fail2ban/tests/fail2banclienttestcase.py
@@ -113,16 +113,7 @@ fail2banclient.input_command = _test_input_command
 fail2bancmdline.PRODUCTION = \
 fail2banserver.PRODUCTION = False
 
-
-def _out_file(fn, handle=logSys.debug):
-	"""Helper which outputs content of the file at HEAVYDEBUG loglevels"""
-	if (handle != logSys.debug or logSys.getEffectiveLevel() <= logging.DEBUG):
-		handle('---- ' + fn + ' ----')
-		for line in fileinput.input(fn):
-			line = line.rstrip('\n')
-			handle(line)
-		handle('-'*30)
-
+_out_file = LogCaptureTestCase.dumpFile
 
 def _write_file(fn, mode, *lines):
 	f = open(fn, mode)

--- a/fail2ban/tests/files/action.d/action_modifyainfo.py
+++ b/fail2ban/tests/files/action.d/action_modifyainfo.py
@@ -12,4 +12,9 @@ class TestAction(ActionBase):
         del aInfo['ip']
         self._logSys.info("%s unban deleted aInfo IP", self._name)
 
+    def flush(self):
+        # intended error to cover no unhandled exception occurs in flash
+        # as well as unbans are done individually after errored flush.
+        raise ValueError("intended error")
+
 Action = TestAction

--- a/fail2ban/tests/files/action.d/action_modifyainfo.py
+++ b/fail2ban/tests/files/action.d/action_modifyainfo.py
@@ -13,7 +13,7 @@ class TestAction(ActionBase):
         self._logSys.info("%s unban deleted aInfo IP", self._name)
 
     def flush(self):
-        # intended error to cover no unhandled exception occurs in flash
+        # intended error to cover no unhandled exception occurs in flush
         # as well as unbans are done individually after errored flush.
         raise ValueError("intended error")
 

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -40,7 +40,7 @@ from ..server.jail import Jail
 from ..server.filterpoll import FilterPoll
 from ..server.filter import FailTicket, Filter, FileFilter, FileContainer
 from ..server.failmanager import FailManagerEmpty
-from ..server.ipdns import getfqdn, DNSUtils, IPAddr
+from ..server.ipdns import asip, getfqdn, DNSUtils, IPAddr
 from ..server.mytime import MyTime
 from ..server.utils import Utils, uni_decode
 from .utils import setUpMyTime, tearDownMyTime, mtimesleep, with_tmpdir, LogCaptureTestCase, \
@@ -1843,11 +1843,15 @@ class DNSUtilsNetworkTests(unittest.TestCase):
 	def setUp(self):
 		"""Call before every test case."""
 		super(DNSUtilsNetworkTests, self).setUp()
-		unittest.F2B.SkipIfNoNetwork()
+		#unittest.F2B.SkipIfNoNetwork()
 
 	def test_IPAddr(self):
-		self.assertTrue(IPAddr('192.0.2.1').isIPv4)
-		self.assertTrue(IPAddr('2001:DB8::').isIPv6)
+		ip4 = IPAddr('192.0.2.1')
+		ip6 = IPAddr('2001:DB8::')
+		self.assertTrue(ip4.isIPv4)
+		self.assertTrue(ip6.isIPv6)
+		self.assertTrue(asip('192.0.2.1').isIPv4)
+		self.assertTrue(id(asip(ip4)) == id(ip4))
 
 	def test_IPAddr_Raw(self):
 		# raw string:
@@ -1884,6 +1888,7 @@ class DNSUtilsNetworkTests(unittest.TestCase):
 	def testUseDns(self):
 		res = DNSUtils.textToIp('www.example.com', 'no')
 		self.assertSortedEqual(res, [])
+		unittest.F2B.SkipIfNoNetwork()
 		res = DNSUtils.textToIp('www.example.com', 'warn')
 		# sort ipaddr, IPv4 is always smaller as IPv6
 		self.assertSortedEqual(res, ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946'])
@@ -1892,6 +1897,7 @@ class DNSUtilsNetworkTests(unittest.TestCase):
 		self.assertSortedEqual(res, ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946'])
 
 	def testTextToIp(self):
+		unittest.F2B.SkipIfNoNetwork()
 		# Test hostnames
 		hostnames = [
 			'www.example.com',
@@ -1905,6 +1911,8 @@ class DNSUtilsNetworkTests(unittest.TestCase):
 				self.assertSortedEqual(res, ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946'])
 			else:
 				self.assertSortedEqual(res, [])
+
+	def testIpToIp(self):
 		# pure ips:
 		for s in ('93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946'):
 			ips = DNSUtils.textToIp(s, 'yes')
@@ -2061,6 +2069,7 @@ class DNSUtilsNetworkTests(unittest.TestCase):
 		self.assertTrue(IPAddr("2606:2800:220:1:248:1893:25c8:1946").isInNet(ips))
 
 	def testIPAddr_wrongDNS_IP(self):
+		unittest.F2B.SkipIfNoNetwork()
 		DNSUtils.dnsToIp('`this`.dns-is-wrong.`wrong-nic`-dummy')
 		DNSUtils.ipToName('*')
 
@@ -2083,6 +2092,9 @@ class DNSUtilsNetworkTests(unittest.TestCase):
 		self.assertEqual(getfqdn(lname), lname)
 		# coverage (targeting all branches): FQDN from loopback and DNS blackhole is always the same:
 		self.assertIn(getfqdn('localhost.'), ('localhost', 'localhost.'))
+	
+	def testFQDN_DNS(self):
+		unittest.F2B.SkipIfNoNetwork()
 		self.assertIn(getfqdn('as112.arpa.'), ('as112.arpa.', 'as112.arpa'))
 
 

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -752,7 +752,7 @@ class Transmitter(TransmitterBase):
 		self.assertSortedEqual(
 			self.transm.proceed(["get", self.jailName, "actionmethods",
 				action])[1],
-			['ban', 'start', 'stop', 'testmethod', 'unban'])
+			['ban', 'reban', 'start', 'stop', 'testmethod', 'unban'])
 		self.assertEqual(
 			self.transm.proceed(["set", self.jailName, "action", action,
 				"testmethod", '{"text": "world!"}']),

--- a/fail2ban/tests/utils.py
+++ b/fail2ban/tests/utils.py
@@ -22,6 +22,7 @@ __author__ = "Yaroslav Halchenko"
 __copyright__ = "Copyright (c) 2013 Yaroslav Halchenko"
 __license__ = "GPL"
 
+import fileinput
 import itertools
 import logging
 import optparse
@@ -741,11 +742,8 @@ class LogCaptureTestCase(unittest.TestCase):
 				self._dirty |= 2 # records changed
 
 	def setUp(self):
-
 		# For extended testing of what gets output into logging
 		# system, we will redirect it to a string
-		logSys = getLogger("fail2ban")
-
 		# Keep old settings
 		self._old_level = logSys.level
 		self._old_handlers = logSys.handlers
@@ -762,7 +760,6 @@ class LogCaptureTestCase(unittest.TestCase):
 		"""Call after every test case."""
 		# print "O: >>%s<<" % self._log.getvalue()
 		self.pruneLog()
-		logSys = getLogger("fail2ban")
 		logSys.handlers = self._old_handlers
 		logSys.level = self._old_level
 		super(LogCaptureTestCase, self).tearDown()
@@ -844,6 +841,16 @@ class LogCaptureTestCase(unittest.TestCase):
 
 	def getLog(self):
 		return self._log.getvalue()
+
+	@staticmethod
+	def dumpFile(fn, handle=logSys.debug):
+		"""Helper which outputs content of the file at HEAVYDEBUG loglevels"""
+		if (handle != logSys.debug or logSys.getEffectiveLevel() <= logging.DEBUG):
+			handle('---- ' + fn + ' ----')
+			for line in fileinput.input(fn):
+				line = line.rstrip('\n')
+				handle(line)
+			handle('-'*30)
 
 
 pid_exists = Utils.pid_exists


### PR DESCRIPTION
* avoids unhandled exception during flush
* improves invariant check and repair (avoid unhandled exception, consider family on conditional operations, etc), prepared for bulk re-ban in repair case (if bulk-ban becomes implemented);
* automatic reban (repeat banning action) after repair/restore sane environment, if already logged ticket causes new failures (via new action operation `actionreban` or `actionban` if still not defined);
* introduces banning epoch for actions and tickets (to distinguish or recognize removed set of the tickets);
* check avoids repair by unban/stop (unless parameter `actionrepair_on_unban` set to `true`)
* better handling for all conditional operations (distinguish families for certain operations like repair/flush/stop, prepared for other families, e. g. if different handling for subnets expected, etc)
* fixes pass2allow-ftp jail - it has inverted handling, so action should prohibit access per default for any IP, therefore reset start on demand parameter for this action (will be started immediately)
* auto-detection of IPv6 subsystem availability (important for not on-demand actions or jails, like pass2allow)

partially implements #980;
closes #1680 (better as large-scale banning implementation with on-demand reban by failure, at least unless a bulk-ban gets implemented);