### PR TITLE
Updated firewallcmd-ipset.conf and added discord_notifications.conf

### DIFF
--- a/config/action.d/discord_notifications.conf
+++ b/config/action.d/discord_notifications.conf
@@ -1,0 +1,24 @@
+[Definition]
+
+actionstart = curl -sX POST "<webhookurl>" \
+            -H "Content-Type: application/json" \
+            -d '{"username":"<botname>","avatar_url":"https:\/\/avatars.githubusercontent.com\/u\/1087378","content":null,"embeds":[{"title":":bell: Jail Notification :bell:","description":"Jail **[<name>]** has started!","color":65280,"thumbnail":{"url":"https:\/\/github.com\/poqdavid\/f2b_discord_notification\/raw\/master\/check.png"}}]}'
+
+actionstop = curl -sX POST "<webhookurl>" \
+            -H "Content-Type: application/json" \
+            -d '{"username":"<botname>","avatar_url":"https:\/\/avatars.githubusercontent.com\/u\/1087378","content":null,"embeds":[{"title":":bell: Jail Notification :bell:","description":"Jail **[<name>]** has been stopped!","color":16711680,"thumbnail":{"url":"https:\/\/github.com\/poqdavid\/f2b_discord_notification\/raw\/master\/x.png"}}]}'
+
+actionban = curl -sX POST "<webhookurl>" \
+            -H "Content-Type: application/json" \
+            -d '{"username":"<botname>","avatar_url":"https:\/\/avatars.githubusercontent.com\/u\/1087378","content":"<@&<discord_roleid>>","embeds":[{"title":":bell: Ban Notification :bell:","color":16711680,"fields":[{"name":"IP:","value":"```<ip>```","inline":true},{"name":"Reason:","value":"**<failures>** failed attempt(s) on **[<name>]** service.","inline":true},{"name":"Information about the IP","value":"[GreyNoise.io > <ip>](<https:\/\/viz.greynoise.io\/ip\/<ip>>)\n[VirusTotal.com > <ip>](<https:\/\/www.virustotal.com\/gui\/ip-address\/<ip>\/detection>)\n[DB-IP.com > <ip>](<https:\/\/db-ip.com\/<ip>>)"}],"footer":{"text":null},"thumbnail":{"url":"https:\/\/github.com\/poqdavid\/f2b_discord_notification\/raw\/master\/ban.png"}}],"allowed_mentions": { "roles": ["<discord_roleid>"] }}' 
+
+actionunban = curl -sX POST "<webhookurl>" \
+            -H "Content-Type: application/json" \
+            -d '{"username":"<botname>","avatar_url":"https:\/\/avatars.githubusercontent.com\/u\/1087378","content":null,"embeds":[{"title":":bell: Unban Notification :bell:","color":65280,"fields":[{"name":"IP:","value":"```<ip>```","inline":true},{"name":"Reason:","value":"UNBANNED","inline":true},{"name":"Information about the IP","value":"[GreyNoise.io > <ip>](<https:\/\/viz.greynoise.io\/ip\/<ip>>)\n[VirusTotal.com > <ip>](<https:\/\/www.virustotal.com\/gui\/ip-address\/<ip>\/detection>)\n[DB-IP.com > <ip>](<https:\/\/db-ip.com\/<ip>>)"}],"thumbnail":{"url":"https:\/\/github.com\/poqdavid\/f2b_discord_notification\/raw\/master\/check.png"}}]}'
+[Init]
+
+webhookurl = https://discord.com/api/webhooks<webhook>
+
+# DEV NOTES:
+#
+# Author: POQDavid

--- a/config/action.d/firewallcmd-ipset.conf
+++ b/config/action.d/firewallcmd-ipset.conf
@@ -19,11 +19,21 @@ before = firewallcmd-common.conf
 [Definition]
 
 actionstart = <ipstype_<ipsettype>/actionstart>
-              firewall-cmd --direct --add-rule <family> filter <chain> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
+              firewall-cmd --direct --add-chain <family> filter <ipmset>
+              firewall-cmd --direct --add-rule <family> filter <ipmset> 1000 -j RETURN
+              firewall-cmd --direct --add-rule <family> filter <chain> 0 -j <ipmset>
+			  firewall-cmd --direct --add-rule <family> filter FORWARD 0 -j <ipmset>
+			  firewall-cmd --direct --add-rule <family> filter OUTPUT 0 -j <ipmset>
+			  <actiontype_<actiontype>/actionstart>
 
 actionflush = <ipstype_<ipsettype>/actionflush>
 
-actionstop = firewall-cmd --direct --remove-rule <family> filter <chain> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
+actionstop = <actiontype_<actiontype>/actionstart>
+             firewall-cmd --direct --remove-rule <family> filter <chain> 0 -j <ipmset>
+			 firewall-cmd --direct --remove-rule <family> filter FORWARD 0 -j <ipmset>
+			 firewall-cmd --direct --remove-rule <family> filter OUTPUT 0 -j <ipmset>
+			 firewall-cmd --direct --remove-rules <family> filter <ipmset>
+             firewall-cmd --direct --remove-chain <family> filter <ipmset>
              <actionflush>
              <ipstype_<ipsettype>/actionstop>
 
@@ -47,16 +57,31 @@ actionunban = ipset -exist del <ipmset> <ip>
 
 [ipstype_firewalld]
 
-actionstart = firewall-cmd --direct --new-ipset=<ipmset> --type=hash:ip --option=timeout=<default-ipsettime> <firewalld_familyopt>
+actionstart = firewall-cmd --permanent --new-ipset=<ipmset> --type=hash:ip --option=timeout=<default-ipsettime> <firewalld_familyopt>
+              firewall-cmd --reload
 
 # TODO: there doesn't seem to be an explicit way to invoke the ipset flush function using firewall-cmd
-actionflush = 
+actionflush = firewall-cmd --permanent --delete-ipset=<ipmset>
+              firewall-cmd --permanent --new-ipset=<ipmset> --type=hash:ip --option=timeout=<default-ipsettime> <firewalld_familyopt>
+			  firewall-cmd --reload
 
-actionstop = firewall-cmd --direct --delete-ipset=<ipmset>
+actionstop = firewall-cmd --permanent --delete-ipset=<ipmset>
+             firewall-cmd --reload
 
-actionban = firewall-cmd --ipset=<ipmset> --add-entry=<ip>
+# NOTE: ban or unban doesn't work unless you reload firewalld which will wipe all the none permanent rules
+actionban = firewall-cmd --permanent --ipset=<ipmset> --add-entry=<ip>
 
-actionunban = firewall-cmd --ipset=<ipmset> --remove-entry=<ip>
+actionunban = firewall-cmd --permanent --ipset=<ipmset> --remove-entry=<ip>
+
+[actiontype_allports]
+
+actionstart = firewall-cmd --direct --add-rule <family> filter <ipmset> 0 -m set --match-set <ipmset> src -j <blocktype>
+actionstop = firewall-cmd --direct --remove-rule <family> filter <ipmset> 0 -m set --match-set <ipmset> src -j <blocktype>
+
+[actiontype_multiport]
+
+actionstart = firewall-cmd --direct --add-rule <family> filter <ipmset> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
+actionstop = firewall-cmd --direct --remove-rule <family> filter <ipmset> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
 
 [Init]
 
@@ -93,20 +118,14 @@ ipsettype = ipset
 # Default: Value of the multiport
 actiontype = <multiport>
 
-# Option: allports
-# Notes.: default addition to block all ports
-# Usage.: use in jail config:  banaction = firewallcmd-ipset[actiontype=<allports>]
-#         for all protocols:   banaction = firewallcmd-ipset[actiontype=""]
-allports = -p <protocol>
-
 # Option: multiport
 # Notes.: addition to block access only to specific ports
 # Usage.: use in jail config:  banaction = firewallcmd-ipset[actiontype=<multiport>]
 multiport = -p <protocol> -m multiport --dports <port>
 
 ipmset = f2b-<name>
-familyopt =
-firewalld_familyopt =
+familyopt = family inet
+firewalld_familyopt = --option=family=inet
 
 [Init?family=inet6]
 
@@ -117,5 +136,5 @@ firewalld_familyopt = --option=family=inet6
 
 # DEV NOTES:
 #
-# Author: Edgar Hoch, Daniel Black, Sergey Brester and Mihail Politaev
+# Author: Edgar Hoch, Daniel Black, Sergey Brester, Mihail Politaev and POQDavid
 # firewallcmd-new / iptables-ipset-proto6 combined for maximium goodness


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file

Added `discord_notifications.conf` so to be able to get notifications of bans, unbans, jails started and stopped
`discord_notifications[webhook=/XXXXXXXXXXXXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX, botname=Fail2Ban, discord_roleid=<id>]`

As for the `firewallcmd-ipset.conf` I did a few changes/improvements to the config and tested them

- Added proper values for `familyopt` and `firewalld_familyopt` for ipv4
- Added separate `actionstart` and `actionstop` for `allports` option which I think is a better way to ban all ports
- Improved `ipstype_firewalld` section a bit
- Added `FORWARD` and `OUTPUT` to firewalld rules to make it a bit stricter

Also was thinking to remove the `ipstype_firewalld` section cause it's not needed at least for iptables
and you have to use `--permanent` flag which also needs `firewall-cmd --reload` command or the changes won't take effect and also when you use that it gets rid of the rest of the rules since they aren't marked permanent not to mention the whole adding IP process would be really slow since you need to reload for each IP and that would take a while if you reboot or restart the Fail2Ban server also I feel like it can cause trouble if there is a large number of IPs getting blocked.

As far as I know, even with nftables firewalld has to use the reload command not sure how it works with the nftables but I don't think it's a good idea to reload for each IP, not 100% sure if I am right so please correct me if I am wrong.