### PR TITLE
Remove duplicate method and rename invalid parameter

### DIFF
--- a/fail2ban/server/failmanager.py
+++ b/fail2ban/server/failmanager.py
@@ -59,10 +59,6 @@ class FailManager:
 		with self.__lock:
 			return len(self.__failList), sum([f.getRetry() for f in self.__failList.values()])
 
-	def getFailTotal(self):
-		with self.__lock:
-			return self.__failTotal
-
 	def setMaxRetry(self, value):
 		self.__maxRetry = value
 	

--- a/fail2ban/server/observer.py
+++ b/fail2ban/server/observer.py
@@ -87,7 +87,7 @@ class ObserverThread(JailThread):
 		except KeyError:
 			raise KeyError("Invalid event index : %s" % i)
 
-	def __delitem__(self, name):
+	def __delitem__(self, i):
 		try:
 			del self._queue[i]
 		except KeyError:


### PR DESCRIPTION
Remove duplicate method 'getFailTotal' in failmanager.py and also rename invalid parameter 'name' in observer.py.