### PR TITLE
fail2ban.service: use RuntimeDirectory instead of hardcoding /run

### DIFF
--- a/files/fail2ban.service.in
+++ b/files/fail2ban.service.in
@@ -7,13 +7,12 @@ PartOf=iptables.service firewalld.service ip6tables.service ipset.service nftabl
 [Service]
 Type=simple
 Environment="PYTHONNOUSERSITE=1"
-ExecStartPre=/bin/mkdir -p /run/fail2ban
 ExecStart=@BINDIR@/fail2ban-server -xf start
 # if should be logged in systemd journal, use following line or set logtarget to sysout in fail2ban.local
 # ExecStart=@BINDIR@/fail2ban-server -xf --logtarget=sysout start
 ExecStop=@BINDIR@/fail2ban-client stop
 ExecReload=@BINDIR@/fail2ban-client reload
-PIDFile=/run/fail2ban/fail2ban.pid
+RuntimeDirectory=fail2ban
 Restart=on-failure
 RestartPreventExitStatus=0 255
 


### PR DESCRIPTION
Also, remove PIDFile option, it's not needed for a Type=simple process run in foreground.

IMHO, fail2ban should not even create the PID file when run with "-f".