### PR TITLE
Fix PF so it will actually kill the session so the ban takes place

### DIFF
--- a/config/action.d/pf.conf
+++ b/config/action.d/pf.conf
@@ -66,7 +66,7 @@ actioncheck = <pfctl> -sr | grep -q <tablename>-<name>
 #          <time>  unix timestamp of the ban time
 # Values:  CMD
 #
-actionban = <pfctl> -t <tablename>-<name> -T add <ip>
+actionban = <pfctl> -t <tablename>-<name> -T add <ip> | pfctl -k <ip>
 
 
 # Option:  actionunban


### PR DESCRIPTION
Currently PF support is slightly broken. A abusive IP can continue it's action even if it is banned as the state is still good. Fixing this requires calling `pfctl -k <ip>` to kill the states for that IP.

Noticed this when I saw it was constantly failing to ban IPs attempting to use a DNS server for a amp attack. Suricata was flagging it and F2B was shoving the IP into the table, but because it had a existing state the ban would not come into affect.


Before submitting your PR, please review the following checklist:

- [X] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [X] **CONSIDER adding a unit test** if your PR resolves an issue
- [X] **LIST ISSUES** this PR resolves
- [X] **MAKE SURE** this PR doesn't break existing tests
- [X] **KEEP PR small** so it could be easily reviewed.
- [X] **AVOID** making unnecessary stylistic changes in unrelated code
- [X] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
