### PR TITLE
Add Bitwarden syslog support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -73,6 +73,7 @@ ver. 0.10.6-dev (20??/??/??) - development edition
 * new filter and jail for GitLab recognizing failed application logins (gh-2689)
 * new filter and jail for SoftEtherVPN recognizing failed application logins (gh-2723)
 * `filter.d/guacamole.conf` extended with `logging` parameter to follow webapp-logging if it's configured (gh-2631)
+* `filter.d/bitwarden.conf` enhanced to support syslog (gh-2778)
 * introduced new prefix `{UNB}` for `datepattern` to disable word boundaries in regex;
 * datetemplate: improved anchor detection for capturing groups `(^...)`;
 * datepattern: improved handling with wrong recognized timestamps (timezones, no datepattern, etc)

--- a/config/filter.d/bitwarden.conf
+++ b/config/filter.d/bitwarden.conf
@@ -2,5 +2,11 @@
 # Detecting failed login attempts
 # Logged in bwdata/logs/identity/Identity/log.txt
 
+[INCLUDES]
+before = common.conf
+
 [Definition]
-failregex = ^\s*\[WRN\]\s+Failed login attempt(?:, 2FA invalid)?\. <HOST>$
+failregex = ^%(__prefix_line)s\s*\[[^\s]+\]\s+Failed login attempt(?:, 2FA invalid)?\. <HOST>$
+
+# DEV Notes:
+# __prefix_line can result to an empty string, so it can support syslog and non-syslog at once.

--- a/config/filter.d/bitwarden.conf
+++ b/config/filter.d/bitwarden.conf
@@ -6,7 +6,8 @@
 before = common.conf
 
 [Definition]
-failregex = ^%(__prefix_line)s\s*\[[^\s]+\]\s+Failed login attempt(?:, 2FA invalid)?\. <HOST>$
+_daemon = Bitwarden-Identity
+failregex = ^%(__prefix_line)s\s*\[(?:W(?:RN|arning)|Bit\.Core\.[^\]]+)\]\s+Failed login attempt(?:, 2FA invalid)?\. <ADDR>$
 
 # DEV Notes:
 # __prefix_line can result to an empty string, so it can support syslog and non-syslog at once.

--- a/fail2ban/tests/files/logs/bitwarden
+++ b/fail2ban/tests/files/logs/bitwarden
@@ -2,6 +2,9 @@
 2019-11-26 01:04:49.008 +08:00 [WRN] Failed login attempt. 192.168.0.16
 
 # failJSON: { "time": "2019-11-25T21:39:58", "match": true , "host": "192.168.0.21" }
+2019-11-25 21:39:58.464 +01:00 [WRN] Failed login attempt, 2FA invalid. 192.168.0.21
+
+# failJSON: { "time": "2019-11-25T21:39:58", "match": true , "host": "192.168.0.21" }
 2019-11-25 21:39:58.464 +01:00 [Warning] Failed login attempt, 2FA invalid. 192.168.0.21
 
 # failJSON: { "time": "2019-09-24T13:16:50", "match": true , "host": "192.168.0.23" }

--- a/fail2ban/tests/files/logs/bitwarden
+++ b/fail2ban/tests/files/logs/bitwarden
@@ -2,7 +2,7 @@
 2019-11-26 01:04:49.008 +08:00 [WRN] Failed login attempt. 192.168.0.16
 
 # failJSON: { "time": "2019-11-25T21:39:58", "match": true , "host": "192.168.0.21" }
-2019-11-25 21:39:58.464 +01:00 [WRN] Failed login attempt, 2FA invalid. 192.168.0.21
+2019-11-25 21:39:58.464 +01:00 [Warning] Failed login attempt, 2FA invalid. 192.168.0.21
 
 # failJSON: { "time": "2019-09-24T13:16:50", "match": true , "host": "192.168.0.23" }
 2019-09-24T13:16:50 e5a81dbf7fd1 Bitwarden-Identity[1]: [Bit.Core.IdentityServer.ResourceOwnerPasswordValidator] Failed login attempt. 192.168.0.23

--- a/fail2ban/tests/files/logs/bitwarden
+++ b/fail2ban/tests/files/logs/bitwarden
@@ -3,3 +3,6 @@
 
 # failJSON: { "time": "2019-11-25T21:39:58", "match": true , "host": "192.168.0.21" }
 2019-11-25 21:39:58.464 +01:00 [WRN] Failed login attempt, 2FA invalid. 192.168.0.21
+
+# failJSON: { "time": "2019-09-24T13:16:50", "match": true , "host": "192.168.0.23" }
+2019-09-24T13:16:50 e5a81dbf7fd1 Bitwarden-Identity[1]: [Bit.Core.IdentityServer.ResourceOwnerPasswordValidator] Failed login attempt. 192.168.0.23


### PR DESCRIPTION
Hi,

This follows #2567, adding syslog support to Bitwarden jail, as it can now log through syslog (https://github.com/bitwarden/server/pull/742).

Thank you !