### PR TITLE
enrich ip information from internetdb.shodan.io

### DIFF
--- a/config/action.d/shodan-internetdb.conf
+++ b/config/action.d/shodan-internetdb.conf
@@ -1,0 +1,46 @@
+# Fail2ban configuration file
+# Action to get IP information from internetdb.shodan.io.
+# Shodan provides IP properties: cpes, hostnames, open ports, tags and vulnerabilities for free.
+#
+# IMPORTANT:
+# Action get IP details and save it to /etc/fail2ban/jail.d/fail2ban-shodan-internetdb.csv. 
+# Please ensure you have this repository.
+
+[Definition]
+
+# bypass action for restored tickets
+norestored = 1
+
+# Option:  actionstart
+# Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
+# Values:  CMD
+#
+actionstart = [ -f /etc/fail2ban/jail.d/fail2ban-shodan-internetdb.csv ] && printf  "Internetdb file exists." || echo -n "ip,cpes,tags,hostnames,ports,vulns," > /etc/fail2ban/jail.d/fail2ban-shodan-internetdb.csv
+
+# Option:  actionstop
+# Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
+# Values:  CMD
+#
+actionstop =
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+actioncheck =
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionban = if grep -q '<ip>' /etc/fail2ban/jail.d/fail2ban-shodan-internetdb.csv; then printf  "Already Have"; else status_code=$(curl -o /dev/null --write-out %%{http_code} -s "https://internetdb.shodan.io/<ip>"); if [ $status_code == 200 ]; then for word in tags cpes hostnames ports vulns; do curl -s "https://internetdb.shodan.io/<ip>" | grep -Po "\"$word\":\K\[(.*?)\]" | tr "\n" "," | sed "s/\"/\"\"/g" | sed "s/\[/\"[/g" |  sed "s/\]/\]\"/g"; done >> /etc/fail2ban/jail.d/fail2ban-shodan-internetdb.csv | printf  "\n<ip>," >> /etc/fail2ban/jail.d/fail2ban-shodan-internetdb.csv; else printf "\n<ip>,,,,,," >> /etc/fail2ban/jail.d/fail2ban-shodan-internetdb.csv; fi; fi
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionunban = sed -i '/<ip>/d' /etc/fail2ban/jail.d/fail2ban-shodan-internetdb.csv


### PR DESCRIPTION
Action `shodan-internetdb` adds open ports, vulnerabilities and other information to IPs when being banned. The result is save to _/etc/fail2ban/jail.d/fail2ban-shodan-internetdb.csv_.
`shodan-internetdb` use the free [InternetDB API](https://internetdb.shodan.io/) that is available to everybody and doesn't require an API key.