### PR TITLE
Use variables for log paths

### DIFF
--- a/config/jail.conf
+++ b/config/jail.conf
@@ -367,7 +367,7 @@ maxretry = 1
 
 filter = openhab
 banaction = %(banaction_allports)s
-logpath = /opt/openhab/logs/request.log
+logpath = %(openhab_request_log)s
 
 
 # To use more aggressive http-auth modes set filter parameter "mode" in jail.local:
@@ -434,19 +434,19 @@ logpath  = %(roundcube_errors_log)s
 [openwebmail]
 
 port     = http,https
-logpath  = /var/log/openwebmail.log
+logpath  = %(logs_path)s/openwebmail.log
 
 
 [horde]
 
 port     = http,https
-logpath  = /var/log/horde/horde.log
+logpath  = %(logs_path)s/horde/horde.log
 
 
 [groupoffice]
 
 port     = http,https
-logpath  = /home/groupoffice/log/info.log
+logpath  = %(groupoffice_log)s
 
 
 [sogo-auth]
@@ -454,12 +454,12 @@ logpath  = /home/groupoffice/log/info.log
 # without proxy this would be:
 # port    = 20000
 port     = http,https
-logpath  = /var/log/sogo/sogo.log
+logpath  = %(logs_path)s/sogo/sogo.log
 
 
 [tine20]
 
-logpath  = /var/log/tine20/tine20.log
+logpath  = %(logs_path)s/tine20/tine20.log
 port     = http,https
 
 
@@ -477,14 +477,14 @@ backend  = %(syslog_backend)s
 [guacamole]
 
 port     = http,https
-logpath  = /var/log/tomcat*/catalina.out
-#logpath  = /var/log/guacamole.log
+logpath  = %(logs_path)s/tomcat*/catalina.out
+#logpath  = %(logs_path)s/guacamole.log
 
 [monit]
 #Ban clients brute-forcing the monit gui login
 port = 2812
-logpath  = /var/log/monit
-           /var/log/monit.log
+logpath  = %(logs_path)s/monit
+           %(logs_path)s/monit.log
 
 
 [webmin-auth]
@@ -509,13 +509,13 @@ backend  = %(syslog_backend)s
 [squid]
 
 port     =  80,443,3128,8080
-logpath = /var/log/squid/access.log
+logpath = %(logs_path)s/squid/access.log
 
 
 [3proxy]
 
 port    = 3128
-logpath = /var/log/3proxy.log
+logpath = %(logs_path)s/3proxy.log
 
 
 #
@@ -568,7 +568,7 @@ logpath  = %(vsftpd_log)s
 [assp]
 
 port     = smtp,465,submission
-logpath  = /root/path/to/assp/logs/maillog.txt
+logpath  = %(assp_mail_log)s
 
 
 [courier-smtp]
@@ -616,7 +616,7 @@ backend  = %(syslog_backend)s
 
 filter  = qmail
 port    = smtp,465,submission
-logpath = /service/qmail/log/main/current
+logpath = %(qmail_log)s
 
 
 # dovecot defaults to logging to the mail syslog facility
@@ -657,7 +657,7 @@ logpath = %(exim_main_log)s
 [kerio]
 
 port    = imap,smtp,imaps,465
-logpath = /opt/kerio/mailserver/store/logs/security.log
+logpath = %(kerio_security_log)s
 
 
 #
@@ -693,7 +693,7 @@ backend = %(syslog_backend)s
 [squirrelmail]
 
 port = smtp,465,submission,imap,imap2,imaps,pop3,pop3s,http,https,socks
-logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
+logpath = %(squirrelmail_access_log)s
 
 
 [cyrus-imap]
@@ -731,7 +731,7 @@ backend = %(syslog_backend)s
 # filter   = named-refused
 # port     = domain,953
 # protocol = udp
-# logpath  = /var/log/named/security.log
+# logpath  = %(logs_path)s/named/security.log
 
 # IMPORTANT: see filter.d/named-refused for instructions to enable logging
 # This jail blocks TCP traffic for DNS requests.
@@ -739,7 +739,7 @@ backend = %(syslog_backend)s
 [named-refused]
 
 port     = domain,953
-logpath  = /var/log/named/security.log
+logpath  = %(logs_path)s/named/security.log
 
 
 [nsd]
@@ -747,7 +747,7 @@ logpath  = /var/log/named/security.log
 port     = 53
 action_  = %(default/action_)s[name=%(__name__)s-tcp, protocol="tcp"]
            %(default/action_)s[name=%(__name__)s-udp, protocol="udp"]
-logpath = /var/log/nsd.log
+logpath = %(logs_path)s/nsd.log
 
 
 #
@@ -759,7 +759,7 @@ logpath = /var/log/nsd.log
 port     = 5060,5061
 action_  = %(default/action_)s[name=%(__name__)s-tcp, protocol="tcp"]
            %(default/action_)s[name=%(__name__)s-udp, protocol="udp"]
-logpath  = /var/log/asterisk/messages
+logpath  = %(logs_path)s/asterisk/messages
 maxretry = 10
 
 
@@ -768,7 +768,7 @@ maxretry = 10
 port     = 5060,5061
 action_  = %(default/action_)s[name=%(__name__)s-tcp, protocol="tcp"]
            %(default/action_)s[name=%(__name__)s-udp, protocol="udp"]
-logpath  = /var/log/freeswitch.log
+logpath  = %(logs_path)s/freeswitch.log
 maxretry = 10
 
 
@@ -776,7 +776,7 @@ maxretry = 10
 [znc-adminlog]
 
 port     = 6667
-logpath  = /var/lib/znc/moddata/adminlog/znc.log
+logpath  = %(znc_log)s
 
 
 # To log wrong MySQL access attempts add to /etc/my.cnf in [mysqld] or
@@ -789,7 +789,7 @@ logpath  = /var/lib/znc/moddata/adminlog/znc.log
 #
 # for own logfile
 # [mysqld]
-# log-error=/var/log/mysqld.log
+# log-error=%(logs_path)s/mysqld.log
 [mysqld-auth]
 
 port     = 3306
@@ -800,7 +800,7 @@ backend  = %(mysql_backend)s
 [mssql-auth]
 # Default configuration for Microsoft SQL Server for Linux
 # See the 'mssql-conf' manpage how to change logpath or port
-logpath = /var/opt/mssql/log/errorlog
+logpath = %(mssql_error_log)s
 port = 1433
 filter = mssql-auth
 
@@ -809,7 +809,7 @@ filter = mssql-auth
 [mongodb-auth]
 # change port when running with "--shardsvr" or "--configsvr" runtime operation
 port     = 27017
-logpath  = /var/log/mongodb/mongodb.log
+logpath  = %(logs_path)s/mongodb/mongodb.log
 
 
 # Jail for more extended banning of persistent abusers
@@ -821,7 +821,7 @@ logpath  = /var/log/mongodb/mongodb.log
 #    to maintain entries for failed logins for sufficient amount of time
 [recidive]
 
-logpath  = /var/log/fail2ban.log
+logpath  = %(logs_path)s/fail2ban.log
 banaction = %(banaction_allports)s
 bantime  = 1w
 findtime = 1d
@@ -848,18 +848,18 @@ maxretry  = 2
 # stunnel - need to set port for this
 [stunnel]
 
-logpath = /var/log/stunnel4/stunnel.log
+logpath = %(logs_path)s/stunnel4/stunnel.log
 
 
 [ejabberd-auth]
 
 port    = 5222
-logpath = /var/log/ejabberd/ejabberd.log
+logpath = %(logs_path)s/ejabberd/ejabberd.log
 
 
 [counter-strike]
 
-logpath = /opt/cstrike/logs/L[0-9]*.log
+logpath = %(counter_strike_log)s
 tcpport = 27030,27031,27032,27033,27034,27035,27036,27037,27038,27039
 udpport = 1200,27000,27001,27002,27003,27004,27005,27006,27007,27008,27009,27010,27011,27012,27013,27014,27015
 action_  = %(default/action_)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp"]
@@ -868,23 +868,23 @@ action_  = %(default/action_)s[name=%(__name__)s-tcp, port="%(tcpport)s", protoc
 [softethervpn]
 port     = 500,4500
 protocol = udp
-logpath  = /usr/local/vpnserver/security_log/*/sec.log
+logpath  = %(softethervpn_sec_log)s
 
 [gitlab]
 port    = http,https
-logpath = /var/log/gitlab/gitlab-rails/application.log
+logpath = %(logs_path)s/gitlab/gitlab-rails/application.log
 
 [grafana]
 port    = http,https
-logpath = /var/log/grafana/grafana.log
+logpath = %(logs_path)s/grafana/grafana.log
 
 [bitwarden]
 port    = http,https
-logpath = /home/*/bwdata/logs/identity/Identity/log.txt
+logpath = %(bitwarden_log)s
 
 [centreon]
 port    = http,https
-logpath = /var/log/centreon/login.log
+logpath = %(logs_path)s/centreon/login.log
 
 # consider low maxretry and a long bantime
 # nobody except your own Nagios server should ever probe nrpe
@@ -897,15 +897,15 @@ maxretry = 1
 
 [oracleims]
 # see "oracleims" filter file for configuration requirement for Oracle IMS v6 and above
-logpath = /opt/sun/comms/messaging64/log/mail.log_current
+logpath = %(oracleims_log)s
 banaction = %(banaction_allports)s
 
 [directadmin]
-logpath = /var/log/directadmin/login.log
+logpath = %(logs_path)s/directadmin/login.log
 port = 2222
 
 [portsentry]
-logpath  = /var/lib/portsentry/portsentry.history
+logpath  = %(portsentry_log)s
 maxretry = 1
 
 [pass2allow-ftp]
@@ -930,12 +930,12 @@ findtime     = 1
 port     = 64738
 action_  = %(default/action_)s[name=%(__name__)s-tcp, protocol="tcp"]
            %(default/action_)s[name=%(__name__)s-udp, protocol="udp"]
-logpath  = /var/log/mumble-server/mumble-server.log
+logpath  = %(logs_path)s/mumble-server/mumble-server.log
 
 
 [screensharingd]
 # For Mac OS Screen Sharing Service (VNC)
-logpath  = /var/log/system.log
+logpath  = %(logs_path)s/system.log
 logencoding = utf-8
 
 [haproxy-http-auth]
@@ -943,15 +943,15 @@ logencoding = utf-8
 # logs to a syslog server which would then write them to disk.
 # See "haproxy-http-auth" filter for a brief cautionary note when setting
 # maxretry and findtime.
-logpath  = /var/log/haproxy.log
+logpath  = %(logs_path)s/haproxy.log
 
 [slapd]
 port    = ldap,ldaps
-logpath = /var/log/slapd.log
+logpath = %(logs_path)s/slapd.log
 
 [domino-smtp]
 port    = smtp,ssmtp
-logpath = /home/domino01/data/IBM_TECHNICAL_SUPPORT/console.log
+logpath = %(domino_smtp_log)s
 
 [phpmyadmin-syslog]
 port    = http,https
@@ -969,7 +969,7 @@ logpath = %(apache_error_log)s
 # to use 'traefik-auth' filter you have to configure your Traefik instance,
 # see `filter.d/traefik-auth.conf` for details and service example.
 port    = http,https
-logpath = /var/log/traefik/access.log
+logpath = %(logs_path)s/traefik/access.log
 
 [scanlogd]
 logpath = %(syslog_local0)s
@@ -977,4 +977,4 @@ banaction = %(banaction_allports)s
 
 [monitorix]
 port	= 8080
-logpath = /var/log/monitorix-httpd
+logpath = %(logs_path)s/monitorix-httpd

--- a/config/paths-arch.conf
+++ b/config/paths-arch.conf
@@ -9,16 +9,16 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
-apache_error_log = /var/log/httpd/*error_log
+apache_error_log = %(logs_path)s/httpd/*error_log
 
-apache_access_log = /var/log/httpd/*access_log
+apache_access_log = %(logs_path)s/httpd/*access_log
 
-exim_main_log = /var/log/exim/main.log
+exim_main_log = %(logs_path)s/exim/main.log
 
-mysql_log = /var/log/mariadb/mariadb.log
-            /var/log/mysqld.log
+mysql_log = %(logs_path)s/mariadb/mariadb.log
+            %(logs_path)s/mysqld.log
 
-roundcube_errors_log = /var/log/roundcubemail/errors
+roundcube_errors_log = %(logs_path)s/roundcubemail/errors
 
 # These services will log to the journal via syslog, so use the journal by
 # default.

--- a/config/paths-common.conf
+++ b/config/paths-common.conf
@@ -16,9 +16,12 @@ default_backend = %(default/backend)s
 #
 # Note systemd-backend does not need the logpath at all.
 #
-syslog_local0 = /var/log/messages
+var_log_path = /var/log
+logs_path = %(var_log_path)s
 
-syslog_authpriv = /var/log/auth.log
+syslog_local0 = %(logs_path)s/messages
+
+syslog_authpriv = %(logs_path)s/auth.log
 syslog_daemon  = %(syslog_local0)s
 syslog_ftp = %(syslog_local0)s
 syslog_mail =
@@ -36,21 +39,21 @@ sshd_backend = %(default_backend)s
 dropbear_log = %(syslog_authpriv)s
 dropbear_backend = %(default_backend)s
 
-apache_error_log = /var/log/apache2/*error.log
+apache_error_log = %(logs_path)s/apache2/*error.log
 
-apache_access_log = /var/log/apache2/*access.log
+apache_access_log = %(logs_path)s/apache2/*access.log
 
 # from /etc/audit/auditd.conf
-auditd_log = /var/log/audit/audit.log
+auditd_log = %(logs_path)s/audit/audit.log
 
-exim_main_log = /var/log/exim/mainlog
+exim_main_log = %(logs_path)s/exim/mainlog
 
-nginx_error_log = /var/log/nginx/*error.log
+nginx_error_log = %(logs_path)s/nginx/*error.log
 
-nginx_access_log = /var/log/nginx/*access.log
+nginx_access_log = %(logs_path)s/nginx/*access.log
 
 
-lighttpd_error_log = /var/log/lighttpd/error.log
+lighttpd_error_log = %(logs_path)s/lighttpd/error.log
 
 # http://www.hardened-php.net/suhosin/configuration.html#suhosin.log.syslog.facility
 # syslog_user is the default. Lighttpd also hooks errors into its log.
@@ -75,7 +78,7 @@ wuftpd_backend = %(default_backend)s
 # syslog_enable defaults to no. so it defaults to vsftpd_log_file setting of /var/log/vsftpd.log
 # No distro seems to set it to syslog by default
 # If syslog set it defaults to ftp facility if exists at compile time otherwise falls back to daemonlog.
-vsftpd_log = /var/log/vsftpd.log
+vsftpd_log = %(logs_path)s/vsftpd.log
 
 # Technically syslog_facility in main.cf can overwrite but no-one sane does this.
 postfix_log = %(syslog_mail_warn)s
@@ -90,4 +93,32 @@ solidpop3d_log = %(syslog_local0)s
 mysql_log = %(syslog_daemon)s
 mysql_backend = %(default_backend)s
 
-roundcube_errors_log = /var/log/roundcube/errors
+roundcube_errors_log = %(logs_path)s/roundcube/errors
+
+openhab_request_log = /opt/openhab/logs/request.log
+
+assp_mail_log = /root/path/to/assp/logs/maillog.txt
+
+qmail_log = /service/qmail/log/main/current
+
+kerio_security_log = /opt/kerio/mailserver/store/logs/security.log
+
+squirrelmail_access_log = /var/lib/squirrelmail/prefs/squirrelmail_access_log
+
+mssql_error_log = /var/opt/mssql/log/errorlog
+
+znc_log = /var/lib/znc/moddata/adminlog/znc.log
+
+counter_strike_log = /opt/cstrike/logs/L[0-9]*.log
+
+softethervpn_sec_log = /usr/local/vpnserver/security_log/*/sec.log
+
+bitwarden_log = /home/*/bwdata/logs/identity/Identity/log.txt
+
+groupoffice_log  = /home/groupoffice/log/info.log
+
+oracleims_log = /opt/sun/comms/messaging64/log/mail.log_current
+
+portsentry_log = /var/lib/portsentry/portsentry.history
+
+domino_smtp_log = /home/domino01/data/IBM_TECHNICAL_SUPPORT/console.log

--- a/config/paths-debian.conf
+++ b/config/paths-debian.conf
@@ -9,22 +9,22 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
-syslog_mail = /var/log/mail.log
+syslog_mail = %(logs_path)s/mail.log
 
 # control the `mail.warn` setting, see `/etc/rsyslog.d/50-default.conf` (if commented `mail.*` wins).
-# syslog_mail_warn = /var/log/mail.warn
+# syslog_mail_warn = %(logs_path)s/mail.warn
 syslog_mail_warn = %(syslog_mail)s
 
-syslog_user  =  /var/log/user.log
+syslog_user  =  %(logs_path)s/user.log
 
-syslog_ftp = /var/log/syslog
+syslog_ftp = %(logs_path)s/syslog
 
-syslog_daemon =  /var/log/daemon.log
+syslog_daemon =  %(logs_path)s/daemon.log
 
-exim_main_log = /var/log/exim4/mainlog
+exim_main_log = %(logs_path)s/exim4/mainlog
 
 # was in debian squeezy but not in wheezy
 # /etc/proftpd/proftpd.conf (SystemLog)
-proftpd_log = /var/log/proftpd/proftpd.log
+proftpd_log = %(logs_path)s/proftpd/proftpd.log
 
-roundcube_errors_log = /var/log/roundcube/errors.log
+roundcube_errors_log = %(logs_path)s/roundcube/errors.log

--- a/config/paths-fedora.conf
+++ b/config/paths-fedora.conf
@@ -9,26 +9,26 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
-syslog_mail = /var/log/maillog
+syslog_mail = %(logs_path)s/maillog
 
-syslog_mail_warn = /var/log/maillog
+syslog_mail_warn = %(logs_path)s/maillog
 
-syslog_authpriv = /var/log/secure
+syslog_authpriv = %(logs_path)s/secure
 
-apache_error_log = /var/log/httpd/*error_log
+apache_error_log = %(logs_path)s/httpd/*error_log
 
-apache_access_log = /var/log/httpd/*access_log
+apache_access_log = %(logs_path)s/httpd/*access_log
 
 # /etc/proftpd/proftpd.conf (ExtendedLog for Anonymous)
-# proftpd_log = /var/log/proftpd/auth.log
+# proftpd_log = %(logs_path)s/proftpd/auth.log
 # Tested and it worked out in /var/log/messages so assuming syslog_ftp for now.
 
-exim_main_log = /var/log/exim/main.log
+exim_main_log = %(logs_path)s/exim/main.log
 
-mysql_log = /var/log/mariadb/mariadb.log
-            /var/log/mysqld.log
+mysql_log = %(logs_path)s/mariadb/mariadb.log
+            %(logs_path)s/mysqld.log
 
-roundcube_errors_log = /var/log/roundcubemail/errors
+roundcube_errors_log = %(logs_path)s/roundcubemail/errors
 
 # These services will log to the journal via syslog, so use the journal by
 # default.

--- a/config/paths-freebsd.conf
+++ b/config/paths-freebsd.conf
@@ -11,12 +11,12 @@ after  = paths-overrides.local
 
 # http://www.freebsd.org/doc/handbook/configtuning-syslog.html
 #
-syslog_mail = /var/log/maillog
+syslog_mail = %(logs_path)s/maillog
 
-syslog_mail_warn = /var/log/maillog
+syslog_mail_warn = %(logs_path)s/maillog
 
 # note - is only ftp.info - if notice /var/log/messages may be needed
-syslog_ftp = /var/log/xferlog
+syslog_ftp = %(logs_path)s/xferlog
 
 # Linux things
 
@@ -25,13 +25,12 @@ syslog_ftp = /var/log/xferlog
 # http://svnweb.freebsd.org/ports/head/www/apache24/files/patch-config.layout
 # http://svnweb.freebsd.org/ports/head/www/apache22/files/patch-config.layout
 
-apache_error_log = /var/log/httpd-error.log
+apache_error_log = %(logs_path)s/httpd-error.log
 
-apache_access_log = /var/log/httpd-access.log
+apache_access_log = %(logs_path)s/httpd-access.log
 
 # http://svnweb.freebsd.org/ports/head/www/nginx/Makefile?view=markup
 
-nginx_error_log = /var/log/nginx/error.log
+nginx_error_log = %(logs_path)s/nginx/error.log
 
-nginx_access_log = /var/log/nginx/access.log
-
+nginx_access_log = %(logs_path)s/nginx/access.log

--- a/config/paths-opensuse.conf
+++ b/config/paths-opensuse.conf
@@ -9,7 +9,7 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
-syslog_mail = /var/log/mail
+syslog_mail = %(logs_path)s/mail
 
 syslog_mail_warn = %(syslog_mail)s
 
@@ -17,9 +17,9 @@ syslog_authpriv = %(syslog_local0)s
 
 pureftpd_log = %(syslog_local0)s
 
-exim_main_log = /var/log/exim/main.log
+exim_main_log = %(logs_path)s/exim/main.log
 
-mysql_log = /var/log/mysql/mysqld.log
+mysql_log = %(logs_path)s/mysql/mysqld.log
 
 roundcube_errors_log = /srv/www/roundcubemail/logs/errors
 

--- a/config/paths-osx.conf
+++ b/config/paths-osx.conf
@@ -10,11 +10,11 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
-syslog_mail = /var/log/mail.log
+syslog_mail = %(logs_path)s/mail.log
 
-syslog_mail_warn = /var/log/mail.warn
+syslog_mail_warn = %(logs_path)s/mail.warn
 
-syslog_authpriv = /var/log/secure.log
+syslog_authpriv = %(logs_path)s/secure.log
 #syslog_auth = 
 
 syslog_user = 
@@ -24,4 +24,3 @@ syslog_ftp =
 syslog_daemon = 
 
 syslog_local0 =
-


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file

The aim with these changes is to avoid using hardcoded paths for `logpath` in jail configurations. Since the master branch now has `paths-*.conf` for various distros, it should be easy for each distro to specify if a specific application's log is expected in a different location than the default value defined in `paths-common.conf`.

An additional benefit (and a goal I am working towards) is the 
```ini
var_log_path = /var/log
logs_path = %(var_log_path)s
```
variables can be easily adjusted for use in docker images/containers.
For example, if a user running fail2ban in docker mounts a volume for the host system `/var/log` directory inside the container as `/host_logs` they could easily change `var_log_path = /var/log` to `var_log_path = /host_logs` using the `paths-overrides.local` file.
A benefit of this approach would allow the user to have other applications inside the docker container that might use `/var/log` and have no need to involve fail2ban, so the user could keep the container application's `/var/log` separate (contained) from their host system's `/var/log`, while having the host system's `/var/log` available to fail2ban.

Another benefit would be that users running fail2ban in docker could aggregate their logs into a specific folder on their host system and mount that folder as a volume to their fail2ban container such as `/aggregated_logs` and set `logs_path = /aggregated_logs`.

It is commonly seen in environments where multiple docker containers are deployed that each container will have a mounted volume (or multiple) that contains persistent user data such as configs and logs, and the data will reside on the host in a location such as `/mnt/user/appdata/<name_of_container>` (this structure is used by unRAID, but a similar structure is often deployed by users of docker containers in other environments when using docker as well) that contains persistent user data such as config and logs. With a structure like this, users can mount subfolders of `/aggregated_logs` (if they choose to use this as their `logs_path`). fail2ban running in a docker container can be easily configured to see all the necessary logs beneath the `logs_path`. For example, `/mnt/user/appdata/nginx/log/` and `/mnt/user/appdata/lighttpd/log/` can be mounted as volumes into a fail2ban docker container as `/aggregated_logs/nginx/` and `/aggregated_logs/lighttpd/` which would allow fail2ban to see the logs in the expected location from `paths-common.conf`.