### PR TITLE
Add bcc and dontsend capabilities to xarf-login-attack action

### DIFF
--- a/config/action.d/xarf-login-attack.conf
+++ b/config/action.d/xarf-login-attack.conf
@@ -49,6 +49,8 @@ actionban = oifs=${IFS};
             IFS=${oifs}
             IP=<ip>
             FROM=<sender>
+            BCC=<bcc>
+            DONTSEND=<dontsend>
             SERVICE=<service>
             FAILURES=<failures>
             REPORTID=<time>@<fq-hostname>
@@ -56,11 +58,16 @@ actionban = oifs=${IFS};
             PORT=<port>
             DATE=`LC_ALL=C date --date=@<time> +"%%a, %%d %%h %%Y %%T %%z"`
             if [ ! -z "$ADDRESSES" ]; then
-                oifs=${IFS}; IFS=,; ADDRESSES=$(echo $ADDRESSES)
-                IFS=${oifs}
+                if [ ! -z "$DONTSEND" ]; then
+                    for ckaddr in "${DONTSEND[@]}"; do
+                        if [[ "$ADDRESSES" == *"$ckaddr"* ]]; then
+                           exit 0   
+                        fi
+                    done
+                 fi
                 (printf -- %%b "<header>\n<message>\n<report>\n\n";
                  date '+Note: Local timezone is %%z (%%Z)';
-                 printf -- %%b "\n<ipmatches>\n\n<footer>") | <mailcmd> <mailargs> $ADDRESSES
+                 printf -- %%b "\n<ipmatches>\n\n<footer>") | <mailcmd> <mailargs> $ADDRESSES $BCC
             fi
 
 actionunban =
@@ -141,3 +148,11 @@ sender = fail2ban@<fq-hostname>
 # Notes.:  This is the port number that received the login-attack
 port = 0
 
+# Option:  bcc
+# Notes:   Allows the user to specify a user to receive a copy of the email
+bcc =
+
+# Option:  dontsend
+# Notes:   Array of abuse emails to ignore.  Eg.
+# dontsend = ('email@one.com' 'email@two.com' 'email@three.com')
+dontsend =


### PR DESCRIPTION
This PR provides the ability to specify an optional bcc for the generated abuse emails.  It also provides the ability to provide an array of abuse addresses for which no email should be generated.  This solves the problem of published abuse addresses which bounce the mail back to the sender or, as in the case of lacnicnet, say that they cannot assist because the are a regional allocation registry.

The dontsend array is specified in jail.local as:

dontsend = ( 'one@address.com' 'two@address.com' 'three@address.com')

The bcc is specified in jail.local as:

bcc = someaddress@myhost.com

Then xarf-login-attack is called as usual, with either of the new ptional oparameters passed as desired:

action = %(action_)s
         xarf-login-attack-local[mailargs=%(mailargs)s,mailcmd=%(mailcmd)s,bcc=%(bcc)s,dontsend=%(dontsend)s]

I also removed a redundant IFS operation on $ADDRESSES.

Resolves #2919 and #2920 .
