### PR TITLE
support ejabberd 20.x and other authentications

### DIFF
--- a/config/filter.d/ejabberd-auth.conf
+++ b/config/filter.d/ejabberd-auth.conf
@@ -17,7 +17,8 @@
 # Values:  TEXT
 #
 failregex = ^=INFO REPORT====  ===\nI\(<0\.\d+\.0>:ejabberd_c2s:\d+\) : \([^)]+\) Failed authentication for \S+ from (?:IP )?<HOST>(?: \({{(?:\d+,){3}\d+},\d+}\))?$
-            ^(?:\.\d+)? \[info\] <0\.\d+\.\d>@ejabberd_c2s:\w+:\d+ \([^\)]+\) Failed (?:c2s \w+ )?authentication for \S+ from (?:IP )?(?:::FFFF:)?<HOST>(?:: |$)
+            ^(?:\.\d+)? \[info\] <0\.\d+\.\d>@ejabberd_c2s:\w+:\d+ \([^\)]+\) Failed (?:c2s [A-Z0-9\-]+ )?authentication for \S+ from (?:IP )?(?:::FFFF:)?<HOST>(?:: |$)
+            ^(?:\.\d+)? \[info\] <0\.\d+\.\d>@ejabberd_c2s:\w+:\d+ \([^\)]+\) Failed (?:c2s [A-Z0-9\-]+ )?authentication for \S+ from (?:IP )?(?:::ffff:)?<HOST>(?:: |$)
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.


### PR DESCRIPTION
only PLAIN matched the regex, i.e. SCRAM-SHA-1 didn't match.
In ejabberd 20, failed logins are looged as warning, not as info anymore.

An example log line is:
```
2020-05-14 09:48:55.731 [warning] <0.22523.0>@ejabberd_c2s:process_auth_result:279 (tls|<0.22523.0>) Failed c2s SCRAM-SHA-1 authentication for xyz@abc.de from ::ffff:8
.8.8.8: Invalid username or password
```
