### PR TITLE
Regex count (stats) and reorder (rise up) mechanism

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,18 @@ ver. 1.0.1-dev-1 (20??/??/??) - development nightly edition
 * better recognition of log rotation, better performance by reopen: avoid unnecessary seek to begin of file
   (and hash calculation)
 * file filter reads only complete lines (ended with new-line) now, so waits for end of line (for its completion)
+* regex of multiple `failregex` (and `ignoreregex`) can rise up in filter depending on numer of matched lines,
+  (most used expressions go to the begin of list so will be applied first) what can provide better performance by
+  match search; two new option allow to switch this behavior for single or any expression:
+  - `NO-RISE-UP` or `NoRiseUp` - disable rising up for the regex for which this option is set
+  - `NO-REORDER` or `NoReorder` - disable reordering of `failregex` or `ignoreregex` list completely
+* `fail2ban-regex` extended:
+  - `prefregex`, `failregex` and `ignoreregex` are showing as original pattern now and PCRE expression
+    only in verbose mode (and all patterns are reordered by number of matches now);
+  - new option `--verbose-regex` or `--VR` which show substituted PCRE expression of `prefregex`,
+    matched `failregex` and `ignoreregex` additionally to pattern (without the need to enable more verbose mode)
+* `fail2ban-regex` and test suite e. g. sample regexs factory are adjusted to use more common functionality
+  of filter module (fewer special tweaks inside the modules)
 
 
 ver. 0.11.2 (2020/11/23) - heal-the-world-with-security-tools

--- a/fail2ban/client/fail2banregex.py
+++ b/fail2ban/client/fail2banregex.py
@@ -192,33 +192,6 @@ def get_opt_parser():
 	return p
 
 
-class RegexStat(object):
-
-	def __init__(self, failregex):
-		self._stats = 0
-		self._failregex = failregex
-		self._ipList = list()
-
-	def __str__(self):
-		return "%s(%r) %d failed: %s" \
-		  % (self.__class__, self._failregex, self._stats, self._ipList)
-
-	def inc(self):
-		self._stats += 1
-
-	def getStats(self):
-		return self._stats
-
-	def getFailRegex(self):
-		return self._failregex
-
-	def appendIP(self, value):
-		self._ipList.append(value)
-
-	def getIPList(self):
-		return self._ipList
-
-
 class LineStats(object):
 	"""Just a convenience container for stats
 	"""
@@ -256,8 +229,6 @@ class Fail2banRegex(object):
 		self._filter = Filter(None)
 		self._prefREMatched = 0
 		self._prefREGroups = list()
-		self._ignoreregex = list()
-		self._failregex = list()
 		self._time_elapsed = None
 		self._line_stats = LineStats(opts)
 
@@ -398,7 +369,6 @@ class Fail2banRegex(object):
 			# to stream:
 			readercommands = reader.convert()
 
-			regex_values = {}
 			for opt in readercommands:
 				if opt[0] == 'multi-set':
 					optval = opt[3]
@@ -411,17 +381,11 @@ class Fail2banRegex(object):
 						for optval in optval:
 							self._filter.prefRegex = optval
 					elif opt[2] == "addfailregex":
-						stor = regex_values.get('fail')
-						if not stor: stor = regex_values['fail'] = list()
 						for optval in optval:
-							stor.append(RegexStat(optval))
-							#self._filter.addFailRegex(optval)
+							self._filter.addFailRegex(optval)
 					elif opt[2] == "addignoreregex":
-						stor = regex_values.get('ignore')
-						if not stor: stor = regex_values['ignore'] = list()
 						for optval in optval:
-							stor.append(RegexStat(optval))
-							#self._filter.addIgnoreRegex(optval)
+							self._filter.addIgnoreRegex(optval)
 					elif opt[2] == "maxlines":
 						for optval in optval:
 							self.setMaxLines(optval)
@@ -436,22 +400,14 @@ class Fail2banRegex(object):
 						  "read from %s: %s" % (opt[2], optval, value, e) )
 					return False
 
-		else:
+		else: # direct failregex or ignoreregex:
 			self.output( "Use %11s line : %s" % (regex, shortstr(value)) )
-			regex_values = {regextype: [RegexStat(value)]}
+			getattr(self._filter, 'add%sRegex' % regextype.title())(value)
 
-		for regextype, regex_values in regex_values.iteritems():
-			regex = regextype + 'regex'
-			setattr(self, "_" + regex, regex_values)
-			for regex in regex_values:
-				getattr(
-					self._filter,
-					'add%sRegex' % regextype.title())(regex.getFailRegex())
 		return True
 
-	def _onIgnoreRegex(self, idx, ignoreRegex):
+	def _onIgnoreRegex(self, ignoreRegex):
 		self._lineIgnored = True
-		self._ignoreregex[idx].inc()
 
 	def testRegex(self, line, date=None):
 		orgLineBuffer = self._filter._Filter__lineBuffer
@@ -469,9 +425,10 @@ class Fail2banRegex(object):
 					# Append True/False flag depending if line was matched by
 					# more than one regex
 					match.append(len(ret)>1)
-					regex = self._failregex[match[0]]
-					regex.inc()
-					regex.appendIP(match)
+					if self._verbose:
+						regex = match[0]
+						if not regex.stats.get('matchList'): regex.stats['matchList'] = list()
+						regex.stats['matchList'].append(match[1:])
 				if not match[3].get('nofail'):
 					ret.append(match)
 				else:
@@ -627,16 +584,16 @@ class Fail2banRegex(object):
 			header = "%s line(s):" % (ltype.capitalize(),)
 			if self._debuggex:
 				if ltype == 'missed' or ltype == 'matched':
-					regexlist = self._failregex
+					regexlist = self._filter.failRegex
 				else:
-					regexlist = self._ignoreregex
+					regexlist = self._filter.ignoreRegex
 				l = lstats[ltype + '_lines_timeextracted']
 				if lines < self._maxlines or getattr(self, '_print_all_' + ltype):
 					ans = [[]]
 					for arg in [l, regexlist]:
 						ans = [ x + [y] for x in ans for y in arg ]
-					b = map(lambda a: a[0] +  ' | ' + a[1].getFailRegex() + ' |  ' + 
-						debuggexURL(self.encode_line(a[0]), a[1].getFailRegex(), 
+					b = map(lambda a: a[0] +  ' | ' + a[1].getRegex() + ' |  ' + 
+						debuggexURL(self.encode_line(a[0]), a[1].getRegex(), 
 							multiline, self._opts.usedns), ans)
 					pprint_list([x.rstrip() for x in b], header)
 				else:
@@ -654,27 +611,26 @@ class Fail2banRegex(object):
 		output( "Results" )
 		output( "=======" )
 
-		def print_failregexes(title, failregexes):
+		def _printRegexes(title, failregexes):
 			# Print title
 			total, out = 0, []
 			for cnt, failregex in enumerate(failregexes):
-				match = failregex.getStats()
-				total += match
-				if (match or self._verbose):
-					out.append("%2d) [%d] %s" % (cnt+1, match, failregex.getFailRegex()))
+				total += failregex.matchCount
+				if (failregex.matchCount or self._verbose):
+					out.append("[%d] %s" % (failregex.matchCount, failregex.getRegex()))
 
-				if self._verbose and len(failregex.getIPList()):
-					for ip in failregex.getIPList():
-						timeTuple = time.localtime(ip[2])
+				if self._verbose and failregex.stats.get('matchList'):
+					for ip in failregex.stats['matchList']:
+						timeTuple = time.localtime(ip[1])
 						timeString = time.strftime("%a %b %d %H:%M:%S %Y", timeTuple)
 						out.append(
 							"    %s  %s%s" % (
-								ip[1],
+								ip[0],
 								timeString,
 								ip[-1] and " (multiple regex matched)" or ""))
 
 			output( "\n%s: %d total" % (title, total) )
-			pprint_list(out, " #) [# of hits] regular expression")
+			pprint_list(out, "[# of hits] regular expression")
 			return total
 
 		# Print prefregex:
@@ -689,8 +645,8 @@ class Fail2banRegex(object):
 			pprint_list(out)
 
 		# Print regex's:
-		total = print_failregexes("Failregex", self._failregex)
-		_ = print_failregexes("Ignoreregex", self._ignoreregex)
+		total = _printRegexes("Failregex", self._filter.failRegex)
+		_ = _printRegexes("Ignoreregex", self._filter.ignoreRegex)
 
 
 		if self._filter.dateDetector is not None:

--- a/fail2ban/server/failregex.py
+++ b/fail2ban/server/failregex.py
@@ -252,6 +252,15 @@ class Regex:
 	@property
 	def pattern(self):
 		return self._pattern
+
+	@property
+	def stats(self):
+		"""Automatically created statistics member.
+
+		Used for statistic purposes (e. g. in fail2ban-regex stores matches in verbose mode)."""
+		if not hasattr(self, '_stats'):
+			self._stats = dict()
+		return self._stats
 	
 	##
 	# Returns string buffer using join of the tupleLines.

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -780,7 +780,7 @@ class Filter(JailThread):
 					self._riseUpRegex(self.__ignoreRegex, ignoreRegexIndex, ignoreRegex)
 				fnd = ignoreRegexIndex
 				logSys.log(7, "  Matched ignoreregex %d and was ignored", fnd)
-				if self.onIgnoreRegex: self.onIgnoreRegex(fnd, ignoreRegex)
+				if self.onIgnoreRegex: self.onIgnoreRegex(ignoreRegex)
 				# remove ignored match:
 				if not self.checkAllRegex or self.__lineBufferSize > 1:
 					# todo: check ignoreRegex.getUnmatchedTupleLines() would be better (fix testGetFailuresMultiLineIgnoreRegex):
@@ -999,7 +999,7 @@ class Filter(JailThread):
 					fail = fail.copy()
 				# append failure with match to the list:
 				for ip in ips:
-					failList.append([failRegexIndex, ip, date, fail])
+					failList.append([failRegex, ip, date, fail])
 				if not self.checkAllRegex:
 					break
 			except RegexException as e: # pragma: no cover - unsure if reachable

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -756,7 +756,7 @@ class Filter(JailThread):
 		# avoid reorder too often (e. g. always 2 regex each after other):
 		c = reToMove.matchCount + 2
 		# try index 0, half of distance and previous position:
-		for mi in set((0, reIdx/2, reIdx-1)):
+		for mi in set((0, reIdx//2, reIdx-1)):
 			if reLst[mi].matchCount < c:
 				if logSys.getEffectiveLevel() <= 5:
 					logSys.log(5, "    Rise-up RE: match counts %r > %r, move RE %r to %r",

--- a/fail2ban/tests/config/filter.d/zzz-sshd-obsolete-multiline.conf
+++ b/fail2ban/tests/config/filter.d/zzz-sshd-obsolete-multiline.conf
@@ -37,7 +37,7 @@ __pam_auth = pam_[a-z]+
 cmnfailre = ^%(__prefix_line_sl)s[aA]uthentication (?:failure|error|failed) for .* from <HOST>( via \S+)?\s*%(__suff)s$
          ^%(__prefix_line_sl)sUser not known to the underlying authentication module for .* from <HOST>\s*%(__suff)s$
          ^%(__prefix_line_sl)sFailed \S+ for invalid user <F-USER>(?P<cond_user>\S+)|(?:(?! from ).)*?</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?(?(cond_user): |(?:(?:(?! from ).)*)$)
-         ^%(__prefix_line_sl)sFailed (?:<F-NOFAIL>publickey</F-NOFAIL>|\S+) for (?P<cond_inv>invalid user )?<F-USER>(?P<cond_user>\S+)|(?(cond_inv)(?:(?! from ).)*?|[^:]+)</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?(?(cond_user): |(?:(?:(?! from ).)*)$)
+         {NO-RISE-UP}^%(__prefix_line_sl)sFailed (?:<F-NOFAIL>publickey</F-NOFAIL>|\S+) for (?P<cond_inv>invalid user )?<F-USER>(?P<cond_user>\S+)|(?(cond_inv)(?:(?! from ).)*?|[^:]+)</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?(?(cond_user): |(?:(?:(?! from ).)*)$)
          ^%(__prefix_line_sl)sROOT LOGIN REFUSED FROM <HOST>
          ^%(__prefix_line_sl)s[iI](?:llegal|nvalid) user .*? from <HOST>%(__suff)s$
          ^%(__prefix_line_sl)sUser .+ from <HOST> not allowed because not listed in AllowUsers\s*%(__suff)s$
@@ -47,7 +47,6 @@ cmnfailre = ^%(__prefix_line_sl)s[aA]uthentication (?:failure|error|failed) for 
          ^%(__prefix_line_sl)sReceived disconnect from <HOST>%(__on_port_opt)s:\s*3: .*: Auth fail%(__suff)s$
          ^%(__prefix_line_sl)sUser .+ from <HOST> not allowed because a group is listed in DenyGroups\s*%(__suff)s$
          ^%(__prefix_line_sl)sUser .+ from <HOST> not allowed because none of user's groups are listed in AllowGroups\s*%(__suff)s$
-         ^%(__prefix_line_ml1)s%(__pam_auth)s\(sshd:auth\):\s+authentication failure;\s*logname=\S*\s*uid=\d*\s*euid=\d*\s*tty=\S*\s*ruser=\S*\s*rhost=<HOST>\s.*%(__suff)s$%(__prefix_line_ml2)sConnection closed
          ^%(__prefix_line_sl)s(error: )?maximum authentication attempts exceeded for .* from <HOST>%(__on_port_opt)s(?: ssh\d*)? \[preauth\]$
          ^%(__prefix_line_ml1)sUser .+ not allowed because account is locked%(__prefix_line_ml2)sReceived disconnect from <HOST>%(__on_port_opt)s:\s*11: .+%(__suff)s$
          ^%(__prefix_line_ml1)sDisconnecting: Too many authentication failures(?: for .+?)?%(__suff)s%(__prefix_line_ml2)sConnection closed by%(__authng_user)s <HOST>%(__suff)s$

--- a/fail2ban/tests/config/filter.d/zzz-sshd-obsolete-multiline.conf
+++ b/fail2ban/tests/config/filter.d/zzz-sshd-obsolete-multiline.conf
@@ -37,7 +37,7 @@ __pam_auth = pam_[a-z]+
 cmnfailre = ^%(__prefix_line_sl)s[aA]uthentication (?:failure|error|failed) for .* from <HOST>( via \S+)?\s*%(__suff)s$
          ^%(__prefix_line_sl)sUser not known to the underlying authentication module for .* from <HOST>\s*%(__suff)s$
          ^%(__prefix_line_sl)sFailed \S+ for invalid user <F-USER>(?P<cond_user>\S+)|(?:(?! from ).)*?</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?(?(cond_user): |(?:(?:(?! from ).)*)$)
-         {NO-RISE-UP}^%(__prefix_line_sl)sFailed (?:<F-NOFAIL>publickey</F-NOFAIL>|\S+) for (?P<cond_inv>invalid user )?<F-USER>(?P<cond_user>\S+)|(?(cond_inv)(?:(?! from ).)*?|[^:]+)</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?(?(cond_user): |(?:(?:(?! from ).)*)$)
+         {^NO-RISE-UP}^%(__prefix_line_sl)sFailed (?:<F-NOFAIL>publickey</F-NOFAIL>|\S+) for (?P<cond_inv>invalid user )?<F-USER>(?P<cond_user>\S+)|(?(cond_inv)(?:(?! from ).)*?|[^:]+)</F-USER> from <HOST>%(__on_port_opt)s(?: ssh\d*)?(?(cond_user): |(?:(?:(?! from ).)*)$)
          ^%(__prefix_line_sl)sROOT LOGIN REFUSED FROM <HOST>
          ^%(__prefix_line_sl)s[iI](?:llegal|nvalid) user .*? from <HOST>%(__suff)s$
          ^%(__prefix_line_sl)sUser .+ from <HOST> not allowed because not listed in AllowUsers\s*%(__suff)s$

--- a/fail2ban/tests/fail2banregextestcase.py
+++ b/fail2ban/tests/fail2banregextestcase.py
@@ -182,10 +182,12 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 	def testDirectRE_1(self):
 		self.assertTrue(_test_exec(
+			"-l", "notice", # suppress debug messages (output of --print-all-matched only)
 			"--datepattern", r"^(?:%a )?%b %d %H:%M:%S(?:\.%f)?(?: %ExY)?",
 			"--print-all-matched",
 			FILENAME_01, RE_00
 		))
+		self.assertLogged('[19] ' + RE_00); # pattern
 		self.assertLogged('Lines: 19 lines, 0 ignored, 16 matched, 3 missed')
 
 		self.assertLogged('Error decoding line');
@@ -237,6 +239,17 @@ class Fail2banRegexTest(LogCaptureTestCase):
 
 		self.assertLogged('141.3.81.106  Sun Aug 14 11:53:59 2005')
 		self.assertLogged('141.3.81.106  Sun Aug 14 11:54:59 2005')
+
+	def testVerboseRegex(self):
+		self.assertTrue(_test_exec(
+			"-d", "^Epoch", "-l", "notice",
+			"--verbose-regex",
+			("1490349000 192.0.2.1 FAIL\n"*5),
+			r"^\s*<ADDR> FAIL\b"
+		))
+		self.assertLogged('Lines: 5 lines, 0 ignored, 5 matched, 0 missed')
+		self.assertLogged(r'[5] ^\s*<ADDR> FAIL\b'); # pattern
+		self.assertLogged('(?P<ip4>', '(?P<ip6>', all=True); # real regex
 
 	def testVerboseFullSshd(self):
 		self.assertTrue(_test_exec(


### PR DESCRIPTION
* regex of multiple `failregex` (and `ignoreregex`) can rise up in filter depending on numer of matched lines,
  (most used expressions go to the begin of list so will be applied first) what can provide better performance by
  match search; two new option allow to switch this behavior for single or any expression:
  - `NO-RISE-UP` or `NoRiseUp` - disable rising up for the regex for which this option is set
  - `NO-REORDER` or `NoReorder` - disable reordering of `failregex` or `ignoreregex` list completely
* `fail2ban-regex` extended:
  - `prefregex`, `failregex` and `ignoreregex` are showing as original pattern now and PCRE expression
    only in verbose mode (and all patterns are reordered by number of matches now);
  - new option `--verbose-regex` or `--VR` which show substituted PCRE expression of `prefregex`,
    matched `failregex` and `ignoreregex` additionally to pattern (without the need to enable more verbose mode)
* `fail2ban-regex` and test suite e. g. sample regexs factory are adjusted to use more common functionality
  of filter module (fewer special tweaks inside the modules);
* performance improvements, simplifying code base and new test cases covering new concerns
* can help to implement some statistic (e. g. part of #2972)
* new regex options feature can be used to implement more regex-related tweaks, for example define a subnet size per regex (like #2992) etc;