### PR TITLE
Make badips.py more robust

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -46,6 +46,8 @@ ver. 0.10.6-dev (20??/??/??) - development edition
   so would bother the action interpolation
 * `action.d/*-ipset*.conf`: several ipset actions fixed (no timeout per default anymore), so no discrepancy
   between ipset and fail2ban (removal from ipset will be managed by fail2ban only, gh-2703)
+* `action.d/badips.py`: script more robust when badips API does not answer (gh-2603)
+* `action.d/badips.py`: new `unbanstop` option to toggle indivual unban when fail2ban stops (gh-2603)
 * `action.d/cloudflare.conf`: fixed `actionunban` (considering new-line chars and optionally real json-parsing
    with `jq`, gh-2140, gh-2656)
 * `filter.d/common.conf`: avoid substitute of default values in related `lt_*` section, `__prefix_line`

--- a/fail2ban/tests/action_d/test_badips.py
+++ b/fail2ban/tests/action_d/test_badips.py
@@ -153,5 +153,5 @@ if sys.version_info >= (2,7): # pragma: no cover - may be unavailable
 			# produce an error using wrong category/IP:
 			self.action._category = 'f2b-this-category-dont-available-test-suite-only'
 			aInfo['ip'] = ''
-			self.assertRaises(BadIPsActionTest.pythonModule.HTTPError, self.action.ban, aInfo)
-			self.assertLogged('IP is invalid', 'invalid category', wait=True, all=False)
+			self.action.ban(aInfo)
+			self.assertLogged('IP is invalid', 'Failed to ban', wait=True, all=False)


### PR DESCRIPTION
Hi,

This PR makes `badips.py` more robust when badips API does not answer.
It then closes #2600.
We are now then sure the script will correctly run, even if for example badips API is not reachable when fail2ban starts.

Ban categories are retrieved only one time now, instead of 4 times initially... speeding-up the startup time (and also making it more reliable).

It also adds a new option, `unbanonstop`, which allow to enable/disable unban of every IP individually.
It then closes #2602.

Let's then merge this into upcoming **0.10.6** ?

Thank you 👍 