### PR TITLE
nsd.conf: fix for the current log format

### DIFF
--- a/config/filter.d/nsd.conf
+++ b/config/filter.d/nsd.conf
@@ -22,8 +22,8 @@ _daemon = nsd
 #          (?:::f{4,6}:)?(?P<host>[\w\-.^_]+)
 # Values:  TEXT
 
-failregex =  ^%(__prefix_line)sinfo: ratelimit block .* query <HOST> TYPE255$
-             ^%(__prefix_line)sinfo: .* <HOST> refused, no acl matches
+failregex =  ^%(__prefix_line)sinfo: ratelimit block .* query <ADDR> TYPE255$
+             ^%(__prefix_line)sinfo: .* from(?: client)? <ADDR> refused, no acl matches\.?$
 
 ignoreregex =
 

--- a/config/filter.d/nsd.conf
+++ b/config/filter.d/nsd.conf
@@ -23,7 +23,7 @@ _daemon = nsd
 # Values:  TEXT
 
 failregex =  ^%(__prefix_line)sinfo: ratelimit block .* query <HOST> TYPE255$
-             ^%(__prefix_line)sinfo: .* <HOST> refused, no acl matches\.$
+             ^%(__prefix_line)sinfo: .* <HOST> refused, no acl matches
 
 ignoreregex =
 

--- a/fail2ban/tests/files/logs/nsd
+++ b/fail2ban/tests/files/logs/nsd
@@ -2,3 +2,5 @@
 [1387288694] nsd[7745]: info: ratelimit block example.com. type any target 192.0.2.0/24 query 192.0.2.105 TYPE255
 # failJSON: { "time": "2013-12-18T07:42:15", "match": true , "host": "192.0.2.115" }
 [1387348935] nsd[23600]: info: axfr for zone domain.nl. from client 192.0.2.115 refused, no acl matches.
+# failJSON: { "time": "2021-03-05T05:25:14", "match": true , "host": "192.0.2.32", "desc": "new format, no client after from, no dot at end, gh-2965" }
+[2021-03-05 05:25:14.562] nsd[160800]: info: axfr for example.com. from 192.0.2.32 refused, no acl matches


### PR DESCRIPTION
New nsd 4.3.5 log format:

|  [2021-03-05 05:25:14.562] nsd[160800]: info: axfr for example.com. from 192.35.168.32 refused, no acl matches
|  [2021-03-06 05:24:33.223] nsd[356033]: info: axfr for localhost. from 192.35.168.160 refused, no acl matches
|  [2021-03-07 05:23:26.641] nsd[547893]: info: axfr for example.com. from 192.35.168.64 refused, no acl matches
|  [2021-03-08 05:18:54.067] nsd[739606]: info: axfr for example.com. from 192.35.168.32 refused, no acl matches

Before submitting your PR, please review the following checklist:

- [ ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [ ] **KEEP PR small** so it could be easily reviewed.
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
