### PR TITLE
nftables.conf - add support for cidr notation

### DIFF
--- a/config/action.d/nftables.conf
+++ b/config/action.d/nftables.conf
@@ -55,7 +55,7 @@ _nft_for_proto-multiport-done = done
 _nft_list = <nftables> -a list chain <table_family> <table> <chain>
 _nft_get_handle_id = grep -oP '@<addr_set>\s+.*\s+\Khandle\s+(\d+)$'
 
-_nft_add_set = <nftables> add set <table_family> <table> <addr_set> \{ type <addr_type>\; flags interval\; \}
+_nft_add_set = <nftables> add set <table_family> <table> <addr_set> \{ type <addr_type>\;<addr_options> \}
               <_nft_for_proto-<type>-iter>
               <nftables> add rule <table_family> <table> <chain> %(rule_stat)s
               <_nft_for_proto-<type>-done>
@@ -196,6 +196,11 @@ addr_set = addr-set-<name>
 # Notes.: The family of the banned addresses
 # Values: [ ip | ip6 ]
 addr_family = ip
+
+# Option: addr_options
+# Notes: Additional options for the addr-set, by default allows to store CIDR or address ranges.
+#        Can be set to empty value to create simple addresses set.
+addr_options = <sp>flags interval\;
 
 [Init?family=inet6]
 addr_family = ip6

--- a/config/action.d/nftables.conf
+++ b/config/action.d/nftables.conf
@@ -55,7 +55,7 @@ _nft_for_proto-multiport-done = done
 _nft_list = <nftables> -a list chain <table_family> <table> <chain>
 _nft_get_handle_id = grep -oP '@<addr_set>\s+.*\s+\Khandle\s+(\d+)$'
 
-_nft_add_set = <nftables> add set <table_family> <table> <addr_set> \{ type <addr_type>\; \}
+_nft_add_set = <nftables> add set <table_family> <table> <addr_set> \{ type <addr_type>\; flags interval\; \}
               <_nft_for_proto-<type>-iter>
               <nftables> add rule <table_family> <table> <chain> %(rule_stat)s
               <_nft_for_proto-<type>-done>

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -1360,11 +1360,11 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					r"`done`",
 				),
 				'ip4-start': (
-					r"`nft add set inet f2b-table addr-set-j-w-nft-mp \{ type ipv4_addr\; \}`",
+					r"`nft add set inet f2b-table addr-set-j-w-nft-mp \{ type ipv4_addr\; flags interval\; \}`",
 					r"`nft add rule inet f2b-table f2b-chain $proto dport \{ $(echo 'http,https' | sed s/:/-/g) \} ip saddr @addr-set-j-w-nft-mp reject`",
 				), 
 				'ip6-start': (
-					r"`nft add set inet f2b-table addr6-set-j-w-nft-mp \{ type ipv6_addr\; \}`",
+					r"`nft add set inet f2b-table addr6-set-j-w-nft-mp \{ type ipv6_addr\; flags interval\; \}`",
 					r"`nft add rule inet f2b-table f2b-chain $proto dport \{ $(echo 'http,https' | sed s/:/-/g) \} ip6 saddr @addr6-set-j-w-nft-mp reject`",
 				),
 				'flush': (
@@ -1406,11 +1406,11 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					r"`nft -- add chain inet f2b-table f2b-chain \{ type filter hook input priority -1 \; \}`",
 				),
 				'ip4-start': (
-					r"`nft add set inet f2b-table addr-set-j-w-nft-ap \{ type ipv4_addr\; \}`",
+					r"`nft add set inet f2b-table addr-set-j-w-nft-ap \{ type ipv4_addr\; flags interval\; \}`",
 					r"`nft add rule inet f2b-table f2b-chain meta l4proto \{ tcp,udp \} ip saddr @addr-set-j-w-nft-ap reject`",
 				), 
 				'ip6-start': (
-					r"`nft add set inet f2b-table addr6-set-j-w-nft-ap \{ type ipv6_addr\; \}`",
+					r"`nft add set inet f2b-table addr6-set-j-w-nft-ap \{ type ipv6_addr\; flags interval\; \}`",
 					r"`nft add rule inet f2b-table f2b-chain meta l4proto \{ tcp,udp \} ip6 saddr @addr6-set-j-w-nft-ap reject`",
 				),
 				'flush': (


### PR DESCRIPTION
Currently when trying to add an address like: 141.98.11.0/24 it fails with:

```
fail2ban.utils          [720]: ERROR   7fe8c36f6630 -- exec: nft add element inet f2b-table addr-set-custom \{ 141.98.11.0/24 \}
fail2ban.utils          [720]: ERROR   7fe8c36f6630 -- stderr: "Error: You must add 'flags interval' to your set declaration if you want to add prefix elements"
```

After adding 'flags interval' one can ban ranges now as expected.

Before submitting your PR, please review the following checklist:

- [ ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [ ] **KEEP PR small** so it could be easily reviewed.
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
