### PR TITLE
FreeIPA renames named to named-pkcs11

### DIFF
--- a/config/filter.d/named-refused.conf
+++ b/config/filter.d/named-refused.conf
@@ -22,7 +22,7 @@
 [Definition]
 
 # Daemon name
-_daemon=named(-pkcs11)?
+_daemon=named(?:-\w+)?
 
 # Shortcuts for easier comprehension of the failregex
 

--- a/config/filter.d/named-refused.conf
+++ b/config/filter.d/named-refused.conf
@@ -22,7 +22,7 @@
 [Definition]
 
 # Daemon name
-_daemon=named
+_daemon=named(-pkcs11)?
 
 # Shortcuts for easier comprehension of the failregex
 


### PR DESCRIPTION
FreeIPA renames the BIND9 named daemon to named-pkcs11, so extend the
REGEX match to look for either variant.

Signed-off-by: Brian J. Murrell <brian@interlinx.bc.ca>