### PR TITLE
Enhancements: Update ipfw.conf to better control insertion ob blocking rules.

### DIFF
--- a/config/action.d/ipfw.conf
+++ b/config/action.d/ipfw.conf
@@ -34,7 +34,7 @@ actioncheck =
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = ipfw add <blocktype> tcp from <ip> to <localhost> <port>
+actionban = ipfw add `ipfw show | awk 'BEGIN { l = <insert_after> }; { if ( l <= $1 ) { if ( l == $1 ) l = l + <insert_step>; else { print l; exit;}}};'` <blocktype> tcp from <ip> to <localhost> <port>
 
 
 # Option:  actionunban
@@ -66,3 +66,17 @@ localhost = 127.0.0.1
 # Values:  STRING
 #
 blocktype = unreach port
+
+# Option:  insert_after
+# Notes.:  Rules will be inserted _after_ rule number specified.
+#          If set to 65535 emulates default behivour of "ipfw add"(adding et the end of rulebase, before default action)
+# Values:  INT
+#
+insert_after = 65535
+
+
+# Option:  insert_step
+# Notes.:  Rule number icrement for each new rule. 
+# Values:  INT
+#
+insert_step = 100


### PR DESCRIPTION
Allows to specify where to inset blocking rules to ipfw.  
Does not change default behaviour.  
