### PR TITLE
Add support to Proxmox Web GUI

### DIFF
--- a/config/filter.d/proxmox.conf
+++ b/config/filter.d/proxmox.conf
@@ -1,4 +1,4 @@
-# Fail2Ban filter auth fauiluers on Proxmox Web GUI
+# Fail2Ban filter for Proxmox Web GUI
 #
 # Jail example:
 #    [proxmox]

--- a/config/filter.d/proxmox.conf
+++ b/config/filter.d/proxmox.conf
@@ -12,7 +12,7 @@
 
 [Definition]
 
-failregex = pvedaemon\[.d*\]: authentication failure; rhost=<HOST> user=.* msg=.*
+failregex = pvedaemon\[\d*\]: authentication failure; rhost=<HOST> user=.* msg=.*
 
 ignoreregex =
 

--- a/config/filter.d/proxmox.conf
+++ b/config/filter.d/proxmox.conf
@@ -1,0 +1,18 @@
+# Fail2Ban filter auth fauiluers on Proxmox Web GUI
+#
+# Jail example:
+#    [proxmox]
+#    enabled = true
+#    port = https,http,8006
+#    filter = proxmox
+#    logpath = /var/log/daemon.log
+#    maxretry = 3
+#    # 1 hour
+#    bantime = 3600
+
+[Definition]
+
+failregex = pvedaemon\[.*authentication failure; rhost=<HOST> user=.* msg=.*
+
+ignoreregex =
+

--- a/config/filter.d/proxmox.conf
+++ b/config/filter.d/proxmox.conf
@@ -12,7 +12,7 @@
 
 [Definition]
 
-failregex = pvedaemon\[.*authentication failure; rhost=<HOST> user=.* msg=.*
+failregex = pvedaemon\[.d*\]: authentication failure; rhost=<HOST> user=.* msg=.*
 
 ignoreregex =
 

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -951,3 +951,7 @@ logpath = %(apache_error_log)s
 # see `filter.d/traefik-auth.conf` for details and service example.
 port    = http,https
 logpath = /var/log/traefik/access.log
+
+[proxmox]
+port = https,http,8006
+logpath = /var/log/daemon.log

--- a/fail2ban/tests/files/logs/proxmox
+++ b/fail2ban/tests/files/logs/proxmox
@@ -1,2 +1,6 @@
+#1
+# failJSON: { "time": "2021-03-08T09:37:44", "match": true , "host": "212.106.229.105" }
 Mar  8 09:37:44 HOSTNAME pvedaemon[12021]: authentication failure; rhost=212.106.229.105 user=root@pam msg=Authentication failure
+#2
+# failJSON: { "time": "2021-03-09T03:32:27", "match": true , "host": "212.106.229.105" }
 Mar  9 03:32:27 HOSTNAME pvedaemon[8961]: authentication failure; rhost=212.106.229.105 user=jose@pve msg=invalid credentials

--- a/fail2ban/tests/files/logs/proxmox
+++ b/fail2ban/tests/files/logs/proxmox
@@ -1,6 +1,6 @@
 #1
-# failJSON: { "time": "2021-03-08T09:37:44", "match": true , "host": "212.106.229.105" }
+# failJSON: { "time": "2005-03-08T09:37:44", "match": true , "host": "212.106.229.105" }
 Mar  8 09:37:44 HOSTNAME pvedaemon[12021]: authentication failure; rhost=212.106.229.105 user=root@pam msg=Authentication failure
 #2
-# failJSON: { "time": "2021-03-09T03:32:27", "match": true , "host": "212.106.229.105" }
+# failJSON: { "time": "2005-03-09T03:32:27", "match": true , "host": "212.106.229.105" }
 Mar  9 03:32:27 HOSTNAME pvedaemon[8961]: authentication failure; rhost=212.106.229.105 user=jose@pve msg=invalid credentials

--- a/fail2ban/tests/files/logs/proxmox
+++ b/fail2ban/tests/files/logs/proxmox
@@ -1,0 +1,2 @@
+Mar  8 09:37:44 HOSTNAME pvedaemon[12021]: authentication failure; rhost=212.106.229.105 user=root@pam msg=Authentication failure
+Mar  9 03:32:27 HOSTNAME pvedaemon[8961]: authentication failure; rhost=212.106.229.105 user=jose@pve msg=invalid credentials


### PR DESCRIPTION
Ban users on Proxmox Web GUI

Line matching on /var/log/daemon.log:
```
Mar  8 09:37:44 F39068A pvedaemon[12021]: authentication failure; rhost=212.106.229.105 user=root@pam msg=Authentication failure
```