### PR TITLE
Check the parent directory of .pid file

### DIFF
--- a/files/redhat-initd
+++ b/files/redhat-initd
@@ -24,6 +24,11 @@
 # Check that the config file exists
 [ -f /etc/fail2ban/fail2ban.conf ] || exit 0
 
+# Check pid dir
+if [ ! -d '/var/run/fail2ban' ]; then
+    mkdir /var/run/fail2ban
+fi
+
 FAIL2BAN="/usr/bin/fail2ban-client"
 prog=fail2ban-server
 lockfile=${LOCKFILE-/var/lock/subsys/fail2ban}


### PR DESCRIPTION
will fail to reload or restart, because the dir '/var/run/fail2ban' does not exists

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
