### PR TITLE
Create new action opnsense-alias.conf - ban IPs using a new entry to …

### DIFF
--- a/config/action.d/opnsense-alias.conf
+++ b/config/action.d/opnsense-alias.conf
@@ -1,0 +1,73 @@
+#
+# Author: TuEye
+#
+# IMPORTANT
+#
+# Please set jail.local's permission to 640 because it contains your OS API key.
+#
+# This action depends on curl.
+#
+
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
+# Values:  CMD
+#
+actionstart =
+
+# Option:  actionstop
+# Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
+# Values:  CMD
+#
+actionstop =
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+actioncheck =
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    <ip>  IP address
+#          <failures>  number of failures
+#          <time>  unix timestamp of the ban time
+# Values:  CMD
+#
+actionban = curl -k -s -XPOST -d '{"address":"<ip>"}' -H "Content-Type: application/json" -k -u "<oskey>":"<ossecret>" \
+            https://<osaddress>/api/firewall/alias_util/add/<osalias>
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    <ip>  IP address
+#          <failures>  number of failures
+#          <time>  unix timestamp of the ban time
+# Values:  CMD
+#
+actionunban = curl -k -s -XPOST -d '{"address":"<ip>"}' -H "Content-Type: application/json" -k -u "<oskey>":"<ossecret>" \
+              https://<osaddress>/api/firewall/alias_util/delete/<osalias>
+
+[Init]
+# Option: oskey
+# Notes.: The api key which you generated in the OPNsense
+# Usage.: use in jail config:  banaction = opnsense-alias[oskey=""]
+oskey =
+
+# Option: ossecret
+# Notes.: The api key which you generated in the OPNsense
+# Usage.: use in jail config:  banaction = opnsense-alias[ossecret=""]
+ossecret =
+
+# Option: osaddress
+# Notes.: The address to your OPNsense eg.: 192.168.1.1:443
+# Usage.: use in jail config:  banaction = opnsense-alias[osaddress=""]
+osaddress = 
+
+# Option: osalias
+# Notes.: The name of the exisiting alias to which the banned IP should be added
+# Usage.: use in jail config:  banaction = opnsense-alias[osalias=""]
+osalias = 


### PR DESCRIPTION
…an OPNsense firewall alias

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.

# Details
With this action it is possible to add a new entry to an exisitng alias in the OPNsense firewall.
The OPNsense alias is used to add and delete this entrys.