### PR TITLE
Display last instead of first 1000 log messages

### DIFF
--- a/config/action.d/helpers-common.conf
+++ b/config/action.d/helpers-common.conf
@@ -14,4 +14,4 @@ _bypass_if_restored = if [ '<restored>' = '1' ]; then exit 0; fi;
 [Init]
 greplimit = tail -n <grepmax>
 grepmax = 1000
-grepopts = -m <grepmax>
+grepopts = 


### PR DESCRIPTION
With the previous configuration, the expanded default "_grep_logs" command looked as follows:
`logpath="<logpath>"; grep -m 1000 -wF "<ip>" $logpath | tail -n 1000`

As a consequence, the first 1000 matching lines of "<logpath>" were grepped:
`grep -m 1000 -wF "<ip>" $logpath`

And then, the last 1000 lines of the grepped result were kept:
`tail -n 1000`

But since the grepped result only contained the first 1000 matching lines, those are eventually returned. This means that the first 1000 lines are returned, instead of the last 1000 lines.

As a correction, I propose to only keep the last 1000 lines of the result with tail and not filter "-m 1000" with grep:
`logpath="<logpath>"; grep -wF "<ip>" $logpath | tail -n 1000`