### PR TITLE
Newline after plugin output

### DIFF
--- a/files/nagios/check_fail2ban
+++ b/files/nagios/check_fail2ban
@@ -228,6 +228,7 @@ $plugstate = "WARNING" if (($how_many_banned >= $warning) && ($how_many_banned <
 
 $return_print = $display." - ".$plugstate." - ".$return_print;
 $return_print .= " | $perf_print" if ($perfdata_value);
+$return_print .= "\n";
 
 print $return_print;
 exit $ERRORS{"$plugstate"};


### PR DESCRIPTION
This PR simply adds a newline at the end of the nagios plugin.

Before PR:

```
nagios@mail01:~$ /usr/lib/nagios/plugins/check_fail2ban.pl -p
CHECK FAIL2BAN ACTIVITY - CRITICAL - 2 detected jails with 7 current banned IP(s) | postfix-sasl.currentBannedIP=7 sshd.currentBannedIP=0 nagios@mail01:~$
```

After this PR:

```
nagios@mail01:~$ /usr/lib/nagios/plugins/check_fail2ban.pl -p
CHECK FAIL2BAN ACTIVITY - CRITICAL - 2 detected jails with 7 current banned IP(s) | postfix-sasl.currentBannedIP=7 sshd.currentBannedIP=0
```