### PR TITLE
Improve grammar and readability of timestamp warnings

### DIFF
--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -618,6 +618,7 @@ class Filter(JailThread):
 		noDate = False
 		if date:
 			tupleLine = line
+			line = "".join(line)
 			self.__lastTimeText = tupleLine[1]
 			self.__lastDate = date
 		else:
@@ -654,6 +655,8 @@ class Filter(JailThread):
 				if self.__lastDate and self.__lastDate > MyTime.time() - 60:
 					tupleLine = ("", self.__lastTimeText, line)
 					date = self.__lastDate
+				elif self.checkFindTime and self.inOperation:
+					date = MyTime.time()
 		
 		if self.checkFindTime and date is not None:
 			# if in operation (modifications have been really found):

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -664,7 +664,7 @@ class Filter(JailThread):
 				# if weird date - we'd simulate now for timeing issue (too large deviation from now):
 				delta = int(date - MyTime.time())
 				if abs(delta) > 60:
-					delta /= 60
+					delta //= 60
 					# log timing issue as warning once per day:
 					self._logWarnOnce("_next_simByTimeWarn",
 						("Detected a log entry %sm %s the current time in operation mode. "

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -662,9 +662,10 @@ class Filter(JailThread):
 				if (date is None or date < MyTime.time() - 60 or date > MyTime.time() + 60):
 					# log time zone issue as warning once per day:
 					self._logWarnOnce("_next_simByTimeWarn",
-						("Simulate NOW in operation since found time has too large deviation %s ~ %s +/- %s",
-							date, MyTime.time(), 60),
-						("Please check jail has possibly a timezone issue. Line with odd timestamp: %s", 
+						("Found at least one log entry with a timestamp more" +
+						 " than a minute from the current time. This is rarely a problem."),
+						("Please check this jail and associated logs as" +
+						 " there is potentially a timezone or latency problem: %s",
 							line))
 					# simulate now as date:
 					date = MyTime.time()
@@ -674,9 +675,11 @@ class Filter(JailThread):
 				if date is not None and date < MyTime.time() - self.getFindTime():
 					# log time zone issue as warning once per day:
 					self._logWarnOnce("_next_ignByTimeWarn",
-						("Ignore line since time %s < %s - %s",
-							date, MyTime.time(), self.getFindTime()),
-						("Please check jail has possibly a timezone issue. Line with odd timestamp: %s", 
+						("Ignoring all log entries older than %s; these are probably" +
+						 " messages generated while fail2ban was not running.",
+							self.getFindTime()),
+						("Please check this jail and associated logs as" +
+						 " there is potentially a timezone or latency problem: %s",
 							line))
 					# ignore - too old (obsolete) entry:
 					return []

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -659,14 +659,19 @@ class Filter(JailThread):
 			# if in operation (modifications have been really found):
 			if self.inOperation:
 				# if weird date - we'd simulate now for timeing issue (too large deviation from now):
-				if (date is None or date < MyTime.time() - 60 or date > MyTime.time() + 60):
+				delta = date - MyTime.time()
+				if (date is None or abs(delta) > 60):
+					latency = "This could indicate a latency problem."
+					timezone = "This looks like a timezone problem."
 					# log time zone issue as warning once per day:
 					self._logWarnOnce("_next_simByTimeWarn",
-						("Found at least one log entry with a timestamp more" +
-						 " than a minute from the current time. This is rarely a problem."),
-						("Please check this jail and associated logs as" +
-						 " there is potentially a timezone or latency problem: %s",
-							line))
+						("Found a log entry with a timestamp %ss %s the current time. %s",
+						 abs(delta),
+						 "before" if delta <= 0 else "after",
+						 latency if -15*60 <= delta <= 0 else timezone),
+						("Please check this jail and associated logs as there" +
+						 " is potentially a timezone or latency problem: %s",
+						 line))
 					# simulate now as date:
 					date = MyTime.time()
 					self.__lastDate = date

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -662,13 +662,22 @@ class Filter(JailThread):
 				delta = date - MyTime.time()
 				if (date is None or abs(delta) > 60):
 					latency = "This could indicate a latency problem."
+					synchronization = "This could be a clock synchronization" + \
+						" problem; are you sure that NTP is set up?"
 					timezone = "This looks like a timezone problem."
+					msg = ""
+					if -15*60 <= delta <= 0:
+						msg = latency
+					elif 0 < delta <= 15*60:
+						msg = synchronization
+					else:
+						msg = timezone
 					# log time zone issue as warning once per day:
 					self._logWarnOnce("_next_simByTimeWarn",
 						("Found a log entry with a timestamp %ss %s the current time. %s",
 						 abs(delta),
 						 "before" if delta <= 0 else "after",
-						 latency if -15*60 <= delta <= 0 else timezone),
+						 msg),
 						("Please check this jail and associated logs as there" +
 						 " is potentially a timezone or latency problem: %s",
 						 line))

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -457,8 +457,6 @@ class IgnoreIP(LogCaptureTestCase):
 			for i in (1,2,3):
 				self.filter.processLineAndAdd('2019-10-27 02:00:00 fail from 192.0.2.15'); # +3 = 3
 			self.assertLogged(
-				"Simulate NOW in operation since found time has too large deviation",
-				"Please check jail has possibly a timezone issue.",
 				"192.0.2.15:1", "192.0.2.15:2", "192.0.2.15:3",
 				"Total # of detected failures: 3.", wait=True)
 			#

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -444,11 +444,11 @@ class IgnoreIP(LogCaptureTestCase):
 	def testTimeJump_InOperation(self):
 		self._testTimeJump(inOperation=True)
 
-	def testWrongTimeZone(self):
+	def testWrongTimeOrTZ(self):
 		try:
 			self.filter.addFailRegex('fail from <ADDR>$')
 			self.filter.setDatePattern(r'{^LN-BEG}%Y-%m-%d %H:%M:%S(?:\s*%Z)?\s')
-			self.filter.setMaxRetry(5); # don't ban here
+			self.filter.setMaxRetry(50); # don't ban here
 			self.filter.inOperation = True; # real processing (all messages are new)
 			# current time is 1h later than log-entries:
 			MyTime.setTime(1572138000+3600)
@@ -476,36 +476,29 @@ class IgnoreIP(LogCaptureTestCase):
 				"Match without a timestamp:",
 				"192.0.2.17:1", "192.0.2.17:2", "192.0.2.17:3",
 				"Total # of detected failures: 9.", all=True, wait=True)
-		finally:
-			tearDownMyTime()
-
-	def testWrongTimeDelta(self):
-		try:
-			self.filter.addFailRegex('fail from <ADDR>$')
-			self.filter.setDatePattern(r'{^LN-BEG}%Y-%m-%d %H:%M:%S(?:\s*%Z)?\s')
-			self.filter.setMaxRetry(5); # don't ban here
-			self.filter.inOperation = True; # real processing (all messages are new)
-			expectable_messages = ["timezone problem.", "clock synchronization problem;", "latency problem."]
-			cases = [(-90*60, 0),
-				 (-10*60, 1),
-				 (-30, None),
-				 (30, None),
-				 (10*60, 2),
-				 (90*60, 0)]
-			for idx, (delta, expect) in enumerate(cases):
+			#
+			phase = 3
+			for delta, expect in (
+				(-90*60, "timezone"), #90 minutes after
+				(-60*60, "timezone"), #60 minutes after
+				(-10*60, "timezone"), #10 minutes after
+				(-59,    None),       #59 seconds after
+				(59,     None),       #59 seconds before
+				(61,     "latency"),  #>1 minute before
+				(55*60,  "latency"),  #55 minutes before
+				(90*60,  "timezone")  #90 minutes before
+			):
+				phase += 1
 				MyTime.setTime(1572138000+delta)
 				setattr(self.filter, "_next_simByTimeWarn", -1)
-				self.pruneLog('[phase {phase}] log entries offset by {delta}s'.format(phase=idx+1, delta=delta))
-				for i in (1,2,3):
-					self.filter.processLineAndAdd('2019-10-27 02:00:00 fail from 192.0.2.15');
-				for (idx, msg) in enumerate(expectable_messages):
-					if idx == expect:
-						self.assertLogged(expectable_messages[idx])
-					else:
-						self.assertNotLogged(expectable_messages[idx])
-				self.assertLogged(
-					"192.0.2.15:1", "192.0.2.15:2", "192.0.2.15:3",
-					"Total # of detected failures: 3.", wait=True)
+				self.pruneLog('[phase {phase}] log entries offset by {delta}s'.format(phase=phase, delta=delta))
+				self.filter.processLineAndAdd('2019-10-27 02:00:00 fail from 192.0.2.15');
+				self.assertLogged("Found 192.0.2.15", wait=True)
+				if expect:
+					self.assertLogged(("timezone problem", "latency problem")[int(expect == "latency")], all=True)
+					self.assertNotLogged(("timezone problem", "latency problem")[int(expect != "latency")])
+				else:
+					self.assertNotLogged("timezone problem", "latency problem", all=True)
 		finally:
 			tearDownMyTime()
 

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -457,13 +457,18 @@ class IgnoreIP(LogCaptureTestCase):
 			for i in (1,2,3):
 				self.filter.processLineAndAdd('2019-10-27 02:00:00 fail from 192.0.2.15'); # +3 = 3
 			self.assertLogged(
+				"Detected a log entry 60m before the current time in operation mode. This looks like a timezone problem.",
+				"Please check a jail for a timing issue.",
 				"192.0.2.15:1", "192.0.2.15:2", "192.0.2.15:3",
-				"Total # of detected failures: 3.", wait=True)
+				"Total # of detected failures: 3.", all=True, wait=True)
 			#
+			setattr(self.filter, "_next_simByTimeWarn", -1)
 			self.pruneLog("[phase 2] wrong TZ given in log")
 			for i in (1,2,3):
 				self.filter.processLineAndAdd('2019-10-27 04:00:00 GMT fail from 192.0.2.16'); # +3 = 6
 			self.assertLogged(
+				"Detected a log entry 120m after the current time in operation mode. This looks like a timezone problem.",
+				"Please check a jail for a timing issue.",
 				"192.0.2.16:1", "192.0.2.16:2", "192.0.2.16:3",
 				"Total # of detected failures: 6.", all=True, wait=True)
 			self.assertNotLogged("Found a match but no valid date/time found")
@@ -496,7 +501,7 @@ class IgnoreIP(LogCaptureTestCase):
 				self.assertLogged("Found 192.0.2.15", wait=True)
 				if expect:
 					self.assertLogged(("timezone problem", "latency problem")[int(expect == "latency")], all=True)
-					self.assertNotLogged(("timezone problem", "latency problem")[int(expect != "latency")])
+					self.assertNotLogged(("timezone problem", "latency problem")[int(expect != "latency")], all=True)
 				else:
 					self.assertNotLogged("timezone problem", "latency problem", all=True)
 		finally:


### PR DESCRIPTION
These two warnings are terse, use jargon and are not very grammatically correct. This makes them quite difficult to understand without seeking out the author and asking him to explain them. This should be at least a little better.

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
