### PR TITLE
GeoIP ignore support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Optional:
 - [systemd >= 204](http://www.freedesktop.org/wiki/Software/systemd) and python bindings:
   * [python-systemd package](https://www.freedesktop.org/software/systemd/python-systemd/index.html)
 - [dnspython](http://www.dnspython.org/)
+- [geoiplookup](https://linux.die.net/man/1/geoiplookup)
 
 
 To install:

--- a/fail2ban/client/beautifier.py
+++ b/fail2ban/client/beautifier.py
@@ -147,6 +147,14 @@ class Beautifier:
 					for ip in response[:-1]:
 						msg += "|- " + ip + "\n"
 					msg += "`- " + response[-1]
+			elif inC[2] in ("ignoregeo", "addignoregeo", "delignoregeo"):
+				if len(response) == 0:
+					msg = "No GEO location is ignored"
+				else:
+					msg = "These GEO locations are ignored:\n"
+					for geo in response[:-1]:
+						msg += "|- " + geo + "\n"
+					msg += "`- " + response[-1]
 			elif inC[2] in ("failregex", "addfailregex", "delfailregex",
 							"ignoreregex", "addignoreregex", "delignoreregex"):
 				if len(response) == 0:

--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -108,6 +108,7 @@ class JailReader(ConfigReader):
 		"ignorecommand": ["string", None],
 		"ignoreself": ["bool", None],
 		"ignoreip": ["string", None],
+		"ignoregeoapi": ["string", None],
 		"ignoregeo": ["string", None],
 		"ignorecache": ["string", None],
 		"filter": ["string", ""],

--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -108,6 +108,7 @@ class JailReader(ConfigReader):
 		"ignorecommand": ["string", None],
 		"ignoreself": ["bool", None],
 		"ignoreip": ["string", None],
+		"ignoregeo": ["string", None],
 		"ignorecache": ["string", None],
 		"filter": ["string", ""],
 		"logtimezone": ["string", None],
@@ -264,6 +265,8 @@ class JailReader(ConfigReader):
 				backend = value
 			elif opt == "ignoreip":
 				stream.append(["set", self.__name, "addignoreip"] + splitwords(value))
+			elif opt == "ignoregeo":
+				stream.append(["set", self.__name, "addignoregeo"] + splitwords(value))
 			elif opt not in JailReader._ignoreOpts:
 				stream.append(["set", self.__name, opt, value])
 		# consider options order (after other options):

--- a/fail2ban/client/jailreader.py
+++ b/fail2ban/client/jailreader.py
@@ -108,7 +108,6 @@ class JailReader(ConfigReader):
 		"ignorecommand": ["string", None],
 		"ignoreself": ["bool", None],
 		"ignoreip": ["string", None],
-		"ignoregeoapi": ["string", None],
 		"ignoregeo": ["string", None],
 		"ignorecache": ["string", None],
 		"filter": ["string", ""],

--- a/fail2ban/protocol.py
+++ b/fail2ban/protocol.py
@@ -131,6 +131,7 @@ protocol = [
 ["get <JAIL> journalmatch", "gets the journal filter match for <JAIL>"],
 ["get <JAIL> ignoreself", "gets the current value of the ignoring the own IP addresses"],
 ["get <JAIL> ignoreip", "gets the list of ignored IP addresses for <JAIL>"],
+["get <JAIL> ignoregeo", "gets the list of ignored GEO locations for <JAIL>"],
 ["get <JAIL> ignorecommand", "gets ignorecommand of <JAIL>"],
 ["get <JAIL> failregex", "gets the list of regular expressions which matches the failures for <JAIL>"],
 ["get <JAIL> ignoreregex", "gets the list of regular expressions which matches patterns to ignore for <JAIL>"],

--- a/fail2ban/protocol.py
+++ b/fail2ban/protocol.py
@@ -88,6 +88,8 @@ protocol = [
 ["set <JAIL> ignoreself true|false", "allows the ignoring of own IP addresses"], 
 ["set <JAIL> addignoreip <IP>", "adds <IP> to the ignore list of <JAIL>"], 
 ["set <JAIL> delignoreip <IP>", "removes <IP> from the ignore list of <JAIL>"], 
+["set <JAIL> addignoregeo <GEO>", "adds <GEO> to the ignore list of <JAIL>"], 
+["set <JAIL> delignoregeo <GEO>", "removes <GEO> from the ignore list of <JAIL>"], 
 ["set <JAIL> ignorecommand <VALUE>", "sets ignorecommand of <JAIL>"],
 ["set <JAIL> ignorecache <VALUE>", "sets ignorecache of <JAIL>"],
 ["set <JAIL> addlogpath <FILE> ['tail']", "adds <FILE> to the monitoring list of <JAIL>, optionally starting at the 'tail' of the file (default 'head')."], 

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -86,6 +86,8 @@ class Filter(JailThread):
 		## The ignore IP list.
 		self.__ignoreIpSet = set()
 		self.__ignoreIpList = []
+		# GEO-IP database api endpoint
+		self.__ignoreGeoApi = None
 		## The ignore GEO ip list.
 		self.__ignoreGeoSet = set()
 		## External command
@@ -545,6 +547,19 @@ class Filter(JailThread):
 
 	def getIgnoreIP(self):
 		return self.__ignoreIpList + list(self.__ignoreIpSet)
+
+	def setIgnoreGEOAPI(self, api):
+		if api == "":
+			return
+		
+		if self.__ignoreGeoApi:
+			logSys.log(logging.MSG, "  GEO API was already set to %r and will be changed.", self.__ignoreGeoApi)
+
+		logSys.debug("  Set %r as GEO API endpoint", api)
+		self.__ignoreGeoApi = api
+
+	def getIgnoreGEOAPI(self):
+		return self.__ignoreGeoApi
 
 	def addIgnoreGEO(self, geo):
 		# An empty string is always false

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -616,7 +616,7 @@ class Filter(JailThread):
 		response = urlopen(httprequest)
 		geoipcc = json.loads(response.read().decode())['countryCode']
 
-		if response == 200 and geoipcc in self.__ignoreGeoSet:
+		if response.getcode() == 200 and geoipcc in self.__ignoreGeoSet:
 			self.logIgnoreIp(ip, log_ignore, ignore_source="geo-" + geoipcc)
 			return True
 

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -613,7 +613,6 @@ class Filter(JailThread):
 
 		# check if the IP's geolocation is not on geo ignore list
 		httprequest = Request("http://ip-api.com/json/" + str(ip), headers={"Accept": "application/json"})
-
 		response = urlopen(httprequest)
 		geoipcc = json.loads(response.read().decode())['countryCode']
 

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -631,7 +631,7 @@ class Filter(JailThread):
 		response = urlopen(httprequest)
 		geoipcc = json.loads(response.read().decode())['countryCode']
 
-		if response.getcode() == 200 and geoipcc in self.__ignoreGeoSet:
+		if response == 200 and geoipcc in self.__ignoreGeoSet:
 			self.logIgnoreIp(ip, log_ignore, ignore_source="geo-" + geoipcc)
 			return True
 

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -612,12 +612,15 @@ class Filter(JailThread):
 			return True
 
 		# check if the IP's geolocation is not on geo ignore list
-		if shutil.which('geoiplookup'):
-			geoipcc = str(subprocess.check_output(['geoiplookup',str(ip)])).split(" ")[3].replace(",","")
+		if self.__ignoreGeoSet:
+			if shutil.which("geoiplookup"):
+				geoipcc = str(subprocess.check_output(["geoiplookup",str(ip)])).split(" ")[3].replace(",","")
 
-			if geoipcc in self.__ignoreGeoSet:
-				self.logIgnoreIp(ip, log_ignore, ignore_source="geo-" + geoipcc)
-				return True
+				if geoipcc in self.__ignoreGeoSet:
+					self.logIgnoreIp(ip, log_ignore, ignore_source="geo-" + geoipcc)
+					return True
+			else:
+				self._logWarnOnce("_next_geoByTimeWarn", ("Cannot find geoiplookup. Geolocation is unavailable."))
 
 		# check if the IP is covered by ignore IP (in set or in subnet/dns):
 		if ip in self.__ignoreIpSet:

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -29,9 +29,9 @@ import os
 import re
 import sys
 import time
-import json
+import subprocess
+import shutil
 
-from urllib.request import urlopen, Request
 
 from .actions import Actions
 from .failmanager import FailManagerEmpty, FailManager
@@ -612,13 +612,12 @@ class Filter(JailThread):
 			return True
 
 		# check if the IP's geolocation is not on geo ignore list
-		httprequest = Request("http://ip-api.com/json/" + str(ip), headers={"Accept": "application/json"})
-		response = urlopen(httprequest)
-		geoipcc = json.loads(response.read().decode())['countryCode']
+		if shutil.which('geoiplookup'):
+			geoipcc = str(subprocess.check_output(['geoiplookup',str(ip)])).split(" ")[3].replace(",","")
 
-		if response == 200 and geoipcc in self.__ignoreGeoSet:
-			self.logIgnoreIp(ip, log_ignore, ignore_source="geo-" + geoipcc)
-			return True
+			if geoipcc in self.__ignoreGeoSet:
+				self.logIgnoreIp(ip, log_ignore, ignore_source="geo-" + geoipcc)
+				return True
 
 		# check if the IP is covered by ignore IP (in set or in subnet/dns):
 		if ip in self.__ignoreIpSet:

--- a/fail2ban/server/filter.py
+++ b/fail2ban/server/filter.py
@@ -86,8 +86,6 @@ class Filter(JailThread):
 		## The ignore IP list.
 		self.__ignoreIpSet = set()
 		self.__ignoreIpList = []
-		# GEO-IP database api endpoint
-		self.__ignoreGeoApi = None
 		## The ignore GEO ip list.
 		self.__ignoreGeoSet = set()
 		## External command
@@ -547,19 +545,6 @@ class Filter(JailThread):
 
 	def getIgnoreIP(self):
 		return self.__ignoreIpList + list(self.__ignoreIpSet)
-
-	def setIgnoreGEOAPI(self, api):
-		if api == "":
-			return
-		
-		if self.__ignoreGeoApi:
-			logSys.log(logging.MSG, "  GEO API was already set to %r and will be changed.", self.__ignoreGeoApi)
-
-		logSys.debug("  Set %r as GEO API endpoint", api)
-		self.__ignoreGeoApi = api
-
-	def getIgnoreGEOAPI(self):
-		return self.__ignoreGeoApi
 
 	def addIgnoreGEO(self, geo):
 		# An empty string is always false

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -376,6 +376,12 @@ class Server:
 	def getIgnoreIP(self, name):
 		return self.__jails[name].filter.getIgnoreIP()
 
+	def setIgnoreGEOAPI(self, name, api):
+		self.__jails[name].filter.setIgnoreGEOAPI(api)
+
+	def getIgnoreGEOAPI(self, name):
+		self.__jails[name].filter.getIgnoreGEOAPI()
+
 	def addIgnoreGEO(self, name, geo):
 		self.__jails[name].filter.addIgnoreGEO(geo)
 

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -375,6 +375,15 @@ class Server:
 	
 	def getIgnoreIP(self, name):
 		return self.__jails[name].filter.getIgnoreIP()
+
+	def addIgnoreGEO(self, name, geo):
+		self.__jails[name].filter.addIgnoreGEO(geo)
+
+	def delIgnoreGEO(self, name, geo):
+		self.__jails[name].filter.delIgnoreGEO(geo)
+
+	def getIgnoreGEO(self, name):
+		return self.__jails[name].filter.getIgnoreGEO()
 	
 	def addLogPath(self, name, fileName, tail=False):
 		filter_ = self.__jails[name].filter

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -376,12 +376,6 @@ class Server:
 	def getIgnoreIP(self, name):
 		return self.__jails[name].filter.getIgnoreIP()
 
-	def setIgnoreGEOAPI(self, name, api):
-		self.__jails[name].filter.setIgnoreGEOAPI(api)
-
-	def getIgnoreGEOAPI(self, name):
-		self.__jails[name].filter.getIgnoreGEOAPI()
-
 	def addIgnoreGEO(self, name, geo):
 		self.__jails[name].filter.addIgnoreGEO(geo)
 

--- a/fail2ban/server/transmitter.py
+++ b/fail2ban/server/transmitter.py
@@ -463,6 +463,8 @@ class Transmitter:
 			return self.__server.getIgnoreSelf(name)
 		elif command[1] == "ignoreip":
 			return self.__server.getIgnoreIP(name)
+		elif command[1] == "ignoregeo":
+			return self.__server.getIgnoreGEO(name)
 		elif command[1] == "ignorecommand":
 			return self.__server.getIgnoreCommand(name)
 		elif command[1] == "ignorecache":

--- a/fail2ban/server/transmitter.py
+++ b/fail2ban/server/transmitter.py
@@ -235,11 +235,6 @@ class Transmitter:
 			self.__server.delIgnoreIP(name, value)
 			if self.__quiet: return
 			return self.__server.getIgnoreIP(name)
-		elif command[1] == "setignoregeoapi":
-			for value in command[2:]:
-				self.__server.setIgnoreGEOAPI(name, value)
-			if self.__quiet: return
-			return self.__server.getIgnoreGEOAPI(name)
 		elif command[1] == "addignoregeo":
 			for value in command[2:]:
 				self.__server.addIgnoreGEO(name, value)

--- a/fail2ban/server/transmitter.py
+++ b/fail2ban/server/transmitter.py
@@ -235,6 +235,16 @@ class Transmitter:
 			self.__server.delIgnoreIP(name, value)
 			if self.__quiet: return
 			return self.__server.getIgnoreIP(name)
+		elif command[1] == "addignoregeo":
+			for value in command[2:]:
+				self.__server.addIgnoreGEO(name, value)
+			if self.__quiet: return
+			return self.__server.getIgnoreGEO(name)
+		elif command[1] == "delignoregeo":
+			value = command[2]
+			self.__server.delIgnoreGEO(name, value)
+			if self.__quiet: return
+			return self.__server.getIgnoreGEO(name)
 		elif command[1] == "ignorecommand":
 			value = command[2]
 			self.__server.setIgnoreCommand(name, value)

--- a/fail2ban/server/transmitter.py
+++ b/fail2ban/server/transmitter.py
@@ -235,6 +235,11 @@ class Transmitter:
 			self.__server.delIgnoreIP(name, value)
 			if self.__quiet: return
 			return self.__server.getIgnoreIP(name)
+		elif command[1] == "setignoregeoapi":
+			for value in command[2:]:
+				self.__server.setIgnoreGEOAPI(name, value)
+			if self.__quiet: return
+			return self.__server.getIgnoreGEOAPI(name)
 		elif command[1] == "addignoregeo":
 			for value in command[2:]:
 				self.__server.addIgnoreGEO(name, value)

--- a/man/fail2ban-client.1
+++ b/man/fail2ban-client.1
@@ -229,6 +229,14 @@ adds <IP> to the ignore list of
 removes <IP> from the ignore list
 of <JAIL>
 .TP
+\fBset <JAIL> addignoregeo <GEO>\fR
+adds <GEO> to the ignore list of
+<JAIL>
+.TP
+\fBset <JAIL> delignoreigeo <GEO>\fR
+removes <GEO> from the ignore list
+of <JAIL>
+.TP
 \fBset <JAIL> ignorecommand <VALUE>\fR
 sets ignorecommand of <JAIL>
 .TP

--- a/man/fail2ban-client.1
+++ b/man/fail2ban-client.1
@@ -400,6 +400,10 @@ ignoring the own IP addresses
 gets the list of ignored IP
 addresses for <JAIL>
 .TP
+\fBget <JAIL> ignoregeo\fR
+gets the list of ignored GEO
+addresses for <JAIL>
+.TP
 \fBget <JAIL> ignorecommand\fR
 gets ignorecommand of <JAIL>
 .TP

--- a/man/jail.conf.5
+++ b/man/jail.conf.5
@@ -247,7 +247,7 @@ boolean value (default true) indicates the banning of own IP addresses should be
 list of IPs not to ban. They can include a DNS resp. CIDR mask too. The option affects additionally to \fBignoreself\fR (if true) and don't need to contain own DNS resp. IPs of the running host.
 .TP
 .B ignoregeo
-list of GEO location codes of IPs not to ban. The IPs will be queried on specified GEOIP database server.
+list of GEO location codes of IPs not to ban. For this to work, you should have a `geoiplookup` or other program with the same name installed. This feature was only tested with Maxmind's `geoiplookup`.
 .TP
 .B ignorecommand
 command that is executed to determine if the current candidate IP for banning (or failure-ID for raw IDs) should not be banned. The option affects additionally to \fBignoreself\fR and \fBignoreip\fR and will be first executed if both don't hit.

--- a/man/jail.conf.5
+++ b/man/jail.conf.5
@@ -246,6 +246,9 @@ boolean value (default true) indicates the banning of own IP addresses should be
 .B ignoreip
 list of IPs not to ban. They can include a DNS resp. CIDR mask too. The option affects additionally to \fBignoreself\fR (if true) and don't need to contain own DNS resp. IPs of the running host.
 .TP
+.B ignoregeo
+list of GEO location codes of IPs not to ban. The IPs will be queried on specified GEOIP database server.
+.TP
 .B ignorecommand
 command that is executed to determine if the current candidate IP for banning (or failure-ID for raw IDs) should not be banned. The option affects additionally to \fBignoreself\fR and \fBignoreip\fR and will be first executed if both don't hit.
 .br


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [ x ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ x ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ x ] **LIST ISSUES** this PR resolves
- [ x ] **MAKE SURE** this PR doesn't break existing tests
- [ x ] **KEEP PR small** so it could be easily reviewed.
- [ x ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file

Added geoip lookup in filter in method _inIgnoreIPList, which checks the countries that should be ignored in __ignoreGeoSet attribute. The __ignoreGeoSet is managed either by ignoregeo statement in jail config or by addignoregeo/delignoregeo commands. If the IP has geolocation country code from the __ignoreGeoSet the IP is ignored.

This PR was inspired by our implementation in [websupport.sk](https://www.websupport.sk/) that was just hardcoded. It was not sustainable to patch f2b every time a new version was available and it may be a generally good idea to have a geo IP ignore option available.

This will resolve #1854.