### PR TITLE
add filters for mosquitto mqtt broker

### DIFF
--- a/config/filter.d/mosquitto.conf
+++ b/config/filter.d/mosquitto.conf
@@ -1,0 +1,9 @@
+# Fail2Ban filter for mosquitto MQTT server
+#
+#
+[Init]
+maxlines = 2
+
+[Definition]
+failregex = .+New connection from <HOST>:[0-9]+ on port 1883\.\n.+Client <unknown> disconnected, not authorised\.
+ignoreregex = 

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -987,3 +987,6 @@ logpath = /var/log/monitorix-httpd
 port    = 1080
 logpath = %(syslog_daemon)s
 
+[mosquitto]
+enabled = true
+logpath = /var/log/mosquitto/mosquitto.log

--- a/fail2ban/tests/files/logs/mosquitto
+++ b/fail2ban/tests/files/logs/mosquitto
@@ -1,0 +1,11 @@
+# failJSON: { "time": "2023-06-04T15:42:39", "match": true , "host": "88.130.115.197" }
+1685821252: New connection from 88.130.115.197:58137 on port 1883.
+1685821252: Client <unknown> disconnected, not authorised.
+
+# failJSON: { "time": "2023-06-04T15:43:00", "match": true , "host": "167.94.138.124" }
+1685838539: New connection from 167.94.138.124:48608 on port 1883.
+1685838539: Client <unknown> disconnected, not authorised.
+
+# failJSON: { "time": "2023-06-04T15:43:21", "match": true , "host": "64.62.197.77" }
+1685850159: New connection from 64.62.197.77:17018 on port 1883.
+1685850159: Client <unknown> disconnected, not authorised.


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file

Hi,
I added a filter for the mosquitto mqtt broker. I tested it with mosquitto v2.0.11 and fail2ban v0.11.2.
I couldn't get the testcase to run but the regex and the config itself are working on my server.