### PR TITLE
Support Python3 built w/o 2to3

### DIFF
--- a/fail2ban/client/configreader.py
+++ b/fail2ban/client/configreader.py
@@ -26,7 +26,10 @@ __license__ = "GPL"
 
 import glob
 import os
-from ConfigParser import NoOptionError, NoSectionError
+try:
+    from ConfigParser import NoOptionError, NoSectionError
+except ImportError:
+    from configparser import NoOptionError, NoSectionError
 
 from .configparserinc import sys, SafeConfigParserWithIncludes, logLevel
 from ..helpers import getLogger, _as_bool, _merge_dicts, substituteRecursiveTags

--- a/fail2ban/client/fail2banregex.py
+++ b/fail2ban/client/fail2banregex.py
@@ -43,7 +43,11 @@ import time
 import urllib
 from optparse import OptionParser, Option
 
-from ConfigParser import NoOptionError, NoSectionError, MissingSectionHeaderError
+try:
+    from ConfigParser import NoOptionError, NoSectionError, MissingSectionHeaderError
+except ImportError:
+    from configparser import NoOptionError, NoSectionError, MissingSectionHeaderError
+
 
 try: # pragma: no cover
 	from ..server.filtersystemd import FilterSystemd

--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -117,7 +117,7 @@ class JailReader(ConfigReader):
 	}
 	_configOpts.update(FilterReader._configOpts)
 
-	_ignoreOpts = set(['action', 'filter', 'enabled'] + FilterReader._configOpts.keys())
+	_ignoreOpts = set(['action', 'filter', 'enabled'] + list(FilterReader._configOpts.keys()))
 
 	def getOptions(self):
 

--- a/fail2ban/server/actions.py
+++ b/fail2ban/server/actions.py
@@ -156,11 +156,11 @@ class Actions(JailThread, Mapping):
 		else:
 			if hasattr(self, '_reload_actions'):
 				# reload actions after all parameters set via stream:
-				for name, initOpts in self._reload_actions.iteritems():
+				for name, initOpts in self._reload_actions.items():
 					if name in self._actions:
 						self._actions[name].reload(**(initOpts if initOpts else {}))
 				# remove obsolete actions (untouched by reload process):
-				delacts = OrderedDict((name, action) for name, action in self._actions.iteritems()
+				delacts = OrderedDict((name, action) for name, action in self._actions.items()
 					if name not in self._reload_actions)
 				if len(delacts):
 					# unban all tickets using removed actions only:
@@ -330,7 +330,7 @@ class Actions(JailThread, Mapping):
 			True when the thread exits nicely.
 		"""
 		cnt = 0
-		for name, action in self._actions.iteritems():
+		for name, action in self._actions.items():
 			try:
 				action.start()
 			except Exception as e:
@@ -507,7 +507,7 @@ class Actions(JailThread, Mapping):
 					Observers.Main.add('banFound', bTicket, self._jail, btime)
 				logSys.notice("[%s] %sBan %s", self._jail.name, ('' if not bTicket.restored else 'Restore '), ip)
 				# do actions :
-				for name, action in self._actions.iteritems():
+				for name, action in self._actions.items():
 					try:
 						if bTicket.restored and getattr(action, 'norestored', False):
 							continue
@@ -551,7 +551,7 @@ class Actions(JailThread, Mapping):
 					# check epoch in order to reban it:
 					if bTicket.banEpoch < self.banEpoch:
 						if not rebanacts: rebanacts = dict(
-							(name, action) for name, action in self._actions.iteritems()
+							(name, action) for name, action in self._actions.items()
 								if action.banEpoch > bTicket.banEpoch)
 						cnt += self.__reBan(bTicket, actions=rebanacts)
 				else: # pragma: no cover - unexpected: ticket is not banned for some reasons - reban using all actions:
@@ -579,7 +579,7 @@ class Actions(JailThread, Mapping):
 		aInfo = self._getActionInfo(ticket)
 		if log:
 			logSys.notice("[%s] Reban %s%s", self._jail.name, ip, (', action %r' % actions.keys()[0] if len(actions) == 1 else ''))
-		for name, action in actions.iteritems():
+		for name, action in actions.items():
 			try:
 				logSys.debug("[%s] action %r: reban %s", self._jail.name, name, ip)
 				if not aInfo.immutable: aInfo.reset()
@@ -603,7 +603,7 @@ class Actions(JailThread, Mapping):
 		if not self.banManager._inBanList(ticket): return
 		# do actions :
 		aInfo = None
-		for name, action in self._actions.iteritems():
+		for name, action in self._actions.items():
 			try:
 				if ticket.restored and getattr(action, 'norestored', False):
 					continue
@@ -652,7 +652,7 @@ class Actions(JailThread, Mapping):
 		cnt = 0
 		# first we'll execute flush for actions supporting this operation:
 		unbactions = {}
-		for name, action in (actions if actions is not None else self._actions).iteritems():
+		for name, action in (actions if actions is not None else self._actions).items():
 			try:
 				if hasattr(action, 'flush') and (not isinstance(action, CommandAction) or action.actionflush):
 					logSys.notice("[%s] Flush ticket(s) with %s", self._jail.name, name)
@@ -707,7 +707,7 @@ class Actions(JailThread, Mapping):
 		aInfo = self._getActionInfo(ticket)
 		if log:
 			logSys.notice("[%s] Unban %s", self._jail.name, ip)
-		for name, action in unbactions.iteritems():
+		for name, action in unbactions.items():
 			try:
 				logSys.debug("[%s] action %r: unban %s", self._jail.name, name, ip)
 				if not aInfo.immutable: aInfo.reset()

--- a/fail2ban/server/ipdns.py
+++ b/fail2ban/server/ipdns.py
@@ -24,6 +24,7 @@ __license__ = "GPL"
 import socket
 import struct
 import re
+from builtins import range
 
 from .utils import Utils
 from ..helpers import getLogger
@@ -332,7 +333,7 @@ class IPAddr(object):
 
 				# mask out host portion if prefix length is supplied
 				if cidr is not None and cidr >= 0:
-					mask = ~(0xFFFFFFFFL >> cidr)
+					mask = ~(0xFFFFFFFF >> cidr)
 					self._addr &= mask
 					self._plen = cidr
 
@@ -344,13 +345,13 @@ class IPAddr(object):
 
 				# mask out host portion if prefix length is supplied
 				if cidr is not None and cidr >= 0:
-					mask = ~(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFL >> cidr)
+					mask = ~(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF >> cidr)
 					self._addr &= mask
 					self._plen = cidr
 
 				# if IPv6 address is a IPv4-compatible, make instance a IPv4
 				elif self.isInNet(IPAddr.IP6_4COMPAT):
-					self._addr = lo & 0xFFFFFFFFL
+					self._addr = lo & 0xFFFFFFFF
 					self._family = socket.AF_INET
 					self._plen = 32
 		else:
@@ -474,7 +475,7 @@ class IPAddr(object):
 		elif self.isIPv6:
 			# convert network to host byte order
 			hi = self._addr >> 64
-			lo = self._addr & 0xFFFFFFFFFFFFFFFFL
+			lo = self._addr & 0xFFFFFFFFFFFFFFFF
 			binary = struct.pack("!QQ", hi, lo)
 			if self._plen and self._plen < 128:
 				add = "/%d" % self._plen
@@ -532,9 +533,9 @@ class IPAddr(object):
 		if self.family != net.family:
 			return False
 		if self.isIPv4:
-			mask = ~(0xFFFFFFFFL >> net.plen)
+			mask = ~(0xFFFFFFFF >> net.plen)
 		elif self.isIPv6:
-			mask = ~(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFL >> net.plen)
+			mask = ~(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF >> net.plen)
 		else:
 			return False
 		
@@ -551,7 +552,7 @@ class IPAddr(object):
 		m4 = (1 << 32)-1
 		mmap = {m6: 128, m4: 32, 0: 0}
 		m = 0
-		for i in xrange(0, 128):
+		for i in range(0, 128):
 			m |= 1 << i
 			if i < 32:
 				mmap[m ^ m4] = 32-1-i

--- a/fail2ban/server/jail.py
+++ b/fail2ban/server/jail.py
@@ -26,7 +26,10 @@ __license__ = "GPL"
 import logging
 import math
 import random
-import Queue
+try:
+   import queue
+except ImportError:
+   import Queue as queue
 
 from .actions import Actions
 from ..helpers import getLogger, _as_bool, extractOptions, MyTime
@@ -76,7 +79,7 @@ class Jail(object):
 							"might not function correctly. Please shorten"
 							% name)
 		self.__name = name
-		self.__queue = Queue.Queue()
+		self.__queue = queue.Queue()
 		self.__filter = None
 		# Extra parameters for increase ban time
 		self._banExtra = {};
@@ -219,7 +222,7 @@ class Jail(object):
 		try:
 			ticket = self.__queue.get(False)
 			return ticket
-		except Queue.Empty:
+		except queue.Empty:
 			return False
 
 	def setBanTimeExtra(self, opt, value):

--- a/fail2ban/server/strptime.py
+++ b/fail2ban/server/strptime.py
@@ -21,6 +21,7 @@ import re
 import time
 import calendar
 import datetime
+from builtins import range
 from _strptime import LocaleTime, TimeRE, _calc_julian_from_U_or_W
 
 from .mytime import MyTime
@@ -99,7 +100,7 @@ def _updateTimeRE():
 				if len(exprset) > 1 else "".join(exprset)
 		exprset = set( cent(now[0].year + i) for i in (-1, distance) )
 		if len(now) > 1 and now[1]:
-			exprset |= set( cent(now[1].year + i) for i in xrange(-1, now[0].year-now[1].year+1, distance) )
+			exprset |= set( cent(now[1].year + i) for i in range(-1, now[0].year-now[1].year+1, distance) )
 		return grp(sorted(list(exprset)))
 
 	# more precise year patterns, within same century of last year and

--- a/fail2ban/server/utils.py
+++ b/fail2ban/server/utils.py
@@ -53,7 +53,7 @@ _RETCODE_HINTS = {
 
 # Dictionary to lookup signal name from number
 signame = dict((num, name)
-	for name, num in signal.__dict__.iteritems() if name.startswith("SIG"))
+	for name, num in signal.__dict__.items() if name.startswith("SIG"))
 
 class Utils():
 	"""Utilities provide diverse static methods like executes OS shell commands, etc.

--- a/fail2ban/tests/datedetectortestcase.py
+++ b/fail2ban/tests/datedetectortestcase.py
@@ -27,6 +27,7 @@ __license__ = "GPL"
 import unittest
 import time
 import datetime
+from builtins import range
 
 from ..server.datedetector import DateDetector
 from ..server import datedetector
@@ -279,7 +280,7 @@ class DateDetectorTest(LogCaptureTestCase):
 		self.assertEqual(logTime, mu)
 		self.assertEqual(logMatch.group(1), '2012/10/11 02:37:17')
 		# confuse it with year being at the end
-		for i in xrange(10):
+		for i in range(10):
 			( logTime, logMatch ) =	self.datedetector.getTime('11/10/2012 02:37:17 [error] 18434#0')
 			self.assertEqual(logTime, mu)
 			self.assertEqual(logMatch.group(1), '11/10/2012 02:37:17')

--- a/fail2ban/tests/fail2banclienttestcase.py
+++ b/fail2ban/tests/fail2banclienttestcase.py
@@ -30,6 +30,7 @@ import sys
 import time
 import signal
 import unittest
+from builtins import range
 
 from os.path import join as pjoin, isdir, isfile, exists, dirname
 from functools import wraps
@@ -1669,6 +1670,6 @@ class Fail2banServerTest(Fail2banClientServerBase):
 			self.stopAndWaitForServerEnd(SUCCESS)
 
 		def testServerStartStop(self):
-			for i in xrange(2000):
+			for i in range(2000):
 				self._testServerStartStop()
 

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -22,7 +22,11 @@
 __copyright__ = "Copyright (c) 2004 Cyril Jaquier; 2012 Yaroslav Halchenko"
 __license__ = "GPL"
 
-from __builtin__ import open as fopen
+try:
+	from __builtin__ import open as fopen
+except ImportError:
+	from builtins import open as fopen
+from builtins import range
 import unittest
 import os
 import re
@@ -209,7 +213,7 @@ def _copy_lines_between_files(in_, fout, n=None, skip=0, mode='a', terminal_line
 	else:
 		fin = in_
 	# Skip
-	for i in xrange(skip):
+	for i in range(skip):
 		fin.readline()
 	# Read
 	i = 0
@@ -250,7 +254,7 @@ def _copy_lines_to_journal(in_, fields={},n=None, skip=0, terminal_line=""): # p
 	# Required for filtering
 	fields.update(TEST_JOURNAL_FIELDS)
 	# Skip
-	for i in xrange(skip):
+	for i in range(skip):
 		fin.readline()
 	# Read/Write
 	i = 0
@@ -312,7 +316,7 @@ class BasicFilter(unittest.TestCase):
 	def testTest_tm(self):
 		unittest.F2B.SkipIfFast()
 		## test function "_tm" works correct (returns the same as slow strftime):
-		for i in xrange(1417512352, (1417512352 // 3600 + 3) * 3600):
+		for i in range(1417512352, (1417512352 // 3600 + 3) * 3600):
 			tm = MyTime.time2str(i)
 			if _tm(i) != tm: # pragma: no cover - never reachable
 				self.assertEqual((_tm(i), i), (tm, i))
@@ -510,7 +514,7 @@ class IgnoreIP(LogCaptureTestCase):
 
 	def testAddAttempt(self):
 		self.filter.setMaxRetry(3)
-		for i in xrange(1, 1+3):
+		for i in range(1, 1+3):
 			self.filter.addAttempt('192.0.2.1')
 			self.assertLogged('Attempt 192.0.2.1', '192.0.2.1:%d' % i, all=True, wait=True)
 		self.jail.actions._Actions__checkBan()
@@ -547,7 +551,7 @@ class IgnoreIP(LogCaptureTestCase):
 		# like both test-cases above, just cached (so once per key)...
 		self.filter.ignoreCache = {"key":"<ip>"}
 		self.filter.ignoreCommand = 'if [ "<ip>" = "10.0.0.1" ]; then exit 0; fi; exit 1'
-		for i in xrange(5):
+		for i in range(5):
 			self.pruneLog()
 			self.assertTrue(self.filter.inIgnoreIPList("10.0.0.1"))
 			self.assertFalse(self.filter.inIgnoreIPList("10.0.0.0"))
@@ -558,7 +562,7 @@ class IgnoreIP(LogCaptureTestCase):
 		# by host of IP:
 		self.filter.ignoreCache = {"key":"<ip-host>"}
 		self.filter.ignoreCommand = 'if [ "<ip-host>" = "test-host" ]; then exit 0; fi; exit 1'
-		for i in xrange(5):
+		for i in range(5):
 			self.pruneLog()
 			self.assertTrue(self.filter.inIgnoreIPList(FailTicket("2001:db8::1")))
 			self.assertFalse(self.filter.inIgnoreIPList(FailTicket("2001:db8::ffff")))
@@ -570,7 +574,7 @@ class IgnoreIP(LogCaptureTestCase):
 		self.filter.ignoreCache = {"key":"<F-USER>", "max-count":"10", "max-time":"1h"}
 		self.assertEqual(self.filter.ignoreCache, ["<F-USER>", 10, 60*60])
 		self.filter.ignoreCommand = 'if [ "<F-USER>" = "tester" ]; then exit 0; fi; exit 1'
-		for i in xrange(5):
+		for i in range(5):
 			self.pruneLog()
 			self.assertTrue(self.filter.inIgnoreIPList(FailTicket("tester", data={'user': 'tester'})))
 			self.assertFalse(self.filter.inIgnoreIPList(FailTicket("root", data={'user': 'root'})))
@@ -733,7 +737,7 @@ class LogFileFilterPoll(unittest.TestCase):
 			fc = FileContainer(fname, self.filter.getLogEncoding())
 			fc.open()
 			# no time - nothing should be found :
-			for i in xrange(10):
+			for i in range(10):
 				f.write("[sshd] error: PAM: failure len 1\n")
 				f.flush()
 				fc.setPos(0); self.filter.seekToTime(fc, time)
@@ -807,14 +811,14 @@ class LogFileFilterPoll(unittest.TestCase):
 			# variable length of file (ca 45K or 450K before and hereafter):
 			# write lines with smaller as search time:
 			t = time - count - 1
-			for i in xrange(count):
+			for i in range(count):
 				f.write("%s [sshd] error: PAM: failure\n" % _tm(t))
 				t += 1
 			f.flush()
 			fc.setPos(0); self.filter.seekToTime(fc, time)
 			self.assertEqual(fc.getPos(), 47*count)
 			# write lines with exact search time:
-			for i in xrange(10):
+			for i in range(10):
 				f.write("%s [sshd] error: PAM: failure\n" % _tm(time))
 			f.flush()
 			fc.setPos(0); self.filter.seekToTime(fc, time)
@@ -823,8 +827,8 @@ class LogFileFilterPoll(unittest.TestCase):
 			self.assertEqual(fc.getPos(), 47*count)
 			# write lines with greater as search time:
 			t = time+1
-			for i in xrange(count//500):
-				for j in xrange(500):
+			for i in range(count//500):
+				for j in range(500):
 					f.write("%s [sshd] error: PAM: failure\n" % _tm(t))
 					t += 1
 				f.flush()
@@ -1775,7 +1779,7 @@ class GetFailures(LogCaptureTestCase):
 	def testGetFailures02(self):
 		output = ('141.3.81.106', 4, 1124013539.0,
 				  [u'Aug 14 11:%d:59 i60p295 sshd[12365]: Failed publickey for roehl from ::ffff:141.3.81.106 port 51332 ssh2'
-				   % m for m in 53, 54, 57, 58])
+				   % m for m in (53, 54, 57, 58)])
 
 		self.filter.setMaxRetry(4)
 		self.filter.addLogPath(GetFailures.FILENAME_02, autoSeek=0)
@@ -2004,9 +2008,9 @@ class DNSUtilsTests(unittest.TestCase):
 		self.assertTrue(c.get('a') is None)
 		self.assertEqual(c.get('a', 'test'), 'test')
 		# exact 5 elements :
-		for i in xrange(5):
+		for i in range(5):
 			c.set(i, i)
-		for i in xrange(5):
+		for i in range(5):
 			self.assertEqual(c.get(i), i)
 		# remove unavailable key:
 		c.unset('a'); c.unset('a')
@@ -2014,30 +2018,30 @@ class DNSUtilsTests(unittest.TestCase):
 	def testCacheMaxSize(self):
 		c = Utils.Cache(maxCount=5, maxTime=60)
 		# exact 5 elements :
-		for i in xrange(5):
+		for i in range(5):
 			c.set(i, i)
-		self.assertEqual([c.get(i) for i in xrange(5)], [i for i in xrange(5)])
-		self.assertNotIn(-1, (c.get(i, -1) for i in xrange(5)))
+		self.assertEqual([c.get(i) for i in range(5)], [i for i in range(5)])
+		self.assertNotIn(-1, (c.get(i, -1) for i in range(5)))
 		# add one - too many:
 		c.set(10, i)
 		# one element should be removed :
-		self.assertIn(-1, (c.get(i, -1) for i in xrange(5)))
+		self.assertIn(-1, (c.get(i, -1) for i in range(5)))
 		# test max size (not expired):
-		for i in xrange(10):
+		for i in range(10):
 			c.set(i, 1)
 		self.assertEqual(len(c), 5)
 
 	def testCacheMaxTime(self):
 		# test max time (expired, timeout reached) :
 		c = Utils.Cache(maxCount=5, maxTime=0.0005)
-		for i in xrange(10):
+		for i in range(10):
 			c.set(i, 1)
 		st = time.time()
 		self.assertTrue(Utils.wait_for(lambda: time.time() >= st + 0.0005, 1))
 		# we have still 5 elements (or fewer if too slow test mashine):
 		self.assertTrue(len(c) <= 5)
 		# but all that are expiered also:
-		for i in xrange(10):
+		for i in range(10):
 			self.assertTrue(c.get(i) is None)
 		# here the whole cache should be empty:
 		self.assertEqual(len(c), 0)
@@ -2058,7 +2062,7 @@ class DNSUtilsTests(unittest.TestCase):
 					c = count
 					while c:
 						c -= 1
-						s = xrange(0, 256, 1) if forw else xrange(255, -1, -1)
+						s = range(0, 256, 1) if forw else range(255, -1, -1)
 						if random: shuffle([i for i in s])
 						for i in s:
 							IPAddr('192.0.2.'+str(i), IPAddr.FAM_IPv4)
@@ -2184,16 +2188,16 @@ class DNSUtilsNetworkTests(unittest.TestCase):
 
 	def testAddr2bin(self):
 		res = IPAddr('10.0.0.0')
-		self.assertEqual(res.addr, 167772160L)
+		self.assertEqual(res.addr, 167772160)
 		res = IPAddr('10.0.0.0', cidr=None)
-		self.assertEqual(res.addr, 167772160L)
-		res = IPAddr('10.0.0.0', cidr=32L)
-		self.assertEqual(res.addr, 167772160L)
-		res = IPAddr('10.0.0.1', cidr=32L)
-		self.assertEqual(res.addr, 167772161L)
+		self.assertEqual(res.addr, 167772160)
+		res = IPAddr('10.0.0.0', cidr=32)
+		self.assertEqual(res.addr, 167772160)
+		res = IPAddr('10.0.0.1', cidr=32)
+		self.assertEqual(res.addr, 167772161)
 		self.assertTrue(res.isSingle)
-		res = IPAddr('10.0.0.1', cidr=31L)
-		self.assertEqual(res.addr, 167772160L)
+		res = IPAddr('10.0.0.1', cidr=31)
+		self.assertEqual(res.addr, 167772160)
 		self.assertFalse(res.isSingle)
 
 		self.assertEqual(IPAddr('10.0.0.0').hexdump, '0a000000')

--- a/fail2ban/tests/misctestcase.py
+++ b/fail2ban/tests/misctestcase.py
@@ -17,6 +17,7 @@
 # along with Fail2Ban; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from __future__ import print_function
 __author__ = "Yaroslav Halchenko"
 __copyright__ = "Copyright (c) 2013 Yaroslav Halchenko"
 __license__ = "GPL"
@@ -29,9 +30,10 @@ import tempfile
 import shutil
 import fnmatch
 from glob import glob
-from StringIO import StringIO
+from io import StringIO
+from builtins import range
 
-from utils import LogCaptureTestCase, logSys as DefLogSys
+from .utils import LogCaptureTestCase, logSys as DefLogSys
 
 from ..helpers import formatExceptionInfo, mbasename, TraceBack, FormatterWithTraceBack, getLogger, \
 	getVerbosityFormat, splitwords, uni_decode, uni_string
@@ -256,7 +258,7 @@ class TestsUtilsTest(LogCaptureTestCase):
 					func_raise()
 
 			try:
-				print deep_function(3)
+				print(deep_function(3))
 			except ValueError:
 				s = tb()
 
@@ -311,13 +313,13 @@ class TestsUtilsTest(LogCaptureTestCase):
 		self._testAssertionErrorRE(r"'a' unexpectedly found in 'cba'",
 			self.assertNotIn, 'a', 'cba')
 		self._testAssertionErrorRE(r"1 unexpectedly found in \[0, 1, 2\]",
-			self.assertNotIn, 1, xrange(3))
+			self.assertNotIn, 1, range(3))
 		self._testAssertionErrorRE(r"'A' unexpectedly found in \['C', 'A'\]",
 			self.assertNotIn, 'A', (c.upper() for c in 'cba' if c != 'b'))
 		self._testAssertionErrorRE(r"'a' was not found in 'xyz'",
 			self.assertIn, 'a', 'xyz')
 		self._testAssertionErrorRE(r"5 was not found in \[0, 1, 2\]",
-			self.assertIn, 5, xrange(3))
+			self.assertIn, 5, range(3))
 		self._testAssertionErrorRE(r"'A' was not found in \['C', 'B'\]",
 			self.assertIn, 'A', (c.upper() for c in 'cba' if c != 'a'))
 		## assertLogged, assertNotLogged positive case:

--- a/fail2ban/tests/observertestcase.py
+++ b/fail2ban/tests/observertestcase.py
@@ -29,6 +29,7 @@ import sys
 import unittest
 import tempfile
 import time
+from builtins import range
 
 from ..server.mytime import MyTime
 from ..server.ticket import FailTicket, BanTicket
@@ -68,7 +69,7 @@ class BanTimeIncr(LogCaptureTestCase):
 		a.setBanTimeExtra('multipliers', multipliers)
 		# test algorithm and max time 24 hours :
 		self.assertEqual(
-			[a.calcBanTime(600, i) for i in xrange(1, 11)],
+			[a.calcBanTime(600, i) for i in range(1, 11)],
 			[1200, 2400, 4800, 9600, 19200, 38400, 76800, 86400, 86400, 86400]
 		)
 		# with extra large max time (30 days):
@@ -80,38 +81,38 @@ class BanTimeIncr(LogCaptureTestCase):
 			if multcnt < 11:
 				arr = arr[0:multcnt-1] + ([arr[multcnt-2]] * (11-multcnt))
 		self.assertEqual(
-			[a.calcBanTime(600, i) for i in xrange(1, 11)],
+			[a.calcBanTime(600, i) for i in range(1, 11)],
 			arr
 		)
 		a.setBanTimeExtra('maxtime', '1d')
 		# change factor :
 		a.setBanTimeExtra('factor', '2');
 		self.assertEqual(
-			[a.calcBanTime(600, i) for i in xrange(1, 11)],
+			[a.calcBanTime(600, i) for i in range(1, 11)],
 			[2400, 4800, 9600, 19200, 38400, 76800, 86400, 86400, 86400, 86400]
 		)
 		# factor is float :
 		a.setBanTimeExtra('factor', '1.33');
 		self.assertEqual(
-			[int(a.calcBanTime(600, i)) for i in xrange(1, 11)],
+			[int(a.calcBanTime(600, i)) for i in range(1, 11)],
 			[1596, 3192, 6384, 12768, 25536, 51072, 86400, 86400, 86400, 86400]
 		)
 		a.setBanTimeExtra('factor', None);
 		# change max time :
 		a.setBanTimeExtra('maxtime', '12h')
 		self.assertEqual(
-			[a.calcBanTime(600, i) for i in xrange(1, 11)],
+			[a.calcBanTime(600, i) for i in range(1, 11)],
 			[1200, 2400, 4800, 9600, 19200, 38400, 43200, 43200, 43200, 43200]
 		)
 		a.setBanTimeExtra('maxtime', '24h')
 		## test randomization - not possibe all 10 times we have random = 0:
 		a.setBanTimeExtra('rndtime', '5m')
 		self.assertTrue(
-			False in [1200 in [a.calcBanTime(600, 1) for i in xrange(10)] for c in xrange(10)]
+			False in [1200 in [a.calcBanTime(600, 1) for i in range(10)] for c in range(10)]
 		)
 		a.setBanTimeExtra('rndtime', None)
 		self.assertFalse(
-			False in [1200 in [a.calcBanTime(600, 1) for i in xrange(10)] for c in xrange(10)]
+			False in [1200 in [a.calcBanTime(600, 1) for i in range(10)] for c in range(10)]
 		)
 		# restore default:
 		a.setBanTimeExtra('multipliers', None)
@@ -123,7 +124,7 @@ class BanTimeIncr(LogCaptureTestCase):
 		# this multipliers has the same values as default formula, we test stop growing after count 9:
 		self.testDefault('1 2 4 8 16 32 64 128 256')
 		# this multipliers has exactly the same values as default formula, test endless growing (stops by count 31 only):
-		self.testDefault(' '.join([str(1<<i) for i in xrange(31)]))
+		self.testDefault(' '.join([str(1<<i) for i in range(31)]))
 
 	def testFormula(self):
 		a = self.__jail;
@@ -135,38 +136,38 @@ class BanTimeIncr(LogCaptureTestCase):
 		a.setBanTimeExtra('multipliers', None)
 		# test algorithm and max time 24 hours :
 		self.assertEqual(
-			[int(a.calcBanTime(600, i)) for i in xrange(1, 11)],
+			[int(a.calcBanTime(600, i)) for i in range(1, 11)],
 			[1200, 2400, 4800, 9600, 19200, 38400, 76800, 86400, 86400, 86400]
 		)
 		# with extra large max time (30 days):
 		a.setBanTimeExtra('maxtime', '30d')
 		self.assertEqual(
-			[int(a.calcBanTime(600, i)) for i in xrange(1, 11)],
+			[int(a.calcBanTime(600, i)) for i in range(1, 11)],
 			[1200, 2400, 4800, 9600, 19200, 38400, 76800, 153601, 307203, 614407]
 		)
 		a.setBanTimeExtra('maxtime', '24h')
 		# change factor :
 		a.setBanTimeExtra('factor', '1');
 		self.assertEqual(
-			[int(a.calcBanTime(600, i)) for i in xrange(1, 11)],
+			[int(a.calcBanTime(600, i)) for i in range(1, 11)],
 			[1630, 4433, 12051, 32758, 86400, 86400, 86400, 86400, 86400, 86400]
 		)
 		a.setBanTimeExtra('factor', '2.0 / 2.885385')
 		# change max time :
 		a.setBanTimeExtra('maxtime', '12h')
 		self.assertEqual(
-			[int(a.calcBanTime(600, i)) for i in xrange(1, 11)],
+			[int(a.calcBanTime(600, i)) for i in range(1, 11)],
 			[1200, 2400, 4800, 9600, 19200, 38400, 43200, 43200, 43200, 43200]
 		)
 		a.setBanTimeExtra('maxtime', '24h')
 		## test randomization - not possibe all 10 times we have random = 0:
 		a.setBanTimeExtra('rndtime', '5m')
 		self.assertTrue(
-			False in [1200 in [int(a.calcBanTime(600, 1)) for i in xrange(10)] for c in xrange(10)]
+			False in [1200 in [int(a.calcBanTime(600, 1)) for i in range(10)] for c in range(10)]
 		)
 		a.setBanTimeExtra('rndtime', None)
 		self.assertFalse(
-			False in [1200 in [int(a.calcBanTime(600, 1)) for i in xrange(10)] for c in xrange(10)]
+			False in [1200 in [int(a.calcBanTime(600, 1)) for i in range(10)] for c in range(10)]
 		)
 		# restore default:
 		a.setBanTimeExtra('factor', None);
@@ -229,7 +230,7 @@ class BanTimeIncrDB(LogCaptureTestCase):
 		ticket = FailTicket(ip, stime, [])
 		# test ticket not yet found
 		self.assertEqual(
-			[self.incrBanTime(ticket, 10) for i in xrange(3)], 
+			[self.incrBanTime(ticket, 10) for i in range(3)], 
 			[10, 10, 10]
 		)
 		# add a ticket banned
@@ -284,7 +285,7 @@ class BanTimeIncrDB(LogCaptureTestCase):
 		)
 		# increase ban multiple times:
 		lastBanTime = 20
-		for i in xrange(10):
+		for i in range(10):
 			ticket.setTime(stime + lastBanTime + 5)
 			banTime = self.incrBanTime(ticket, 10)
 			self.assertEqual(banTime, lastBanTime * 2)
@@ -483,7 +484,7 @@ class BanTimeIncrDB(LogCaptureTestCase):
 		ticket = FailTicket(ip, stime-120, [])
 		failManager = jail.filter.failManager = FailManager()
 		failManager.setMaxRetry(3)
-		for i in xrange(3):
+		for i in range(3):
 			failManager.addFailure(ticket)
 			obs.add('failureFound', jail, ticket)
 		obs.wait_empty(5)

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -31,6 +31,7 @@ import os
 import re
 import sys
 import platform
+from builtins import range
 
 from ..server.failregex import Regex, FailRegex, RegexException
 from ..server import actions as _actions
@@ -930,7 +931,7 @@ class TransmitterLogging(TransmitterBase):
 
 	def testLogTarget(self):
 		logTargets = []
-		for _ in xrange(3):
+		for _ in range(3):
 			tmpFile = tempfile.mkstemp("fail2ban", "transmitter")
 			logTargets.append(tmpFile[1])
 			os.close(tmpFile[0])
@@ -1185,7 +1186,7 @@ class LoggingTests(LogCaptureTestCase):
 					os.remove(f)
 
 
-from clientreadertestcase import ActionReader, JailsReader, CONFIG_DIR
+from .clientreadertestcase import ActionReader, JailsReader, CONFIG_DIR
 
 class ServerConfigReaderTests(LogCaptureTestCase):
 
@@ -1396,7 +1397,7 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 				),
 				'ip6-unban': (
 					r"`nft delete element inet f2b-table addr6-set-j-w-nft-mp \{ 2001:db8:: \}`",
-				),					
+				),     
 			}),
 			# nft-allports --
 			('j-w-nft-ap', 'nftables-allports[name=%(__name__)s, protocol="tcp,udp"]', {

--- a/fail2ban/tests/utils.py
+++ b/fail2ban/tests/utils.py
@@ -35,8 +35,9 @@ import time
 import threading
 import unittest
 
-from cStringIO import StringIO
+from io import StringIO
 from functools import wraps
+from builtins import range
 
 from ..helpers import getLogger, str2LogLevel, getVerbosityFormat, uni_decode
 from ..server.ipdns import IPAddr, DNSUtils
@@ -303,7 +304,7 @@ def initTests(opts):
 	c.clear = lambda: logSys.warn('clear CACHE_ipToName is disabled in test suite')
 	# increase max count and max time (too many entries, long time testing):
 	c.setOptions(maxCount=10000, maxTime=5*60)
-	for i in xrange(256):
+	for i in range(256):
 		c.set('192.0.2.%s' % i, None)
 		c.set('198.51.100.%s' % i, None)
 		c.set('203.0.113.%s' % i, None)


### PR DESCRIPTION
This is a preliminary work to make the codebase compatible with both Python2 and Python3, without having to run `2to3` to convert the code whenever one wants to run in Python3 environment.
This is not a complete work, and test might break still. I am looking to get the feedback from the tool maintainers first, to see if they are interested at all with such change.

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
