### PR TITLE
Add rc script for OpenBSD. Tested on the latest stable release: 6.6

### DIFF
--- a/files/openbsd-rc
+++ b/files/openbsd-rc
@@ -1,0 +1,26 @@
+#!/bin/sh
+ 
+daemon="/usr/local/bin/fail2ban-client"
+ 
+. /etc/rc.d/rc.subr
+ 
+rc_bg=YES
+rc_reload=NO
+ 
+rc_pre() {
+    install -d -o root -m 0700 /var/run/fail2ban
+}
+ 
+rc_start() {
+    ${rcexec} "${daemon} start ${daemon_flags} ${_bg}"
+}
+ 
+rc_check() {
+    pgrep -q -f "fail2ban-server"
+}
+ 
+rc_stop() {
+    ${rcexec} "${daemon} stop"
+}
+ 
+rc_cmd $1


### PR DESCRIPTION
- Based on the rc script shared on this blog: https://blog.gordonturner.com/2016/11/20/fail2ban-on-openbsd-6-0/
- Tested on OpenBSD 6.6 with Fail2ban-0.11.1, start/stop/check commands all work fine.