### PR TITLE
iptables actions: add table and rulenum options

### DIFF
--- a/config/action.d/iptables-allports.conf
+++ b/config/action.d/iptables-allports.conf
@@ -17,23 +17,23 @@ before = iptables-common.conf
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
 # Values:  CMD
 #
-actionstart = <iptables> -N f2b-<name>
-              <iptables> -A f2b-<name> -j <returntype>
-              <iptables> -I <chain> -p <protocol> -j f2b-<name>
+actionstart = <iptables> -t <table> -N f2b-<name>
+              <iptables> -t <table> -A f2b-<name> -j <returntype>
+              <iptables> -t <table> -I <chain> <rulenum> -p <protocol> -j f2b-<name>
 
 # Option:  actionstop
 # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
 # Values:  CMD
 #
-actionstop = <iptables> -D <chain> -p <protocol> -j f2b-<name>
+actionstop = <iptables> -t <table> -D <chain> -p <protocol> -j f2b-<name>
              <actionflush>
-             <iptables> -X f2b-<name>
+             <iptables> -t <table> -X f2b-<name>
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command
 # Values:  CMD
 #
-actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
+actioncheck = <iptables> -t <table> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
@@ -41,7 +41,7 @@ actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
+actionban = <iptables> -t <table> -I f2b-<name> 1 -s <ip> -j <blocktype>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -49,7 +49,7 @@ actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionunban = <iptables> -D f2b-<name> -s <ip> -j <blocktype>
+actionunban = <iptables> -t <table> -D f2b-<name> -s <ip> -j <blocktype>
 
 [Init]
 

--- a/config/action.d/iptables-common.conf
+++ b/config/action.d/iptables-common.conf
@@ -22,16 +22,28 @@ after = iptables-blocktype.local
 # Notes.:  command executed once to flush IPS, by shutdown (resp. by stop of the jail or this action)
 # Values:  CMD
 #
-actionflush = <iptables> -F f2b-<name>
+actionflush = <iptables> -t <table> -F f2b-<name>
 
 
 [Init]
 
+# Option:  table
+# Notes    specifies the iptables table to which the Fail2Ban rules should be
+#          added
+# Values:  [filter | nat | mangle | raw]  Default: filter
+table = filter
+
 # Option:  chain
 # Notes    specifies the iptables chain to which the Fail2Ban rules should be
-#          added
+#          added. Common values are INPUT, PREROUTING
 # Values:  STRING  Default: INPUT
 chain = INPUT
+
+# Option:  rulenum
+# Notes    specifies the iptables rule number at which the Fail2Ban rules
+#          should be inserted
+# Values:  NUM  Default: 1
+rulenum = 1
 
 # Default name of the chain
 #

--- a/config/action.d/iptables-ipset-proto4.conf
+++ b/config/action.d/iptables-ipset-proto4.conf
@@ -28,7 +28,7 @@ before = iptables-common.conf
 # Values:  CMD
 #
 actionstart = ipset --create f2b-<name> iphash
-              <iptables> -I <chain> -p <protocol> -m multiport --dports <port> -m set --match-set f2b-<name> src -j <blocktype>
+              <iptables> -t <table> -I <chain> <rulenum> -p <protocol> -m multiport --dports <port> -m set --match-set f2b-<name> src -j <blocktype>
 
 
 # Option:  actionflush
@@ -41,7 +41,7 @@ actionflush = ipset --flush f2b-<name>
 # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
 # Values:  CMD
 #
-actionstop = <iptables> -D <chain> -p <protocol> -m multiport --dports <port> -m set --match-set f2b-<name> src -j <blocktype>
+actionstop = <iptables> -t <table> -D <chain> -p <protocol> -m multiport --dports <port> -m set --match-set f2b-<name> src -j <blocktype>
              <actionflush>
              ipset --destroy f2b-<name>
 

--- a/config/action.d/iptables-ipset-proto6-allports.conf
+++ b/config/action.d/iptables-ipset-proto6-allports.conf
@@ -27,7 +27,7 @@ before = iptables-common.conf
 # Values:  CMD
 #
 actionstart = ipset create <ipmset> hash:ip timeout <default-ipsettime> <familyopt>
-              <iptables> -I <chain> -m set --match-set <ipmset> src -j <blocktype>
+              <iptables> -t <table> -I <chain> <rulenum> -m set --match-set <ipmset> src -j <blocktype>
 
 # Option:  actionflush
 # Notes.:  command executed once to flush IPS, by shutdown (resp. by stop of the jail or this action)
@@ -39,7 +39,7 @@ actionflush = ipset flush <ipmset>
 # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
 # Values:  CMD
 #
-actionstop = <iptables> -D <chain> -m set --match-set <ipmset> src -j <blocktype>
+actionstop = <iptables> -t <table> -D <chain> -m set --match-set <ipmset> src -j <blocktype>
              <actionflush>
              ipset destroy <ipmset>
 

--- a/config/action.d/iptables-ipset-proto6.conf
+++ b/config/action.d/iptables-ipset-proto6.conf
@@ -27,7 +27,7 @@ before = iptables-common.conf
 # Values:  CMD
 #
 actionstart = ipset create <ipmset> hash:ip timeout <default-ipsettime> <familyopt>
-              <iptables> -I <chain> -p <protocol> -m multiport --dports <port> -m set --match-set <ipmset> src -j <blocktype>
+              <iptables> -t <table> -I <chain> <rulenum> -p <protocol> -m multiport --dports <port> -m set --match-set <ipmset> src -j <blocktype>
 
 # Option:  actionflush
 # Notes.:  command executed once to flush IPS, by shutdown (resp. by stop of the jail or this action)
@@ -39,7 +39,7 @@ actionflush = ipset flush <ipmset>
 # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
 # Values:  CMD
 #
-actionstop = <iptables> -D <chain> -p <protocol> -m multiport --dports <port> -m set --match-set <ipmset> src -j <blocktype>
+actionstop = <iptables> -t <table> -D <chain> -p <protocol> -m multiport --dports <port> -m set --match-set <ipmset> src -j <blocktype>
              <actionflush>
              ipset destroy <ipmset>
 

--- a/config/action.d/iptables-multiport-log.conf
+++ b/config/action.d/iptables-multiport-log.conf
@@ -19,34 +19,34 @@ before = iptables-common.conf
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
 # Values:  CMD
 #
-actionstart = <iptables> -N f2b-<name>
-              <iptables> -A f2b-<name> -j <returntype>
-              <iptables> -I <chain> 1 -p <protocol> -m multiport --dports <port> -j f2b-<name>
-              <iptables> -N f2b-<name>-log
-              <iptables> -I f2b-<name>-log -j LOG --log-prefix "$(expr f2b-<name> : '\(.\{1,23\}\)'):DROP " --log-level warning -m limit --limit 6/m --limit-burst 2
-              <iptables> -A f2b-<name>-log -j <blocktype>
+actionstart = <iptables> -t <table> -N f2b-<name>
+              <iptables> -t <table> -A f2b-<name> -j <returntype>
+              <iptables> -t <table> -I <chain> <rulenum> -p <protocol> -m multiport --dports <port> -j f2b-<name>
+              <iptables> -t <table> -N f2b-<name>-log
+              <iptables> -t <table> -I f2b-<name>-log -j LOG --log-prefix "$(expr f2b-<name> : '\(.\{1,23\}\)'):DROP " --log-level warning -m limit --limit 6/m --limit-burst 2
+              <iptables> -t <table> -A f2b-<name>-log -j <blocktype>
 
 # Option:  actionflush
 # Notes.:  command executed once to flush IPS, by shutdown (resp. by stop of the jail or this action)
 # Values:  CMD
 #
-actionflush = <iptables> -F f2b-<name>
-              <iptables> -F f2b-<name>-log
+actionflush = <iptables> -t <table> -F f2b-<name>
+              <iptables> -t <table> -F f2b-<name>-log
 
 # Option:  actionstop
 # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
 # Values:  CMD
 #
-actionstop = <iptables> -D <chain> -p <protocol> -m multiport --dports <port> -j f2b-<name>
+actionstop = <iptables> -t <table> -D <chain> -p <protocol> -m multiport --dports <port> -j f2b-<name>
              <actionflush>
-             <iptables> -X f2b-<name>
-             <iptables> -X f2b-<name>-log
+             <iptables> -t <table> -X f2b-<name>
+             <iptables> -t <table> -X f2b-<name>-log
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command
 # Values:  CMD
 #
-actioncheck = <iptables> -n -L f2b-<name>-log >/dev/null
+actioncheck = <iptables> -t <table> -n -L f2b-<name>-log >/dev/null
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
@@ -54,7 +54,7 @@ actioncheck = <iptables> -n -L f2b-<name>-log >/dev/null
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = <iptables> -I f2b-<name> 1 -s <ip> -j f2b-<name>-log
+actionban = <iptables> -t <table> -I f2b-<name> 1 -s <ip> -j f2b-<name>-log
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -62,7 +62,7 @@ actionban = <iptables> -I f2b-<name> 1 -s <ip> -j f2b-<name>-log
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionunban = <iptables> -D f2b-<name> -s <ip> -j f2b-<name>-log
+actionunban = <iptables> -t <table> -D f2b-<name> -s <ip> -j f2b-<name>-log
 
 [Init]
 

--- a/config/action.d/iptables-multiport.conf
+++ b/config/action.d/iptables-multiport.conf
@@ -14,23 +14,23 @@ before = iptables-common.conf
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
 # Values:  CMD
 #
-actionstart = <iptables> -N f2b-<name>
-              <iptables> -A f2b-<name> -j <returntype>
-              <iptables> -I <chain> -p <protocol> -m multiport --dports <port> -j f2b-<name>
+actionstart = <iptables> -t <table> -N f2b-<name>
+              <iptables> -t <table> -A f2b-<name> -j <returntype>
+              <iptables> -t <table> -I <chain> <rulenum> -p <protocol> -m multiport --dports <port> -j f2b-<name>
 
 # Option:  actionstop
 # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
 # Values:  CMD
 #
-actionstop = <iptables> -D <chain> -p <protocol> -m multiport --dports <port> -j f2b-<name>
+actionstop = <iptables> -t <table> -D <chain> -p <protocol> -m multiport --dports <port> -j f2b-<name>
              <actionflush>
-             <iptables> -X f2b-<name>
+             <iptables> -t <table> -X f2b-<name>
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command
 # Values:  CMD
 #
-actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
+actioncheck = <iptables> -t <table> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
@@ -38,7 +38,7 @@ actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
+actionban = <iptables> -t <table> -I f2b-<name> 1 -s <ip> -j <blocktype>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -46,7 +46,7 @@ actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionunban = <iptables> -D f2b-<name> -s <ip> -j <blocktype>
+actionunban = <iptables> -t <table> -D f2b-<name> -s <ip> -j <blocktype>
 
 [Init]
 

--- a/config/action.d/iptables-new.conf
+++ b/config/action.d/iptables-new.conf
@@ -16,23 +16,23 @@ before = iptables-common.conf
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
 # Values:  CMD
 #
-actionstart = <iptables> -N f2b-<name>
-              <iptables> -A f2b-<name> -j <returntype>
-              <iptables> -I <chain> -m state --state NEW -p <protocol> --dport <port> -j f2b-<name>
+actionstart = <iptables> -t <table> -N f2b-<name>
+              <iptables> -t <table> -A f2b-<name> -j <returntype>
+              <iptables> -t <table> -I <chain> <rulenum> -m state --state NEW -p <protocol> --dport <port> -j f2b-<name>
 
 # Option:  actionstop
 # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
 # Values:  CMD
 #
-actionstop = <iptables> -D <chain> -m state --state NEW -p <protocol> --dport <port> -j f2b-<name>
+actionstop = <iptables> -t <table> -D <chain> -m state --state NEW -p <protocol> --dport <port> -j f2b-<name>
              <actionflush>
-             <iptables> -X f2b-<name>
+             <iptables> -t <table> -X f2b-<name>
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command
 # Values:  CMD
 #
-actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
+actioncheck = <iptables> -t <table> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
@@ -40,7 +40,7 @@ actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
+actionban = <iptables> -t <table> -I f2b-<name> 1 -s <ip> -j <blocktype>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -48,7 +48,7 @@ actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionunban = <iptables> -D f2b-<name> -s <ip> -j <blocktype>
+actionunban = <iptables> -t <table> -D f2b-<name> -s <ip> -j <blocktype>
 
 [Init]
 

--- a/config/action.d/iptables-xt_recent-echo.conf
+++ b/config/action.d/iptables-xt_recent-echo.conf
@@ -33,7 +33,7 @@ before = iptables-common.conf
 #    own rules. The 3600 second timeout is independent and acts as a
 #    safeguard in case the fail2ban process dies unexpectedly. The
 #    shorter of the two timeouts actually matters.
-actionstart = if [ `id -u` -eq 0 ];then <iptables> -I <chain> -m recent --update --seconds 3600 --name <iptname> -j <blocktype>;fi
+actionstart = if [ `id -u` -eq 0 ];then <iptables> -t <table> -I <chain> <rulenum> -m recent --update --seconds 3600 --name <iptname> -j <blocktype>;fi
 
 # Option:  actionflush
 #
@@ -46,7 +46,7 @@ actionflush =
 # Values:  CMD
 #
 actionstop = echo / > /proc/net/xt_recent/<iptname>
-             if [ `id -u` -eq 0 ];then <iptables> -D <chain> -m recent --update --seconds 3600 --name <iptname> -j <blocktype>;fi
+             if [ `id -u` -eq 0 ];then <iptables> -t <table> -D <chain> -m recent --update --seconds 3600 --name <iptname> -j <blocktype>;fi
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command

--- a/config/action.d/iptables.conf
+++ b/config/action.d/iptables.conf
@@ -14,23 +14,23 @@ before = iptables-common.conf
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
 # Values:  CMD
 #
-actionstart = <iptables> -N f2b-<name>
-              <iptables> -A f2b-<name> -j <returntype>
-              <iptables> -I <chain> -p <protocol> --dport <port> -j f2b-<name>
+actionstart = <iptables> -t <table> -N f2b-<name>
+              <iptables> -t <table> -A f2b-<name> -j <returntype>
+              <iptables> -t <table> -I <chain> <rulenum> -p <protocol> --dport <port> -j f2b-<name>
 
 # Option:  actionstop
 # Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
 # Values:  CMD
 #
-actionstop = <iptables> -D <chain> -p <protocol> --dport <port> -j f2b-<name>
+actionstop = <iptables> -t <table> -D <chain> -p <protocol> --dport <port> -j f2b-<name>
              <actionflush>
-             <iptables> -X f2b-<name>
+             <iptables> -t <table> -X f2b-<name>
 
 # Option:  actioncheck
 # Notes.:  command executed once before each actionban command
 # Values:  CMD
 #
-actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
+actioncheck = <iptables> -t <table> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
 
 # Option:  actionban
 # Notes.:  command executed when banning an IP. Take care that the
@@ -38,7 +38,7 @@ actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
+actionban = <iptables> -t <table> -I f2b-<name> 1 -s <ip> -j <blocktype>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
@@ -46,7 +46,7 @@ actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
 # Tags:    See jail.conf(5) man page
 # Values:  CMD
 #
-actionunban = <iptables> -D f2b-<name> -s <ip> -j <blocktype>
+actionunban = <iptables> -t <table> -D f2b-<name> -s <ip> -j <blocktype>
 
 [Init]
 


### PR DESCRIPTION
- add table option (defaults to "filter") to be able inserting Fail2Ban rules e.g. to the raw table for better performance reasons
- add comment with common values of the chain option (INPUT, PREROUTING)
- add rulenum option (defaults to 1) to use with iptables insert for cases where user wants to prepend Fail2Ban rules with own iptables rules (e.g. hardcoded allowlist rules maintained outside of Fail2Ban)
Default behavior of the iptables* actions remains unchanged - Fail2Ban rules should be added at the head of the INPUT chain of the filter table.