### PR TITLE
add Suricata Fast Log support

### DIFF
--- a/config/filter.d/fast-log-attack-src.conf
+++ b/config/filter.d/fast-log-attack-src.conf
@@ -1,0 +1,13 @@
+#
+# Fast as generated via either Snort or Suricata for grabbing the SRC host for items classified as attacks
+#
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+failregex = \[Classification:.*Attack.*\]\ .* <HOST>:[0-9]+\ \-\>
+ignoreregex =
+datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,
+

--- a/config/filter.d/fast-log-attack-src.conf
+++ b/config/filter.d/fast-log-attack-src.conf
@@ -1,5 +1,5 @@
 #
-# Fast as generated via either Snort or Suricata for grabbing the SRC host for items classified as attacks
+# Fast as generated via either Snort or Suricata for grabbing the SRC host for attacks
 #
 
 [INCLUDES]
@@ -9,5 +9,5 @@ before = common.conf
 [Definition]
 failregex = \[Classification:.*Attack.*\]\ .* <HOST>:[0-9]+\ \-\>
 ignoreregex =
-datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,
+datepattern = ^%%m/%%d/%%Y-%%H:%%M:%%S.%%f
 

--- a/config/filter.d/fast-log-attempted-admin-priv-gain-src.conf
+++ b/config/filter.d/fast-log-attempted-admin-priv-gain-src.conf
@@ -1,0 +1,12 @@
+#
+# Fast as generated via either Snort or Suricata for grabbing the SRC host for attempted admin priv gain
+#
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+failregex = \[Classification\:.*Attempted.*\ [Aa]dministrator.*\ [Pp]rivilege.*\ [Gg]ain.*\]\ .* <HOST>:[0-9]+\ \-\>
+ignoreregex =
+datepattern = ^%%m/%%d/%%Y-%%H:%%M:%%S.%%f

--- a/config/filter.d/fast-log-attempted-info-leak-src.conf
+++ b/config/filter.d/fast-log-attempted-info-leak-src.conf
@@ -1,0 +1,12 @@
+#
+# Fast as generated via either Snort or Suricata for grabbing the SRC host for events classified as attempted info leaks
+#
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+failregex = \[Classification\:.*[Aa]ttempted\ [Ii]nfo.*\ [Ll]eak.*\]\ .* <HOST>:[0-9]+\ \-\>
+ignoreregex =
+datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,

--- a/config/filter.d/fast-log-attempted-info-leak-src.conf
+++ b/config/filter.d/fast-log-attempted-info-leak-src.conf
@@ -1,5 +1,5 @@
 #
-# Fast as generated via either Snort or Suricata for grabbing the SRC host for events classified as attempted info leaks
+# Fast as generated via either Snort or Suricata for grabbing the SRC host for attempted info leaks
 #
 
 [INCLUDES]
@@ -9,4 +9,4 @@ before = common.conf
 [Definition]
 failregex = \[Classification\:.*[Aa]ttempted\ [Ii]nfo.*\ [Ll]eak.*\]\ .* <HOST>:[0-9]+\ \-\>
 ignoreregex =
-datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,
+datepattern = ^%%m/%%d/%%Y-%%H:%%M:%%S.%%f

--- a/config/filter.d/fast-log-invtls-src.conf
+++ b/config/filter.d/fast-log-invtls-src.conf
@@ -9,4 +9,4 @@ before = common.conf
 [Definition]
 failregex = TLS\ invalid\ .*\ <HOST>:[0-9]+\ \-\>
 ignoreregex =
-datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,
+datepattern = ^%%m/%%d/%%Y-%%H:%%M:%%S.%%f

--- a/config/filter.d/fast-log-invtls-src.conf
+++ b/config/filter.d/fast-log-invtls-src.conf
@@ -1,0 +1,12 @@
+#
+# Fast as generated via either Snort or Suricata for grabbing the SRC host for invalid TLS
+#
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+failregex = TLS\ invalid\ .*\ <HOST>:[0-9]+\ \-\>
+ignoreregex =
+datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,

--- a/config/filter.d/fast-log-retrans-src.conf
+++ b/config/filter.d/fast-log-retrans-src.conf
@@ -1,5 +1,5 @@
 #
-# Fast as generated via either Snort or Suricata for grabbing the SRC host info events involving excesive retransmission of packets
+# Fast as generated via either Snort or Suricata for grabbing the SRC host for attacks
 #
 
 [INCLUDES]
@@ -9,4 +9,4 @@ before = common.conf
 [Definition]
 failregex = [Ee]xcessive\ [Rr]etransmissions\ .*\[Classification\:\ Generic\ Protocol\ Command\ Decode\].* <HOST>:[0-9]+\ \-\>
 ignoreregex =
-datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,
+datepattern = ^%%m/%%d/%%Y-%%H:%%M:%%S.%%f

--- a/config/filter.d/fast-log-retrans-src.conf
+++ b/config/filter.d/fast-log-retrans-src.conf
@@ -1,0 +1,12 @@
+#
+# Fast as generated via either Snort or Suricata for grabbing the SRC host info events involving excesive retransmission of packets
+#
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+failregex = [Ee]xcessive\ [Rr]etransmissions\ .*\[Classification\:\ Generic\ Protocol\ Command\ Decode\].* <HOST>:[0-9]+\ \-\>
+ignoreregex =
+datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,

--- a/config/filter.d/fast-log-scan-src.conf
+++ b/config/filter.d/fast-log-scan-src.conf
@@ -1,0 +1,13 @@
+#
+# Fast as generated via either Snort or Suricata for grabbing the SRC host for scans
+#
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+failregex = \[Classification:.*[Ss][Cc][Aa][Nn].*\ <HOST>:[0-9]+\ \-\>
+ignoreregex =
+datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,
+

--- a/config/filter.d/fast-log-scan-src.conf
+++ b/config/filter.d/fast-log-scan-src.conf
@@ -9,5 +9,5 @@ before = common.conf
 [Definition]
 failregex = \[Classification:.*[Ss][Cc][Aa][Nn].*\ <HOST>:[0-9]+\ \-\>
 ignoreregex =
-datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,
+datepattern = ^%%m/%%d/%%Y-%%H:%%M:%%S.%%f
 

--- a/config/filter.d/fast-log-sslbl-src.conf
+++ b/config/filter.d/fast-log-sslbl-src.conf
@@ -1,0 +1,13 @@
+#
+# Fast as generated via either Snort or Suricata for grabbing the SRC host for known bad SSL cert
+#
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+failregex = \]\ SSLBL\:.*\[Classification\:.* <HOST>:[0-9]+\ \-\>
+ignoreregex =
+datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,
+

--- a/config/filter.d/fast-log-sslbl-src.conf
+++ b/config/filter.d/fast-log-sslbl-src.conf
@@ -1,5 +1,5 @@
 #
-# Fast as generated via either Snort or Suricata for grabbing the SRC host for known bad SSL cert
+# Fast as generated via either Snort or Suricata for grabbing the SRC host for known bad SSL
 #
 
 [INCLUDES]
@@ -9,5 +9,5 @@ before = common.conf
 [Definition]
 failregex = \]\ SSLBL\:.*\[Classification\:.* <HOST>:[0-9]+\ \-\>
 ignoreregex =
-datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,
+datepattern = ^%%m/%%d/%%Y-%%H:%%M:%%S.%%f
 

--- a/config/filter.d/fast-log-wrong-proto.conf
+++ b/config/filter.d/fast-log-wrong-proto.conf
@@ -1,8 +1,6 @@
 #
 # Fast as generated via either Snort or Suricata for grabbing the SRC host for when the app layer does not match in both directions
 #
-# This match is restricted to ports it with a high likely hood of not generating possible false positives.
-#
 
 [INCLUDES]
 
@@ -11,5 +9,5 @@ before = common.conf
 [Definition]
 failregex = [Aa]pplayer\ [Mm]ismatch\ protocol\ both\ directions\ .* <HOST>:[0-9]+\ \-\>\ [0-9AaBbCcDdEeFf\:\.]+:(21|25|53|67|68|80|110|123|139|161|443|445|465|587|3389|5060|5900|5901|5902|5903|5904|5905|5906|5907|5908|5909)
 ignoreregex =
-datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,
+datepattern = ^%%m/%%d/%%Y-%%H:%%M:%%S.%%f
 

--- a/config/filter.d/fast-log-wrong-proto.conf
+++ b/config/filter.d/fast-log-wrong-proto.conf
@@ -1,0 +1,15 @@
+#
+# Fast as generated via either Snort or Suricata for grabbing the SRC host for when the app layer does not match in both directions
+#
+# This match is restricted to ports it with a high likely hood of not generating possible false positives.
+#
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+failregex = [Aa]pplayer\ [Mm]ismatch\ protocol\ both\ directions\ .* <HOST>:[0-9]+\ \-\>\ [0-9AaBbCcDdEeFf\:\.]+:(21|25|53|67|68|80|110|123|139|161|443|445|465|587|3389|5060|5900|5901|5902|5903|5904|5905|5906|5907|5908|5909)
+ignoreregex =
+datapattern = {^LN-BEG}%%m/%%d/%%Y-%%H:%%M:%%S,
+

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -978,3 +978,72 @@ banaction = %(banaction_allports)s
 [monitorix]
 port	= 8080
 logpath = /var/log/monitorix-httpd
+
+
+# These next several focus on the fast log produced
+# by snort and optionally Suricata, although more
+# focused on Suricata and available rulesets via
+# suricata-update.
+#
+# et/open
+[fast-log-attack-src]
+filter = fast-log-attack-src
+logpath = %(suricata_fast_log)s
+maxretry=1
+bantime  = 120m
+
+# base Suricata rule set
+[fast-log-wrong-proto]
+filter = fast-log-wrong-proto
+logpath = %(suricata_fast_log)s
+maxretry=1
+bantime  = 120m
+
+# et/open
+[fast-log-scan-src]
+filter = fast-log-scan-src
+logpath = %(suricata_fast_log)s
+maxretry=1
+bantime  = 120m
+
+# sslbl/ssl-fp-blacklist and sslbl/ja3-fingerprints
+[fast-log-sslbl-src]
+filter = fast-log-sslbl-src
+logpath = %(suricata_fast_log)s
+maxretry=1
+bantime  = 120m
+
+# tgreen/hunting and et/open
+[fast-log-ail-src]
+filter = fast-log-attempted-info-leak-src
+logpath = %(suricata_fast_log)s
+maxretry=1
+bantime  = 120m
+
+# tgreen/hunting and et/open
+[fast-log-aapg-src]
+filter = fast-log-attempted-admin-priv-gain-src
+logpath = %(suricata_fast_log)s
+maxretry=1
+bantime  = 120m
+
+# !!! WARNING !!!
+# Decent chance of possible false positives for the
+# next two for when it comes to malicious traffic v.
+# badly configured clients etc, enable carefully
+# or maybe consider restricting ports to like 25 and
+# similar as well as maybe upping max retries notably
+#
+# base Suricata rule set
+[fast-log-retrans-src]
+filter = fast-log-retrans-src
+logpath = %(suricata_fast_log)s
+maxretry=2
+bantime  = 120m
+
+# base Suricata rule set
+[fast-log-invtls-src]
+filter = fast-log-invtls-src
+logpath = %(suricata_fast_log)s
+maxretry=2
+bantime  = 120m

--- a/config/paths-common.conf
+++ b/config/paths-common.conf
@@ -91,3 +91,13 @@ mysql_log = %(syslog_daemon)s
 mysql_backend = %(default_backend)s
 
 roundcube_errors_log = /var/log/roundcube/errors
+
+# Requires enabling in the config via adding the output to the outputs
+# section of Suricata's config yaml.
+#
+#   - fast:
+#      enabled: yes
+#      filename: fast.log
+#      append: yes
+#
+suricata_fast_log = /var/log/suricata/fast.log

--- a/fail2ban/tests/files/logs/fast-log-attack-src
+++ b/fail2ban/tests/files/logs/fast-log-attack-src
@@ -1,0 +1,3 @@
+10/08/2022-19:55:04.165078  [**] [1:2403373:77918] ET CINS Active Threat Intelligence Poor Reputation IP group 74 [**] [Classification: Misc Attack] [Priority: 2] {TCP} 78.128.113.250:40927 -> 192.168.14.42:31408
+10/08/2022-20:02:09.229370  [**] [1:2403367:77918] ET CINS Active Threat Intelligence Poor Reputation IP group 68 [**] [Classification: Misc Attack] [Priority: 2] {UDP} 65.49.20.117:5178 -> 192.168.14.42:53
+10/08/2022-20:10:56.351896  [**] [1:2403367:77918] ET CINS Active Threat Intelligence Poor Reputation IP group 68 [**] [Classification: Misc Attack] [Priority: 2] {TCP} 65.49.20.73:45552 -> 192.168.14.42:443

--- a/fail2ban/tests/files/logs/fast-log-attempted-admin-priv-gain-src
+++ b/fail2ban/tests/files/logs/fast-log-attempted-admin-priv-gain-src
@@ -1,0 +1,5 @@
+10/06/2022-22:29:51.168508  [**] [1:2019309:4] ET WEB_SERVER WGET Command Specifying Output in HTTP Headers [**] [Classification: Attempted Administrator Privilege Gain] [Priority: 1] {TCP} 185.216.71.182:57282 -> 192.168.14.42:80
+10/06/2022-22:29:51.168508  [**] [1:2020899:5] ET EXPLOIT D-Link Devices Home Network Administration Protocol Command Execution [**] [Classification: Attempted Administrator Privilege Gain] [Priority: 1] {TCP} 185.216.71.182:57282 -> 192.168.14.42:80
+10/08/2022-19:15:19.299994  [**] [1:2009363:10] ET HUNTING Suspicious Chmod Usage in URI (Inbound) [**] [Classification: Attempted Administrator Privilege Gain] [Priority: 1] {TCP} 195.178.120.33:44942 -> 192.168.14.42:80
+10/04/2022-03:30:44.151242  [**] [1:2025883:3] ET EXPLOIT MVPower DVR Shell UCE [**] [Classification: Attempted Administrator Privilege Gain] [Priority: 1] {TCP} 156.204.203.37:33016 -> 192.168.14.42:80
+

--- a/fail2ban/tests/files/logs/fast-log-attempted-info-leak-src
+++ b/fail2ban/tests/files/logs/fast-log-attempted-info-leak-src
@@ -1,0 +1,3 @@
+10/07/2022-20:25:42.195149  [**] [1:2100257:10] GPL DNS named version attempt [**] [Classification: Attempted Information Leak] [Priority: 2] {TCP} 45.83.66.17:64614 -> 192.168.14.42:53
+10/07/2022-19:52:48.943767  [**] [1:2023753:3] ET SCAN MS Terminal Server Traffic on Non-standard Port [**] [Classification: Attempted Information Leak] [Priority: 2] {TCP} 185.190.24.102:64537 -> 192.168.14.42:8448
+10/07/2022-01:26:53.845306  [**] [1:2019418:6] ET EXPLOIT SSL excessive fatal alerts (possible POODLE attack against server) [**] [Classification: Attempted Information Leak] [Priority: 2] {TCP} 192.168.14.42:443 -> 18.234.254.127:38304

--- a/fail2ban/tests/files/logs/fast-log-invtls-src
+++ b/fail2ban/tests/files/logs/fast-log-invtls-src
@@ -1,0 +1,4 @@
+10/06/2022-20:07:59.234800  [**] [1:2230003:1] SURICATA TLS invalid handshake message [**] [Classification: Generic Protocol Command Decode] [Priority: 3] {TCP} 165.22.18.14:45666 -> 192.168.14.42:443
+10/06/2022-20:07:59.234800  [**] [1:2230010:1] SURICATA TLS invalid record/traffic [**] [Classification: Generic Protocol Command Decode] [Priority: 3] {TCP} 165.22.18.14:45666 -> 192.168.14.42:443
+10/06/2022-19:04:16.822978  [**] [1:2230003:1] SURICATA TLS invalid handshake message [**] [Classification: Generic Protocol Command Decode] [Priority: 3] {TCP} 87.236.176.146:56949 -> 192.168.14.42:443
+10/06/2022-19:04:16.822978  [**] [1:2230010:1] SURICATA TLS invalid record/traffic [**] [Classification: Generic Protocol Command Decode] [Priority: 3] {TCP} 87.236.176.146:56949 -> 192.168.14.42:443

--- a/fail2ban/tests/files/logs/fast-log-retrans-src
+++ b/fail2ban/tests/files/logs/fast-log-retrans-src
@@ -1,0 +1,5 @@
+10/01/2022-17:52:17.892262  [**] [1:2210054:1] SURICATA STREAM excessive retransmissions [**] [Classification: Generic Protocol Command Decode] [Priority: 3] {TCP} 117.26.89.136:55566 -> 192.168.14.42:25
+10/01/2022-16:08:38.378238  [**] [1:2210054:1] SURICATA STREAM excessive retransmissions [**] [Classification: Generic Protocol Command Decode] [Priority: 3] {TCP} 27.30.19.131:55464 -> 192.168.14.42:25
+10/01/2022-13:28:18.232180  [**] [1:2210054:1] SURICATA STREAM excessive retransmissions [**] [Classification: Generic Protocol Command Decode] [Priority: 3] {TCP} 121.205.230.234:57468 -> 192.168.14.42:25
+
+

--- a/fail2ban/tests/files/logs/fast-log-scan-src
+++ b/fail2ban/tests/files/logs/fast-log-scan-src
@@ -1,0 +1,2 @@
+10/08/2022-03:32:12.984300  [**] [1:2029054:2] ET SCAN Zmap User-Agent (Inbound) [**] [Classification: Detection of a Network Scan] [Priority: 3] {TCP} 192.241.206.226:51308 -> 192.168.14.42:443
+10/08/2022-09:27:48.261773  [**] [1:2031505:1] ET SCAN WordPress Scanner Performing Multiple Requests to Windows Live Writer XML [**] [Classification: Detection of a Network Scan] [Priority: 3] {TCP} 65.21.138.118:57045 -> 192.168.14.42:80

--- a/fail2ban/tests/files/logs/fast-log-sslbl-src
+++ b/fail2ban/tests/files/logs/fast-log-sslbl-src
@@ -1,0 +1,3 @@
+10/07/2022-21:21:36.712370  [**] [1:906200068:1] SSLBL: Malicious JA3 SSL-Client Fingerprint detected (CoinMiner) [**] [Classification: (null)] [Priority: 3] {TCP} 5.255.253.154:57896 -> 192.168.14.42:443
+10/08/2022-04:10:48.547474  [**] [1:906200006:1] SSLBL: Malicious JA3 SSL-Client Fingerprint detected (Tofsee) [**] [Classification: (null)] [Priority: 3] {TCP} 128.1.42.90:23264 -> 192.168.14.42:443
+10/07/2022-04:05:04.250157  [**] [1:906200068:1] SSLBL: Malicious JA3 SSL-Client Fingerprint detected (CoinMiner) [**] [Classification: (null)] [Priority: 3] {TCP} 87.250.224.105:65394 -> 192.168.14.42:443

--- a/fail2ban/tests/files/logs/fast-log-wrong-proto
+++ b/fail2ban/tests/files/logs/fast-log-wrong-proto
@@ -1,0 +1,3 @@
+10/08/2022-18:11:22.963923  [**] [1:2260000:1] SURICATA Applayer Mismatch protocol both directions [**] [Classification: Generic Protocol Command Decode] [Priority: 3] {TCP} 138.197.151.131:47936 -> 192.168.14.42:80
+10/06/2022-05:19:07.765532  [**] [1:2260000:1] SURICATA Applayer Mismatch protocol both directions [**] [Classification: Generic Protocol Command Decode] [Priority: 3] {TCP} 167.99.40.147:36782 -> 192.168.14.42:2222
+10/08/2022-16:18:19.835838  [**] [1:2260000:1] SURICATA Applayer Mismatch protocol both directions [**] [Classification: Generic Protocol Command Decode] [Priority: 3] {TCP} 222.186.19.235:38354 -> 192.168.14.42:80


### PR DESCRIPTION
Issue resolved is the lack of support for the fast.log produced by the likes of Suricata. This adds the required filters and some example jails using those filters.


Before submitting your PR, please review the following checklist:

- [X] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [X] **CONSIDER adding a unit test** if your PR resolves an issue
- [X] **LIST ISSUES** this PR resolves
- [X] **MAKE SURE** this PR doesn't break existing tests
- [X] **KEEP PR small** so it could be easily reviewed.
- [X] **AVOID** making unnecessary stylistic changes in unrelated code
- [X] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
