### PR TITLE
New filter: routeros-auth.conf

### DIFF
--- a/config/filter.d/routeros-auth.conf
+++ b/config/filter.d/routeros-auth.conf
@@ -1,0 +1,10 @@
+# Fail2Ban filter for failure attempts in MikroTik RouterOS
+#
+#
+
+[Definition]
+
+failregex = ^\s*\S+ system,error,critical login failure for user <F-USER>.*?</F-USER> from <ADDR> via \S+$
+
+# Author: Vit Kabele <vit@kabele.me>
+

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -958,6 +958,9 @@ port    = http,https
 logpath = %(syslog_authpriv)s
 backend = %(syslog_backend)s
 
+[routeros-auth]
+port = ssh,http,https
+logpath = /var/log/MikroTik/router.log
 
 [zoneminder]
 # Zoneminder HTTP/HTTPS web interface auth

--- a/fail2ban/tests/files/logs/routeros-auth
+++ b/fail2ban/tests/files/logs/routeros-auth
@@ -1,0 +1,15 @@
+# RouterOS v7.5
+# failJSON: { "time": "2005-02-15T11:25:46", "match": true , "host": "192.168.88.6", "user": "admin" }
+Feb 15 11:25:46 gw.local system,error,critical login failure for user admin from 192.168.88.6 via web
+
+# RouterOS v7.5
+# failJSON: { "match": false }
+Feb 15 11:26:15 gw.local system,info log rule changed by admin
+
+# RouterOS v7.5
+# failJSON: { "time": "2005-02-15T11:57:42", "match": true , "host": "2001:470:1:c84::24", "user": "" }
+Feb 15 11:57:42 1234.hostname.cz system,error,critical login failure for user  from 2001:470:1:c84::24 via ssh
+
+# RouterOS v7.5
+# failJSON: { "time": "2005-03-02T09:09:46", "match": true , "host": "1.2.3.4", "user": "user with space" }
+Mar  2 09:09:46 gw.local system,error,critical login failure for user user with space from 1.2.3.4 via ssh


### PR DESCRIPTION
Add filter to detect failed login attempts in the log produced by MikroTik RouterOS

- Add test for new filter
- Mention the new filter in jail.conf

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
