### PR TITLE
Added filter and sample log file for qpsmtpd

### DIFF
--- a/config/filter.d/qpsmtpd.conf
+++ b/config/filter.d/qpsmtpd.conf
@@ -1,0 +1,11 @@
+
+[Definition]
+
+failregex = ^.*535 LOGIN authentication failed for .* from <HOST>$
+ignoreregex =
+
+datepattern = ^%%a %%b %%d %%H:%%M:%%S %%Y
+
+# DEV NOTES:
+#
+# Author: Tim Lavoie

--- a/fail2ban/tests/files/logs/qpsmtpd
+++ b/fail2ban/tests/files/logs/qpsmtpd
@@ -1,0 +1,4 @@
+Thu Aug 19 23:37:09 2021 host.domain.example.com[11793]: 535 LOGIN authentication failed for marta from 2.56.59.87
+Thu Aug 19 23:40:19 2021 host.domain.example.com[11798]: 535 LOGIN authentication failed for diana from 45.144.225.204
+Thu Aug 19 23:41:24 2021 host.domain.example.com[11799]: 535 LOGIN authentication failed for irene from 45.144.225.206
+Thu Aug 19 23:43:45 2021 host.domain.example.com[11843]: 535 LOGIN authentication failed for reality from 37.0.11.124


### PR DESCRIPTION
I've just had a tiny change accepted into qpsmtpd master, to now include an IP address in the log, starting with https://github.com/smtpd/qpsmtpd/pull/301.

The included filter works in 0.10.2-2.1 in Debian Buster, but of course that version of qpsmtpd is not yet in a release.



Before submitting your PR, please review the following checklist:

- [ Y] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ N] **CONSIDER adding a unit test** if your PR resolves an issue
- [ N] **LIST ISSUES** this PR resolves
- [ Y] **MAKE SURE** this PR doesn't break existing tests
- [ Y] **KEEP PR small** so it could be easily reviewed.
- [ Y] **AVOID** making unnecessary stylistic changes in unrelated code
- [ Y] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
