### PR TITLE
Fixed startup on debian bookworm (using systemd as sshd_backend)

### DIFF
--- a/config/paths-debian.conf
+++ b/config/paths-debian.conf
@@ -28,3 +28,8 @@ exim_main_log = /var/log/exim4/mainlog
 proftpd_log = /var/log/proftpd/proftpd.log
 
 roundcube_errors_log = /var/log/roundcube/errors.log
+
+# These services will log to the journal via syslog, so use the journal by
+# default.
+sshd_backend = systemd
+postfix_backend = systemd


### PR DESCRIPTION
On Debian Bookworm (and newer) rsyslog is not installed as default anymore:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1018788

Because of that systemd should be preferred if possible. I checked sshd and postfix, both of them are logging to journal (Maybe more, but I am not sure).