### PR TITLE
Update haproxy-http-auth.conf

### DIFF
--- a/config/filter.d/haproxy-http-auth.conf
+++ b/config/filter.d/haproxy-http-auth.conf
@@ -7,7 +7,7 @@
 # In other words, even successful logins will have at least 1 fail regex match.
 # Please keep this in mind when setting findtime and maxretry for jails.
 #
-# Author: Jordan Moeser
+# Author: Jordan Moeser, Giuseppe Scarlato
 #
 
 [INCLUDES]
@@ -28,7 +28,7 @@ _daemon = haproxy
 #          (?:::f{4,6}:)?(?P<host>[\w\-.^_]+)
 # Values:  TEXT
 #
-failregex = ^%(__prefix_line)s<HOST>(?::\d+)?\s+.*<NOSRV> -1/-1/-1/-1/\+*\d* 401
+failregex = ^%(__prefix_line)s<HOST>(?::\d+)?\s+.*<NOSRV> (?:\d+|-1)/-1/-1/-1/\+?\d+ 401
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.

--- a/fail2ban/tests/files/logs/haproxy-http-auth
+++ b/fail2ban/tests/files/logs/haproxy-http-auth
@@ -6,3 +6,13 @@ Nov 14 22:45:11 test haproxy[760]: 192.168.33.1:58430 [14/Nov/2015:22:45:11.608]
 Nov 14 22:45:11 test haproxy[760]: 2001:db8::1234:58430 [14/Nov/2015:22:45:11.608] main main/<NOSRV> -1/-1/-1/-1/0 401 248 - - PR-- 0/0/0/0/0 0/0 "GET / HTTP/1.1"
 # failJSON: { "time": "2004-11-14T22:45:11", "match": true , "host": "192.168.33.1" }
 Nov 14 22:45:11 test haproxy[760]: ::ffff:192.168.33.1:58430 [14/Nov/2015:22:45:11.608] main main/<NOSRV> -1/-1/-1/-1/0 401 248 - - PR-- 0/0/0/0/0 0/0 "GET / HTTP/1.1"
+# failJSON: { "time": "2004-10-11T15:02:29", "match": true , "host": "192.168.1.54" }
+Oct 11 15:02:29 localhost haproxy[838]: 192.168.1.54:48556 [11/Oct/2021:15:02:29.601] public~ public/<NOSRV> 0/-1/-1/-1/0 401 256 - - LR-- 2/2/0/0/0 0/0 "GET / HTTP/1.1"
+# failJSON: { "time": "2004-10-11T15:02:29", "match": true , "host": "192.168.1.54" }
+Oct 11 15:02:29 localhost haproxy[838]: 192.168.1.54:48556 [11/Oct/2021:15:02:29.601] public~ public/<NOSRV> 154/-1/-1/-1/+154 401 256 - - LR-- 2/2/0/0/0 0/0 "GET / HTTP/1.1"
+# failJSON: { "time": "2004-10-11T15:02:29", "match": false , "host": "192.168.1.54" }
+Oct 11 15:02:29 localhost haproxy[838]: 192.168.1.54:48556 [11/Oct/2021:15:02:29.601] public~ public/<NOSRV> 154/-1/-1/-1/++154 401 256 - - LR-- 2/2/0/0/0 0/0 "GET / HTTP/1.1"
+# failJSON: { "time": "2004-10-11T15:02:29", "match": false , "host": "192.168.1.54" }
+Oct 11 15:02:29 localhost haproxy[838]: 192.168.1.54:48556 [11/Oct/2021:15:02:29.601] public~ public/<NOSRV> 154/-1/-1/-1/+ 401 256 - - LR-- 2/2/0/0/0 0/0 "GET / HTTP/1.1"
+# failJSON: { "time": "2004-10-11T15:02:29", "match": false , "host": "192.168.1.54" }
+Oct 11 15:02:29 localhost haproxy[838]: 192.168.1.54:48556 [11/Oct/2021:15:02:29.601] public~ public/<NOSRV> 401/-1/-1/-1/401 302 256 - - LR-- 2/2/0/0/0 0/0 "GET / HTTP/1.1"


### PR DESCRIPTION
I updated the `failregex` in haproxy-http-auth.conf because it didn't match this log:
`Oct 11 15:02:29 localhost haproxy[838]: 192.168.1.54:48556 [11/Oct/2021:15:02:29.601] public~ public/<NOSRV> 0/-1/-1/-1/0 401 256 - - LR-- 2/2/0/0/0 0/0 "GET / HTTP/1.1"` .
The log that I just reported shows a valid 401 response from an haproxy server and so should match the `failregex`.

To fix this issue i checked the docs for haproxy at section 8.2.3 (http://cbonte.github.io/haproxy-dconv/2.5/configuration.html#8.2.3). In this section of the docs is specified the http log format for haproxy as follow:
```
  Field   Format                                Extract from the example above
      1   process_name '[' pid ']:'                            haproxy[14389]:
      2   client_ip ':' client_port                             10.0.1.2:33317
      3   '[' request_date ']'                      [06/Feb/2009:12:14:14.655]
      4   frontend_name                                                http-in
      5   backend_name '/' server_name                             static/srv1
      6   TR '/' Tw '/' Tc '/' Tr '/' Ta*                       10/0/30/69/109
      7   status_code                                                      200
      8   bytes_read*                                                     2750
      9   captured_request_cookie                                            -
     10   captured_response_cookie                                           -
     11   termination_state                                               ----
     12   actconn '/' feconn '/' beconn '/' srv_conn '/' retries*    1/1/1/1/0
     13   srv_queue '/' backend_queue                                      0/0
     14   '{' captured_request_headers* '}'                   {haproxy.1wt.eu}
     15   '{' captured_response_headers* '}'                                {}
     16   '"' http_request '"'                      "GET /index.html HTTP/1.1"
```
where:
```
"TR" is the total time in milliseconds spent waiting for a full HTTP
    request from the client (not counting body) after the first byte was
    received. It can be "-1" if the connection was aborted before a complete
    request could be received or a bad request was received.
```
```
"Ta" is the time the request remained active in HAProxy, which is the total
    time in milliseconds elapsed between the first byte of the request was
    received and the last byte of response was sent. It covers all possible
    processing except the handshake (see Th) and idle time (see Ti). There is
    one exception, if "option logasap" was specified, then the time counting
    stops at the moment the log is emitted. In this case, a '+' sign is
    prepended before the value, indicating that the final one will be larger.
```
.

So the problem causing my issue is that the current `failregex` accepts only `-1` as a value for TR but TR could also be a positive integer as you can se in the log that i reported earlier where TR is `0`. Another problem with the current `failregex` is that it accepts as Ta strings such as "+++", "+" or "++123" that are obviously wrong.

In the proposed pull request I have updated the `failregex` to fix the issues that i just showed.

