### PR TITLE
Update  drupal-auth.conf

### DIFF
--- a/config/filter.d/drupal-auth.conf
+++ b/config/filter.d/drupal-auth.conf
@@ -14,7 +14,7 @@ before = common.conf
 
 [Definition]
 
-failregex = ^%(__prefix_line)s(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(\/[\w\.-]+)*\|\d{10}\|user\|<HOST>\|.+\|.*\|\d\|.*\|Login attempt failed (?:for|from) .+\.$
+failregex = ^%(__prefix_line)s(?:https?:\/\/)[^|]+\|[^|]+\|[^|]+\|<ADDR>\|(?:[^|]*\|)*Login attempt failed (?:for|from) <F-USER>[^|]+</F-USER>\.$
 
 ignoreregex =
 

--- a/config/filter.d/drupal-auth.conf
+++ b/config/filter.d/drupal-auth.conf
@@ -14,7 +14,7 @@ before = common.conf
 
 [Definition]
 
-failregex = ^%(__prefix_line)s(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(\/[\w\.-]+)*\|\d{10}\|user\|<HOST>\|.+\|.+\|\d\|.*\|Login attempt failed for .+\.$
+failregex = ^%(__prefix_line)s(https?:\/\/)([\da-z\.-]+)\.([a-z\.]{2,6})(\/[\w\.-]+)*\|\d{10}\|user\|<HOST>\|.+\|.*\|\d\|.*\|Login attempt failed (?:for|from) .+\.$
 
 ignoreregex =
 

--- a/fail2ban/tests/files/logs/drupal-auth
+++ b/fail2ban/tests/files/logs/drupal-auth
@@ -3,5 +3,15 @@ Apr 26 13:15:25 webserver example.com: https://example.com|1430068525|user|1.2.3
 # failJSON: { "time": "2005-04-26T13:15:25", "match": true , "host": "1.2.3.4" }
 Apr 26 13:15:25 webserver example.com: https://example.com/subdir|1430068525|user|1.2.3.4|https://example.com/subdir/user|https://example.com/subdir/user|0||Login attempt failed for drupaladmin.
 
-# failJSON: { "time": "2005-04-26T13:19:08", "match": false , "host": "1.2.3.4" }
+# failJSON: { "time": "2005-04-26T13:19:08", "match": false , "host": "1.2.3.4", "user": "drupaladmin" }
 Apr 26 13:19:08 webserver example.com: https://example.com|1430068748|user|1.2.3.4|https://example.com/user|https://example.com/user|1||Session opened for drupaladmin.
+
+# failJSON: { "time": "2005-04-26T13:20:00", "match": false, "desc": "attempt to inject on URI (pipe, login failed for), not a failure, gh-2742" }
+Apr 26 13:20:00 host drupal-site: https://example.com|1613063581|user|192.0.2.5|https://example.com/user/login?test=%7C&test2=%7C...|https://example.com/user/login?test=|&test2=|0||Login attempt failed for tester|2||Session revisited for drupaladmin.
+
+# failJSON: { "time": "2005-04-26T13:20:01", "match": true , "host": "192.0.2.7", "user": "Jack Sparrow", "desc": "log-format change - for -> from, user name with space, gh-2742" }
+Apr 26 13:20:01 mweb drupal_site[24864]: https://www.example.com|1613058599|user|192.0.2.7|https://www.example.com/en/user/login|https://www.example.com/en/user/login|0||Login attempt failed from Jack Sparrow.
+# failJSON: { "time": "2005-04-26T13:20:02", "match": true , "host": "192.0.2.4", "desc": "attempt to inject on URI (pipe), login failed, gh-2742" }
+Apr 26 13:20:02 host drupal-site: https://example.com|1613063581|user|192.0.2.4|https://example.com/user/login?test=%7C&test2=%7C|https://example.com/user/login?test=|&test2=||0||Login attempt failed from 192.0.2.4.
+# failJSON: { "time": "2005-04-26T13:20:03", "match": false, "desc": "attempt to inject on URI (pipe, login failed from), not a failure, gh-2742" }
+Apr 26 13:20:03 host drupal-site: https://example.com|1613063581|user|192.0.2.5|https://example.com/user/login?test=%7C&test2=%7C...|https://example.com/user/login?test=|&test2=|0||Login attempt failed from 1.2.3.4|2||Session revisited for drupaladmin.


### PR DESCRIPTION
Small fix for Drupal 8. D8 uses "Login attempt failed from" while Drupal 7 uses "Login attempt failed for".
The referer part is a must currently, but some requests have an empty one and are not failing.

**[UPD]** Additionally introduces more precise RE, which avoids certain weakness with catch-all's and is injection safe (see new tests).
It would not match in case of user name contains `|` character, but since D8 seems to not encode or quote it properly, we have no chance to make suitable RE (without to accept injectable URIs) and because it would be anyway poor choice of user name, we can accept a small restriction like this.