### PR TITLE
Fixed the pattern to work with Dante v1.4.2 and tested on the real Dante instance under Ubuntu 22.04.1 LTS

### DIFF
--- a/config/filter.d/dante.conf
+++ b/config/filter.d/dante.conf
@@ -1,7 +1,8 @@
 # Fail2Ban filter for dante
 #
-# Make sure you have "log: error" set in your "client pass" directive
-#
+# Make sure you have "log: error" set in your dante config "client pass" directive to ban by invalid credentials,
+# and "log: connect error" in your "client block" directive to ban by invalid IPs
+
 
 [INCLUDES]
 before = common.conf
@@ -9,7 +10,7 @@ before = common.conf
 [Definition]
 _daemon = danted
 
-failregex = ^%(__prefix_line)sinfo: block\(1\): tcp/accept \]: <HOST>\.\d+ [\d.]+: error after reading \d+ bytes? in \d+ seconds?: (?:could not access |system password authentication failed for )user "<F-USER>[^"]+</F-USER>"
+failregex = ^%(__prefix_line)sinfo: block\(\d+\): tcp/accept \]: <HOST>\.\d+ [\d.]+(?:: error after reading \d+ bytes? in \d+ seconds?: (?:could not access |system password authentication failed for )user "<F-USER>[^"]+</F-USER>")?
 
 [Init]
 journalmatch = _SYSTEMD_UNIT=danted.service


### PR DESCRIPTION
Fixed the pattern to work with Dante v1.4.2 and tested on the real Dante instance under Ubuntu 22.04.1 LTS.

Please see the real examples of the log lines (danted is configured to log to syslog (journalctl)), the hostnames, usernames and IPs are redacted:
```
Nov 19 21:03:46 srv danted[3360179]: info: block(4): tcp/accept ]: 198.51.100.55.58211 198.51.100.83.52483
Nov 19 21:12:57 srv danted[3374579]: info: block(1): tcp/accept ]: 212.28.70.169.8490 198.51.100.83.52483: error after reading 31 bytes in 2 seconds: pam_authenticate() for user "socks5_user" failed: Authentication failure
Nov 19 21:12:57 srv danted[3374579]: info: block(1): tcp/accept ]: 212.28.70.169.8494 198.51.100.83.52483: error after reading 3 bytes in 1 second: eof from local client
```
The string 2 and 3 did match (blocking by invalid user or other failure after connecting), but the string 1 (blocking by IP) not. Therefore, this pull request addresses the issue.