### PR TITLE
Fixed docs: Added missing escape backslash in documentation tip

### DIFF
--- a/FILTERS
+++ b/FILTERS
@@ -270,7 +270,7 @@ Take note of  -l heavydebug  / -l debug  and -v as they might be very useful.
      call graphs and can browse different versions.
 
 .. TIP::
-     Some applications log spaces at the end. If you are not sure add \s*$ as
+     Some applications log spaces at the end. If you are not sure add \\s*$ as
      the end part of the regex.
 
 If your regex is not matching, http://www.debuggex.com/?flavor=python can help


### PR DESCRIPTION
 Added missing \\ in documentation tip
![image](https://user-images.githubusercontent.com/80390413/204340718-8b7b9756-da22-4cc5-803a-3e74aeccbd24.png)