### PR TITLE
action.d/*.conf: moved persisted-storage files to /var/lib/fail2ban directory

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,8 @@ ver. 1.0.3-dev-1 (20??/??/??) - development nightly edition
   if available for platform and uses DNS to find local IPv6 as a fallback only
 * improve `ignoreself` by considering all local addresses from network interfaces additionally to IPs from hostnames (gh-3132)
 * `action.d/mikrotik.conf` - new action for mikrotik routerOS, adds and removes entries from address lists on the router (gh-2860)
+* `action.d/bsd-ipfw.conf` and `action.d/dummy.conf` - moved persisted-storage files to /var/lib/fail2ban directory
+  instead /var/run/fail2ban
 * `filter.d/exim.conf` - fixed "dropped: too many ..." regex, also matching unrecognized commands now (gh-3502)
 * `filter.d/nginx-forbidden.conf` - new filter to ban forbidden locations, e. g. using `deny` directive (gh-2226)
 

--- a/config/action.d/bsd-ipfw.conf
+++ b/config/action.d/bsd-ipfw.conf
@@ -69,7 +69,7 @@ port =
 # Option:  startstatefile
 # Notes:   A file to indicate that the table rule that was added. Ensure it is unique per table.
 # Values:  STRING
-startstatefile = /var/run/fail2ban/ipfw-started-table_<table>
+startstatefile = /var/lib/fail2ban/ipfw-started-table_<table>
 
 # Option: block
 # Notes:  This is how much to block.

--- a/config/action.d/dummy.conf
+++ b/config/action.d/dummy.conf
@@ -59,5 +59,5 @@ debug = [<name>] <actname> <target> --
 
 init = 123
 
-target = /var/run/fail2ban/fail2ban.dummy
+target = /var/lib/fail2ban/fail2ban.dummy
 to_target = >> <target>


### PR DESCRIPTION
There's a case when `/var/run` dir is mounted as a tmpfs (ex, diskless environment). So `/var/run/fail2ban` dir can be absent after system boot and some action-script wouldn't read and write their persisted-storages.

The proposed patch changes persisted-storage of `action.d/bsd-ipfw.conf` and `action.d/dummy.conf`.