### PR TITLE
ufw.conf, add missing comment option in init section

### DIFF
--- a/config/action.d/ufw.conf
+++ b/config/action.d/ufw.conf
@@ -64,6 +64,10 @@ destination = any
 # Notes.: application from sudo ufw app list
 application = 
 
+# Option: comment
+# Notes.: comment for rule added by fail2ban
+comment = by Fail2Ban after <failures> attempts against <name>
+
 # DEV NOTES:
 # 
 # Author: Guilhem Lettron


### PR DESCRIPTION
In the previous pull request I forgot to include the "comment" option in the init section.
It is already referenced by the banaction.
If you want you can make the default empty instead of the text that is now there.

Before submitting your PR, please review the following checklist:

- [ ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [ ] **KEEP PR small** so it could be easily reviewed.
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
