### PR TITLE
close Popen() pipes explicitly for PyPy

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,6 +32,7 @@ ver. 0.10.6-dev (20??/??/??) - development edition
   IPv6-capable now.
 
 ### Fixes
+* restoring a large number (500+ depending on files ulimit) of current bans when using PyPy fixed
 
 ### New Features
 

--- a/fail2ban/server/utils.py
+++ b/fail2ban/server/utils.py
@@ -270,8 +270,9 @@ class Utils():
 				if stderr is not None and stderr != '' and std_level >= logSys.getEffectiveLevel():
 					for l in stderr.splitlines():
 						logSys.log(std_level, "%x -- stderr: %r", realCmdId, uni_decode(l))
-		popen.stdout.close()
-		popen.stderr.close()
+
+		if popen.stdout: popen.stdout.close()
+		if popen.stderr: popen.stderr.close()
 
 		success = False
 		if retcode in success_codes:

--- a/fail2ban/server/utils.py
+++ b/fail2ban/server/utils.py
@@ -260,7 +260,6 @@ class Utils():
 				if stdout is not None and stdout != '' and std_level >= logSys.getEffectiveLevel():
 					for l in stdout.splitlines():
 						logSys.log(std_level, "%x -- stdout: %r", realCmdId, uni_decode(l))
-				popen.stdout.close()
 			if popen.stderr:
 				try:
 					if retcode is None or retcode < 0:
@@ -271,7 +270,8 @@ class Utils():
 				if stderr is not None and stderr != '' and std_level >= logSys.getEffectiveLevel():
 					for l in stderr.splitlines():
 						logSys.log(std_level, "%x -- stderr: %r", realCmdId, uni_decode(l))
-				popen.stderr.close()
+		popen.stdout.close()
+		popen.stderr.close()
 
 		success = False
 		if retcode in success_codes:


### PR DESCRIPTION
Because PyPy's garbage collector isn't reference-count based, it can leave objects alive much longer than under CPython (and I'm sure this isn't news to the F2B devs...).

When starting up and restoring bans, `Popen()` will be called [from here](https://github.com/fail2ban/fail2ban/blob/35591db3e854af89038e230b47a75b8978ed84fd/fail2ban/server/utils.py#L206-L209) for each ban. Each call will open two pipes. These pipes are not explicitly closed, and instead will be closed by GC. If the number of bans to be restored is large (e.g. 500+), then the number of pipes opened will also be large (e.g. 1000+), and this can run afoul a typical default number-of-files ulimit (on my system, 1024) before the PyPy GC begins closing the opened pipes. This can produce errors along the lines of:

```
2020-02-19 13:27:04,443 fail2ban.actions        [3351]: NOTICE  [postfix] Restore Ban 1.1.1.1
2020-02-19 13:27:04,443 fail2ban.utils          [3351]: ERROR   7fdac0da3460 -- exec: ipset add f2b-postfix 1.1.1.1 -exist
2020-02-19 13:27:04,444 fail2ban.utils          [3351]: ERROR   ipset add f2b-postfix 1.1.1.1 -exist -- failed with [Errno 24] Too many open files
2020-02-19 13:27:04,444 fail2ban.actions        [3351]: ERROR   Failed to execute ban jail 'postfix' action 'iptables-ipset-proto6' info 'ActionInfo({'ip': '1.1.1.1', 'family': 'inet4', 'fid': <function <lambda> at 0x00007fdae40de2f0>, 'raw-ticket': <function <lambda> at 0x00007fdae40de890>})': Error banning 1.1.1.1
```

This small PR explicitly closes the pipes under most circumstances.

- [ ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch

    I only submitted this against dev, although it looks like this issue also affects 0.11 and 0.10. I do not believe it affects 0.9.

- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [X] **KEEP PR small** so it could be easily reviewed.
- [X] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
