### PR TITLE
0.10 / ipset timeout removal

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,8 @@ ver. 0.10.6-dev (20??/??/??) - development edition
 * ensure we've unique action name per jail (also if parameter `actname` is not set but name deviates from standard name, gh-2686)
 * don't use `%(banaction)s` interpolation because it can be complex value (containing `[...]` and/or quotes), 
   so would bother the action interpolation
+* `action.d/*-ipset*.conf`: several ipset actions fixed (no timeout per default anymore), so no discrepancy
+  between ipset and fail2ban (removal from ipset will be managed by fail2ban only, gh-2703)
 * `filter.d/common.conf`: avoid substitute of default values in related `lt_*` section, `__prefix_line`
   should be interpolated in definition section (inside the filter-config, gh-2650)
 * `filter.d/courier-smtp.conf`: prefregex extended to consider port in log-message (gh-2697)

--- a/config/action.d/firewallcmd-ipset.conf
+++ b/config/action.d/firewallcmd-ipset.conf
@@ -18,7 +18,7 @@ before = firewallcmd-common.conf
 
 [Definition]
 
-actionstart = ipset create <ipmset> hash:ip timeout <bantime><familyopt>
+actionstart = ipset create <ipmset> hash:ip timeout <default-timeout> <familyopt>
               firewall-cmd --direct --add-rule <family> filter <chain> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
 
 actionflush = ipset flush <ipmset>
@@ -27,7 +27,7 @@ actionstop = firewall-cmd --direct --remove-rule <family> filter <chain> 0 <acti
              <actionflush>
              ipset destroy <ipmset>
 
-actionban = ipset add <ipmset> <ip> timeout <bantime> -exist
+actionban = ipset add <ipmset> <ip> timeout <timeout> -exist
 
 actionunban = ipset del <ipmset> <ip> -exist
 
@@ -40,11 +40,19 @@ actionunban = ipset del <ipmset> <ip> -exist
 #
 chain = INPUT_direct
 
-# Option: bantime
-# Notes:  specifies the bantime in seconds (handled internally rather than by fail2ban)
-# Values:  [ NUM ]  Default: 600
+# Option: default-timeout
+# Notes:  specifies default timeout in seconds (handled default ipset timeout only)
+# Values:  [ NUM ]  Default: 0 (no timeout, managed by fail2ban by unban)
+default-timeout = 0
 
-bantime = 600
+# Option: timeout
+# Notes:  specifies ticket timeout (handled ipset timeout only)
+# Values:  [ NUM ]  Default: 0 (managed by fail2ban by unban)
+timeout = 0
+
+# expresion to caclulate timeout from bantime, example:
+# banaction = %(known/banaction)s[timeout='<timeout-bantime>']
+timeout-bantime = $([ "<bantime>" -le 2147483 ] && echo "<bantime>" || echo 0)
 
 # Option: actiontype
 # Notes.: defines additions to the blocking rule
@@ -69,7 +77,7 @@ familyopt =
 [Init?family=inet6]
 
 ipmset = f2b-<name>6
-familyopt = <sp>family inet6
+familyopt = family inet6
 
 
 # DEV NOTES:

--- a/config/action.d/iptables-ipset-proto6-allports.conf
+++ b/config/action.d/iptables-ipset-proto6-allports.conf
@@ -26,7 +26,7 @@ before = iptables-common.conf
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
 # Values:  CMD
 #
-actionstart = ipset create <ipmset> hash:ip timeout <bantime><familyopt>
+actionstart = ipset create <ipmset> hash:ip timeout <default-timeout> <familyopt>
               <iptables> -I <chain> -m set --match-set <ipmset> src -j <blocktype>
 
 # Option:  actionflush
@@ -49,7 +49,7 @@ actionstop = <iptables> -D <chain> -m set --match-set <ipmset> src -j <blocktype
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = ipset add <ipmset> <ip> timeout <bantime> -exist
+actionban = ipset add <ipmset> <ip> timeout <timeout> -exist
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -61,11 +61,19 @@ actionunban = ipset del <ipmset> <ip> -exist
 
 [Init]
 
-# Option: bantime
-# Notes:  specifies the bantime in seconds (handled internally rather than by fail2ban)
-# Values:  [ NUM ]  Default: 600
-#
-bantime = 600
+# Option: default-timeout
+# Notes:  specifies default timeout in seconds (handled default ipset timeout only)
+# Values:  [ NUM ]  Default: 0 (no timeout, managed by fail2ban by unban)
+default-timeout = 0
+
+# Option: timeout
+# Notes:  specifies ticket timeout (handled ipset timeout only)
+# Values:  [ NUM ]  Default: 0 (managed by fail2ban by unban)
+timeout = 0
+
+# expresion to caclulate timeout from bantime, example:
+# banaction = %(known/banaction)s[timeout='<timeout-bantime>']
+timeout-bantime = $([ "<bantime>" -le 2147483 ] && echo "<bantime>" || echo 0)
 
 ipmset = f2b-<name>
 familyopt =
@@ -74,4 +82,4 @@ familyopt =
 [Init?family=inet6]
 
 ipmset = f2b-<name>6
-familyopt = <sp>family inet6
+familyopt = family inet6

--- a/config/action.d/iptables-ipset-proto6.conf
+++ b/config/action.d/iptables-ipset-proto6.conf
@@ -26,7 +26,7 @@ before = iptables-common.conf
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
 # Values:  CMD
 #
-actionstart = ipset create <ipmset> hash:ip timeout <bantime><familyopt>
+actionstart = ipset create <ipmset> hash:ip timeout <default-timeout> <familyopt>
               <iptables> -I <chain> -p <protocol> -m multiport --dports <port> -m set --match-set <ipmset> src -j <blocktype>
 
 # Option:  actionflush
@@ -49,7 +49,7 @@ actionstop = <iptables> -D <chain> -p <protocol> -m multiport --dports <port> -m
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = ipset add <ipmset> <ip> timeout <bantime> -exist
+actionban = ipset add <ipmset> <ip> timeout <timeout> -exist
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -61,11 +61,19 @@ actionunban = ipset del <ipmset> <ip> -exist
 
 [Init]
 
-# Option: bantime
-# Notes:  specifies the bantime in seconds (handled internally rather than by fail2ban)
-# Values:  [ NUM ]  Default: 600
-#
-bantime = 600
+# Option: default-timeout
+# Notes:  specifies default timeout in seconds (handled default ipset timeout only)
+# Values:  [ NUM ]  Default: 0 (no timeout, managed by fail2ban by unban)
+default-timeout = 0
+
+# Option: timeout
+# Notes:  specifies ticket timeout (handled ipset timeout only)
+# Values:  [ NUM ]  Default: 0 (managed by fail2ban by unban)
+timeout = 0
+
+# expresion to caclulate timeout from bantime, example:
+# banaction = %(known/banaction)s[timeout='<timeout-bantime>']
+timeout-bantime = $([ "<bantime>" -le 2147483 ] && echo "<bantime>" || echo 0)
 
 ipmset = f2b-<name>
 familyopt =
@@ -74,4 +82,4 @@ familyopt =
 [Init?family=inet6]
 
 ipmset = f2b-<name>6
-familyopt = <sp>family inet6
+familyopt = family inet6

--- a/config/action.d/shorewall-ipset-proto6.conf
+++ b/config/action.d/shorewall-ipset-proto6.conf
@@ -51,7 +51,7 @@
 # Values:  CMD
 #
 actionstart = if ! ipset -quiet -name list f2b-<name> >/dev/null;
-              then ipset -quiet -exist create f2b-<name> hash:ip timeout <bantime>;
+              then ipset -quiet -exist create f2b-<name> hash:ip timeout <default-timeout>;
               fi
 
 # Option:  actionstop
@@ -66,7 +66,7 @@ actionstop = ipset flush f2b-<name>
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = ipset add f2b-<name> <ip> timeout <bantime> -exist
+actionban = ipset add f2b-<name> <ip> timeout <timeout> -exist
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -76,10 +76,16 @@ actionban = ipset add f2b-<name> <ip> timeout <bantime> -exist
 #
 actionunban = ipset del f2b-<name> <ip> -exist
 
-[Init]
+# Option: default-timeout
+# Notes:  specifies default timeout in seconds (handled default ipset timeout only)
+# Values:  [ NUM ]  Default: 0 (no timeout, managed by fail2ban by unban)
+default-timeout = 0
 
-# Option: bantime
-# Notes:  specifies the bantime in seconds (handled internally rather than by fail2ban)
-# Values:  [ NUM ]  Default: 600
-#
-bantime = 600
+# Option: timeout
+# Notes:  specifies ticket timeout (handled ipset timeout only)
+# Values:  [ NUM ]  Default: 0 (managed by fail2ban by unban)
+timeout = 0
+
+# expresion to caclulate timeout from bantime, example:
+# banaction = %(known/banaction)s[timeout='<timeout-bantime>']
+timeout-bantime = $([ "<bantime>" -le 2147483 ] && echo "<bantime>" || echo 0)

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -1509,14 +1509,14 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 				),					
 			}),
 			# iptables-ipset-proto6 --
-			('j-w-iptables-ipset', 'iptables-ipset-proto6[name=%(__name__)s, bantime="10m", port="http", protocol="tcp", chain="<known/chain>"]', {
+			('j-w-iptables-ipset', 'iptables-ipset-proto6[name=%(__name__)s, port="http", protocol="tcp", chain="<known/chain>"]', {
 				'ip4': (' f2b-j-w-iptables-ipset ',), 'ip6': (' f2b-j-w-iptables-ipset6 ',),
 				'ip4-start': (
-					"`ipset create f2b-j-w-iptables-ipset hash:ip timeout 600`",
+					"`ipset create f2b-j-w-iptables-ipset hash:ip timeout 0 `",
 					"`iptables -w -I INPUT -p tcp -m multiport --dports http -m set --match-set f2b-j-w-iptables-ipset src -j REJECT --reject-with icmp-port-unreachable`",
 				), 
 				'ip6-start': (
-					"`ipset create f2b-j-w-iptables-ipset6 hash:ip timeout 600 family inet6`",
+					"`ipset create f2b-j-w-iptables-ipset6 hash:ip timeout 0 family inet6`",
 					"`ip6tables -w -I INPUT -p tcp -m multiport --dports http -m set --match-set f2b-j-w-iptables-ipset6 src -j REJECT --reject-with icmp6-port-unreachable`",
 				),
 				'flush': (
@@ -1532,27 +1532,27 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					"`ipset destroy f2b-j-w-iptables-ipset6`",
 				),
 				'ip4-ban': (
-					r"`ipset add f2b-j-w-iptables-ipset 192.0.2.1 timeout 600 -exist`",
+					r"`ipset add f2b-j-w-iptables-ipset 192.0.2.1 timeout 0 -exist`",
 				),
 				'ip4-unban': (
 					r"`ipset del f2b-j-w-iptables-ipset 192.0.2.1 -exist`",
 				),
 				'ip6-ban': (
-					r"`ipset add f2b-j-w-iptables-ipset6 2001:db8:: timeout 600 -exist`",
+					r"`ipset add f2b-j-w-iptables-ipset6 2001:db8:: timeout 0 -exist`",
 				),
 				'ip6-unban': (
 					r"`ipset del f2b-j-w-iptables-ipset6 2001:db8:: -exist`",
 				),					
 			}),
 			# iptables-ipset-proto6-allports --
-			('j-w-iptables-ipset-ap', 'iptables-ipset-proto6-allports[name=%(__name__)s, bantime="10m", chain="<known/chain>"]', {
+			('j-w-iptables-ipset-ap', 'iptables-ipset-proto6-allports[name=%(__name__)s, chain="<known/chain>"]', {
 				'ip4': (' f2b-j-w-iptables-ipset-ap ',), 'ip6': (' f2b-j-w-iptables-ipset-ap6 ',),
 				'ip4-start': (
-					"`ipset create f2b-j-w-iptables-ipset-ap hash:ip timeout 600`",
+					"`ipset create f2b-j-w-iptables-ipset-ap hash:ip timeout 0 `",
 					"`iptables -w -I INPUT -m set --match-set f2b-j-w-iptables-ipset-ap src -j REJECT --reject-with icmp-port-unreachable`",
 				), 
 				'ip6-start': (
-					"`ipset create f2b-j-w-iptables-ipset-ap6 hash:ip timeout 600 family inet6`",
+					"`ipset create f2b-j-w-iptables-ipset-ap6 hash:ip timeout 0 family inet6`",
 					"`ip6tables -w -I INPUT -m set --match-set f2b-j-w-iptables-ipset-ap6 src -j REJECT --reject-with icmp6-port-unreachable`",
 				),
 				'flush': (
@@ -1568,13 +1568,13 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					"`ipset destroy f2b-j-w-iptables-ipset-ap6`",
 				),
 				'ip4-ban': (
-					r"`ipset add f2b-j-w-iptables-ipset-ap 192.0.2.1 timeout 600 -exist`",
+					r"`ipset add f2b-j-w-iptables-ipset-ap 192.0.2.1 timeout 0 -exist`",
 				),
 				'ip4-unban': (
 					r"`ipset del f2b-j-w-iptables-ipset-ap 192.0.2.1 -exist`",
 				),
 				'ip6-ban': (
-					r"`ipset add f2b-j-w-iptables-ipset-ap6 2001:db8:: timeout 600 -exist`",
+					r"`ipset add f2b-j-w-iptables-ipset-ap6 2001:db8:: timeout 0 -exist`",
 				),
 				'ip6-unban': (
 					r"`ipset del f2b-j-w-iptables-ipset-ap6 2001:db8:: -exist`",
@@ -1852,14 +1852,14 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 				),					
 			}),
 			# firewallcmd-ipset (multiport) --
-			('j-w-fwcmd-ipset', 'firewallcmd-ipset[name=%(__name__)s, bantime="10m", port="http", protocol="tcp", chain="<known/chain>"]', {
+			('j-w-fwcmd-ipset', 'firewallcmd-ipset[name=%(__name__)s, port="http", protocol="tcp", chain="<known/chain>"]', {
 				'ip4': (' f2b-j-w-fwcmd-ipset ',), 'ip6': (' f2b-j-w-fwcmd-ipset6 ',),
 				'ip4-start': (
-					"`ipset create f2b-j-w-fwcmd-ipset hash:ip timeout 600`",
+					"`ipset create f2b-j-w-fwcmd-ipset hash:ip timeout 0 `",
 					"`firewall-cmd --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m multiport --dports http -m set --match-set f2b-j-w-fwcmd-ipset src -j REJECT --reject-with icmp-port-unreachable`",
 				), 
 				'ip6-start': (
-					"`ipset create f2b-j-w-fwcmd-ipset6 hash:ip timeout 600 family inet6`",
+					"`ipset create f2b-j-w-fwcmd-ipset6 hash:ip timeout 0 family inet6`",
 					"`firewall-cmd --direct --add-rule ipv6 filter INPUT_direct 0 -p tcp -m multiport --dports http -m set --match-set f2b-j-w-fwcmd-ipset6 src -j REJECT --reject-with icmp6-port-unreachable`",
 				),
 				'flush': (
@@ -1875,27 +1875,27 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					"`ipset destroy f2b-j-w-fwcmd-ipset6`",
 				),
 				'ip4-ban': (
-					r"`ipset add f2b-j-w-fwcmd-ipset 192.0.2.1 timeout 600 -exist`",
+					r"`ipset add f2b-j-w-fwcmd-ipset 192.0.2.1 timeout 0 -exist`",
 				),
 				'ip4-unban': (
 					r"`ipset del f2b-j-w-fwcmd-ipset 192.0.2.1 -exist`",
 				),
 				'ip6-ban': (
-					r"`ipset add f2b-j-w-fwcmd-ipset6 2001:db8:: timeout 600 -exist`",
+					r"`ipset add f2b-j-w-fwcmd-ipset6 2001:db8:: timeout 0 -exist`",
 				),
 				'ip6-unban': (
 					r"`ipset del f2b-j-w-fwcmd-ipset6 2001:db8:: -exist`",
 				),					
 			}),
 			# firewallcmd-ipset (allports) --
-			('j-w-fwcmd-ipset-ap', 'firewallcmd-ipset[name=%(__name__)s, bantime="10m", actiontype=<allports>, protocol="tcp", chain="<known/chain>"]', {
+			('j-w-fwcmd-ipset-ap', 'firewallcmd-ipset[name=%(__name__)s, actiontype=<allports>, protocol="tcp", chain="<known/chain>"]', {
 				'ip4': (' f2b-j-w-fwcmd-ipset-ap ',), 'ip6': (' f2b-j-w-fwcmd-ipset-ap6 ',),
 				'ip4-start': (
-					"`ipset create f2b-j-w-fwcmd-ipset-ap hash:ip timeout 600`",
+					"`ipset create f2b-j-w-fwcmd-ipset-ap hash:ip timeout 0 `",
 					"`firewall-cmd --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m set --match-set f2b-j-w-fwcmd-ipset-ap src -j REJECT --reject-with icmp-port-unreachable`",
 				), 
 				'ip6-start': (
-					"`ipset create f2b-j-w-fwcmd-ipset-ap6 hash:ip timeout 600 family inet6`",
+					"`ipset create f2b-j-w-fwcmd-ipset-ap6 hash:ip timeout 0 family inet6`",
 					"`firewall-cmd --direct --add-rule ipv6 filter INPUT_direct 0 -p tcp -m set --match-set f2b-j-w-fwcmd-ipset-ap6 src -j REJECT --reject-with icmp6-port-unreachable`",
 				),
 				'flush': (
@@ -1911,13 +1911,13 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					"`ipset destroy f2b-j-w-fwcmd-ipset-ap6`",
 				),
 				'ip4-ban': (
-					r"`ipset add f2b-j-w-fwcmd-ipset-ap 192.0.2.1 timeout 600 -exist`",
+					r"`ipset add f2b-j-w-fwcmd-ipset-ap 192.0.2.1 timeout 0 -exist`",
 				),
 				'ip4-unban': (
 					r"`ipset del f2b-j-w-fwcmd-ipset-ap 192.0.2.1 -exist`",
 				),
 				'ip6-ban': (
-					r"`ipset add f2b-j-w-fwcmd-ipset-ap6 2001:db8:: timeout 600 -exist`",
+					r"`ipset add f2b-j-w-fwcmd-ipset-ap6 2001:db8:: timeout 0 -exist`",
 				),
 				'ip6-unban': (
 					r"`ipset del f2b-j-w-fwcmd-ipset-ap6 2001:db8:: -exist`",


### PR DESCRIPTION
Internal handling of timeout in ipset (earlier expiration of ipset entries by timeouts, if it exceeded by time jumps (correction), retarded unban in fail2ban like delays in busy state, etc) is too error-prone and can lead to discrepancy by banned state in fail2ban and ipset (like `already banned` by repeated intrusion attempts after unban in ipset but not in fail2ban's ban-manager).

Candidates to be affected #2670, #2699 (and possibly some others, like #2666).

Several ipset actions fixed (no timeout per default anymore), so no discrepancy between ipset and fail2ban (removal from ipset will be managed by fail2ban only):
- action.d/firewallcmd-ipset.conf
- action.d/iptables-ipset-proto6-allports.conf
- action.d/iptables-ipset-proto6.conf
- action.d/shorewall-ipset-proto6.conf

This should avoid such discrepancy. 
To restore previous handling, parameter `timeout` can be set to `<bantime>` or predefined value `<timeout-bantime>` considering max possible timeout of ipset (2147483 seconds), like here:
```ini
banaction = %(default/banaction)s[timeout='<timeout-bantime>']
```
Also removes a need to specify space `<sp>` by setting of `familyopt` parameter (closes #2579)