### PR TITLE
Update ufw.conf

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,9 @@ ver. 1.0.1-dev-1 (20??/??/??) - development nightly edition
 ### Fixes
 * readline fixed to consider interim new-line character as part of code point in multi-byte logs
   (e. g. unicode encoding like utf-16be, utf-16le);
+* `action.d/ufw.conf`:
+  - fixed handling on IPv6 (using prepend, gh-2331, gh-3018)
+  - application names containing spaces can be used now (gh-656, gh-1532, gh-3018)
 * `filter.d/drupal-auth.conf` more strict regex, extended to match "Login attempt failed from" (gh-2742)
 
 ### New Features and Enhancements
@@ -29,6 +32,9 @@ ver. 1.0.1-dev-1 (20??/??/??) - development nightly edition
 * better recognition of log rotation, better performance by reopen: avoid unnecessary seek to begin of file
   (and hash calculation)
 * file filter reads only complete lines (ended with new-line) now, so waits for end of line (for its completion)
+* `action.d/ufw.conf` (gh-3018):
+  - new option `add` (default `prepend`), can be supplied as `insert 1` for ufw versions before v.0.36 (gh-2331, gh-3018)
+  - new options `kill-mode` and `kill` to drop established connections of intruder (see action for details, gh-3018)
 * `filter.d/nginx-http-auth.conf` - extended with parameter mode, so additionally to `auth` (or `normal`) 
    mode `fallback` (or combined as `aggressive`) can find SSL errors while SSL handshaking, gh-2881
 

--- a/config/action.d/ufw.conf
+++ b/config/action.d/ufw.conf
@@ -13,17 +13,26 @@ actionstop =
 
 actioncheck = 
 
-actionban = [ -n "<application>" ] && app="app <application>"
-            ufw insert <insertpos> <blocktype> from <ip> to <destination> $app
+# ufw does "quickly process packets for which we already have a connection" in before.rules,
+# therefore all related sockets should be closed
+# actionban is using `ss` to do so, this only handles IPv4 and IPv6.
 
-actionunban = [ -n "<application>" ] && app="app <application>"
-              ufw delete <blocktype> from <ip> to <destination> $app
+actionban = if [ -n "<application>" ] && ufw app info "<application>"
+            then
+              ufw prepend <blocktype> from <ip> to <destination> app "<application>" comment "<comment>"
+            else
+              ufw prepend <blocktype> from <ip> to <destination> comment "<comment>"
+            fi
+            ss -K dst [<ip>]
+
+actionunban = if [ -n "<application>" ] && ufw app info "<application>"
+              then
+                ufw delete <blocktype> from <ip> to <destination> app "<application>"
+              else
+                ufw delete <blocktype> from <ip> to <destination>
+              fi
 
 [Init]
-# Option: insertpos
-# Notes.:  The position number in the firewall list to insert the block rule
-insertpos = 1
-
 # Option: blocktype
 # Notes.: reject or deny
 blocktype = reject

--- a/config/action.d/ufw.conf
+++ b/config/action.d/ufw.conf
@@ -23,7 +23,7 @@ actionban = if [ -n "<application>" ] && ufw app info "<application>"
             else
               ufw <add> <blocktype> from <ip> to <destination> comment "<comment>"
             fi
-            ss -K dst [<ip>]
+            <kill>
 
 actionunban = if [ -n "<application>" ] && ufw app info "<application>"
               then
@@ -31,6 +31,21 @@ actionunban = if [ -n "<application>" ] && ufw app info "<application>"
               else
                 ufw delete <blocktype> from <ip> to <destination>
               fi
+
+# Option: kill-mode
+# Notes.: can be set to ss (may be extended later with other modes) to immediately drop all connections from banned IP, default empty (no kill)
+# Example: banaction = ufw[kill-mode=ss]
+kill-mode =
+
+# intern conditional parameter used to provide killing mode after ban:
+_kill_ =
+_kill_ss = ss -K dst "[<ip>]"
+
+# Option: kill
+# Notes.: can be used to specify custom killing feature, by default depending on option kill-mode
+# Examples: banaction = ufw[kill='ss -K "( sport = :http || sport = :https )" dst "[<ip>]"']
+            banaction = ufw[kill='cutter "<ip>"']
+kill = <_kill_<kill-mode>>
 
 [Init]
 # Option: add

--- a/config/action.d/ufw.conf
+++ b/config/action.d/ufw.conf
@@ -19,9 +19,9 @@ actioncheck =
 
 actionban = if [ -n "<application>" ] && ufw app info "<application>"
             then
-              ufw prepend <blocktype> from <ip> to <destination> app "<application>" comment "<comment>"
+              ufw <add> <blocktype> from <ip> to <destination> app "<application>" comment "<comment>"
             else
-              ufw prepend <blocktype> from <ip> to <destination> comment "<comment>"
+              ufw <add> <blocktype> from <ip> to <destination> comment "<comment>"
             fi
             ss -K dst [<ip>]
 
@@ -33,6 +33,10 @@ actionunban = if [ -n "<application>" ] && ufw app info "<application>"
               fi
 
 [Init]
+# Option: add
+# Notes.: can be set to "insert 1" to insert a rule at certain position (here 1):
+add = prepend
+
 # Option: blocktype
 # Notes.: reject or deny
 blocktype = reject


### PR DESCRIPTION
Prerequisites:
* The ss command is available, kernel is compiled with option CONFIG_INET_DIAG_DESTROY.
* Ufw version is => 0.36 (released in 2018)

* Now using "prepend" instead of "insert" to be able to handle IPv6 addresses correctly. The current action will fail for IPv6 addresses.
* Now application names containing a space should handled correctly, solves https://github.com/fail2ban/fail2ban/pull/1532
* Now closing IPv4 and IPv6 connections (if any) from the ip that is being banned. The current action will leave them open.
   Using ss to accomplish this. For this to work the kernel needs to be compiled with the CONFIG_INET_DIAG_DESTROY option.
   My system apparently is compiled that way.

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
  Closes #656, #1532 and #2331
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
