### PR TITLE
Kill state after adding IP to PF table

### DIFF
--- a/config/action.d/pf.conf
+++ b/config/action.d/pf.conf
@@ -66,7 +66,7 @@ actioncheck = <pfctl> -sr | grep -q <tablename>-<name>
 #          <time>  unix timestamp of the ban time
 # Values:  CMD
 #
-actionban = <pfctl> -t <tablename>-<name> -T add <ip>
+actionban = <pfctl> -t <tablename>-<name> -T add <ip> && <pfctl> -k <ip>
 
 
 # Option:  actionunban


### PR DESCRIPTION
When fail2ban adds an IP to a table of the PF firewall, the state has to be killed afterwards. It this does not happen, the connection can stay open, allowing the attacker to continue attacking.
This might be unnecessary when using fail2ban to protect ssh, since the connection always resets after a failed login attempt. However, I'm using fail2ban to protect an instance of nginx against bots that cause 403 and 404 errors. During my testing, I quickly realised that without this edit, the ban would not immediately take effect.

tl;dr: Sometimes bans didn't take effect immediately because the state wasn't killed.

I got the idea from this post on the FreeBSD forums:
https://forums.freebsd.org/threads/pf-and-fail2ban.51624/
