### PR TITLE
Closes #2751 filter.d/sendmail-*.local configparser recursion issue 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ ver. 1.0.1-dev-1 (20??/??/??) - development nightly edition
     different from 0) in case of unsane environment.
 
 ### Fixes
+* `filter.d/sendmail*.conf`: `__prefix_line = %(__prefix_line)...` recursion error when using sendmail*.local files (gh-2751)
 * [stability] prevent race condition - no ban if filter (backend) is continuously busy if
   too many messages will be found in log, e. g. initial scan of large log-file or journal (gh-2660)
 * pyinotify-backend sporadically avoided initial scanning of log-file by start

--- a/config/filter.d/sendmail-auth.conf
+++ b/config/filter.d/sendmail-auth.conf
@@ -8,10 +8,10 @@ before = common.conf
 [Definition]
 
 _daemon = (?:sendmail|sm-(?:mta|acceptingconnections))
-__prefix_line = %(known/__prefix_line)s(?:\w{14,20}: )?
+sendmail_prefix_line = %(known/__prefix_line)s(?:\w{14,20}: )?
 
 # "w{14,20}" will give support for IDs from 14 up to 20 characters long
-failregex = ^%(__prefix_line)s(\S+ )?\[(?:IPv6:<IP6>|<IP4>)\]( \(may be forged\))?: possible SMTP attack: command=AUTH, count=\d+$
+failregex = ^%(sendmail_prefix_line)s(\S+ )?\[(?:IPv6:<IP6>|<IP4>)\]( \(may be forged\))?: possible SMTP attack: command=AUTH, count=\d+$
 
 ignoreregex =
 

--- a/config/filter.d/sendmail-reject.conf
+++ b/config/filter.d/sendmail-reject.conf
@@ -20,9 +20,9 @@ before = common.conf
 [Definition]
 
 _daemon = (?:(sm-(mta|acceptingconnections)|sendmail))
-__prefix_line = %(known/__prefix_line)s(?:\w{14,20}: )?
+sendmail_prefix_line = %(known/__prefix_line)s(?:\w{14,20}: )?
 
-prefregex = ^<F-MLFID>%(__prefix_line)s</F-MLFID><F-CONTENT>.+</F-CONTENT>$
+prefregex = ^<F-MLFID>%(sendmail_prefix_line)s</F-MLFID><F-CONTENT>.+</F-CONTENT>$
 
 cmnfailre = ^ruleset=check_rcpt, arg1=(?P<email><\S+@\S+>), relay=(\S+ )?\[(?:IPv6:<IP6>|<IP4>)\](?: \(may be forged\))?, reject=(550 5\.7\.1 (?P=email)\.\.\. Relaying denied\. (IP name possibly forged \[(\d+\.){3}\d+\]|Proper authentication required\.|IP name lookup failed \[(\d+\.){3}\d+\])|553 5\.1\.8 (?P=email)\.\.\. Domain of sender address \S+ does not exist|550 5\.[71]\.1 (?P=email)\.\.\. (Rejected: .*|User unknown))$
             ^ruleset=check_relay, arg1=(?P<dom>\S+), arg2=(?:IPv6:<IP6>|<IP4>), relay=((?P=dom) )?\[(\d+\.){3}\d+\](?: \(may be forged\))?, reject=421 4\.3\.2 (Connection rate limit exceeded\.|Too many open connections\.)$
@@ -59,7 +59,7 @@ journalmatch = SYSLOG_IDENTIFIER=sm-mta + _SYSTEMD_UNIT=sendmail.service
 # another line with the HOST, therefore no-failure line was added as regex, that
 # contains HOST (see line with tag <F-NOFAIL>).
 #
-# Note the capture <F-MLFID>, includes both the __prefix_lines (which includes
+# Note the capture <F-MLFID>, includes both the sendmail_prefix_lines (which includes
 # the sendmail PID), but also the `\w{14}` which the the sendmail assigned 
 # mail ID (todo: check this is necessary, possible obsolete).
 #


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
