### PR TITLE
Fix Cloudflare unbanip bugs

### DIFF
--- a/config/action.d/cloudflare-token.conf
+++ b/config/action.d/cloudflare-token.conf
@@ -50,15 +50,16 @@ actionban = curl -s -X POST "<_cf_api_url>" \
 #          <time>  unix timestamp of the ban time
 # Values:  CMD
 #
-actionunban = id=$(curl -s -X GET "<_cf_api_url>?mode=<cfmode>&notes=<notes>&configuration.target=<cftarget>&configuration.value=<ip>" \
-                       <_cf_api_prms> \
-                       | awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/'id'\042/){print $(i+1)}}}' \
-                       | tr -d ' "' \
-                       | head -n 1)
-              if [ -z "$id" ]; then echo "<name>: id for <ip> cannot be found using target <cftarget>"; exit 0; fi; \
-              curl -s -X DELETE "<_cf_api_url>/$id" \
-                  <_cf_api_prms> \
-                  --data '{"cascade": "none"}'
+actionunban = id=$(curl -s -X GET \
+              --data-urlencode "mode=<cfmode>" \
+              --data-urlencode "notes=<notes>" \
+              --data-urlencode "configuration.target=<cftarget>" \
+              --data-urlencode "configuration.value=<ip>" \
+               <_cf_api_url> \
+               <_cf_api_prms> \
+		| jq -r '.result[] | select( .mode == "<cfmode>" and .notes == "<notes>" and .configuration.target == "<cftarget>" and .configuration.value == "<ip>") | .id')              
+		if [ -z "$id" ]; then echo "<name>: id for <ip> cannot be found"; exit 0; fi;
+              	curl -s -o /dev/null -X DELETE <_cf_api_prms> "<_cf_api_url>/$id"
 
 _cf_api_url = https://api.cloudflare.com/client/v4/zones/<cfzone>/firewall/access_rules/rules
 _cf_api_prms = -H "Authorization: Bearer <cftoken>" -H "Content-Type: application/json"
@@ -69,11 +70,11 @@ _cf_api_prms = -H "Authorization: Bearer <cftoken>" -H "Content-Type: applicatio
 
 # The Cloudflare <ZONE_ID> of hte domain you want to manage.
 #
-# cfzone =
+#cfzone =
 
 # Your personal Cloudflare token.  Ideally restricted to just have "Zone.Firewall Services" permissions.
 #
-# cftoken =
+#cftoken =
 
 # Target of the firewall rule.  Default is "ip" (v4).
 #
@@ -90,3 +91,4 @@ notes = Fail2Ban <name>
 
 [Init?family=inet6]
 cftarget = ip6
+

--- a/config/action.d/cloudflare.conf
+++ b/config/action.d/cloudflare.conf
@@ -44,7 +44,7 @@ actioncheck =
 #actionban = curl -s -o /dev/null https://www.cloudflare.com/api_json.html -d 'a=ban' -d 'tkn=<cftoken>' -d 'email=<cfuser>' -d 'key=<ip>'
 # API v4
 actionban = curl -s -o /dev/null -X POST <_cf_api_prms> \
-            -d '{"mode":"block","configuration":{"target":"<cftarget>","value":"<ip>"},"notes":"Fail2Ban <name>"}' \
+            -d '{"mode":"<cfmode>","configuration":{"target":"<cftarget>","value":"<ip>"},"notes":"<notes>"}' \
             <_cf_api_url>
 
 # Option:  actionunban
@@ -58,11 +58,16 @@ actionban = curl -s -o /dev/null -X POST <_cf_api_prms> \
 # API v1
 #actionunban = curl -s -o /dev/null https://www.cloudflare.com/api_json.html -d 'a=nul' -d 'tkn=<cftoken>' -d 'email=<cfuser>' -d 'key=<ip>'
 # API v4
-actionunban = id=$(curl -s -X GET <_cf_api_prms> \
-                   "<_cf_api_url>?mode=block&configuration_target=<cftarget>&configuration_value=<ip>&page=1&per_page=1&notes=Fail2Ban%%20<name>" \
-                   | { jq -r '.result[0].id' 2>/dev/null || tr -d '\n' | sed -nE 's/^.*"result"\s*:\s*\[\s*\{\s*"id"\s*:\s*"([^"]+)".*$/\1/p'; })
-              if [ -z "$id" ]; then echo "<name>: id for <ip> cannot be found"; exit 0; fi;
-              curl -s -o /dev/null -X DELETE <_cf_api_prms> "<_cf_api_url>/$id"
+actionunban = id=$(curl -s -X GET \
+              --data-urlencode "mode=<cfmode>" \
+              --data-urlencode "notes=<notes>" \
+              --data-urlencode "configuration.target=<cftarget>" \
+              --data-urlencode "configuration.value=<ip>" \
+               <_cf_api_url> \
+               <_cf_api_prms> \
+        | jq -r '.result[] | select( .mode == "<cfmode>" and .notes == "<notes>" and .configuration.target == "<cftarget>" and .configuration.value == "<ip>") | .id')              
+        if [ -z "$id" ]; then echo "<name>: id for <ip> cannot be found"; exit 0; fi;
+                curl -s -o /dev/null -X DELETE <_cf_api_prms> "<_cf_api_url>/$id"
 
 _cf_api_url = https://api.cloudflare.com/client/v4/user/firewall/access_rules/rules
 _cf_api_prms = -H 'X-Auth-Email: <cfuser>' -H 'X-Auth-Key: <cftoken>' -H 'Content-Type: application/json'
@@ -77,6 +82,16 @@ _cf_api_prms = -H 'X-Auth-Email: <cfuser>' -H 'X-Auth-Key: <cftoken>' -H 'Conten
 # cfemail  = 
 # # Your CF API Key
 # cfapikey = 
+
+# The firewall mode Cloudflare should use.  Default is "block" (deny access).
+# Consider also "js_challenge" or other "allowed_modes" if you want.
+#
+cfmode = block
+
+# The message to include in the firewall IP banning rule.
+#
+notes = Fail2Ban <name>
+
 
 cftoken =
 


### PR DESCRIPTION
Fix bug in Cloudflare-token.conf（unbanip not working.） When your CloudFlare already has some Rules Fix bug of unbanip. When Cloudflare already contains some rules, unbanip from Cloudflare-token.conf and Cloudflare.conf cannot find the rule and delete it.

Before submitting your PR, please review the following checklist:

- [ ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [ ] **KEEP PR small** so it could be easily reviewed.
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
