### PR TITLE
Update URLs for Gentoo

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -13,7 +13,7 @@ Preparation
 * Check distribution patches and see if they can be included
 
   * https://apps.fedoraproject.org/packages/fail2ban/sources
-  * http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/net-analyzer/fail2ban/
+  * https://gitweb.gentoo.org/repo/gentoo.git/tree/net-analyzer/fail2ban
   * http://svnweb.freebsd.org/ports/head/security/py-fail2ban/
   * https://build.opensuse.org/package/show?package=fail2ban&project=openSUSE%3AFactory
   * http://sophie.zarb.org/sources/fail2ban (Mageia)
@@ -134,7 +134,7 @@ Pre Release
 
   * Gentoo: netmon@gentoo.org
 
-    * http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/net-analyzer/fail2ban/metadata.xml?view=markup
+    * https://gitweb.gentoo.org/repo/gentoo.git/tree/net-analyzer/fail2ban/metadata.xml
     * https://bugs.gentoo.org/buglist.cgi?quicksearch=fail2ban
 
   * openSUSE: Stephan Kulow <coolo@suse.com>

--- a/files/fail2ban-logrotate
+++ b/files/fail2ban-logrotate
@@ -1,7 +1,4 @@
 #
-# Gentoo:
-# http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/net-analyzer/fail2ban/files/fail2ban-logrotate?view=markup
-#
 # Debian:
 # https://github.com/fail2ban/fail2ban/blob/debian/debian/fail2ban.logrotate
 


### PR DESCRIPTION
Gentoo moved from CVS to Git in 2015.

Drop the Gentoo URL from fail2ban-logrotate, because the distro specific config file has been dropped in 2013.

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
