### PR TITLE
Restore bans from the database with full ticket information

### DIFF
--- a/fail2ban/server/jail.py
+++ b/fail2ban/server/jail.py
@@ -295,7 +295,7 @@ class Jail(object):
 				):
 					try:
 						#logSys.debug('restored ticket: %s', ticket)
-						if self.filter.inIgnoreIPList(ticket.getID(), log_ignore=True): continue
+						if self.filter.inIgnoreIPList(ticket, log_ignore=True): continue
 						# mark ticked was restored from database - does not put it again into db:
 						ticket.restored = True
 						# correct start time / ban time (by the same end of ban):

--- a/fail2ban/server/jail.py
+++ b/fail2ban/server/jail.py
@@ -295,7 +295,7 @@ class Jail(object):
 				):
 					try:
 						#logSys.debug('restored ticket: %s', ticket)
-						if self.filter.inIgnoreIPList(ticket, log_ignore=True): continue
+						if self.filter._inIgnoreIPList(ticket.getID(), ticket): continue
 						# mark ticked was restored from database - does not put it again into db:
 						ticket.restored = True
 						# correct start time / ban time (by the same end of ban):


### PR DESCRIPTION
In the case where we use the `ignoreCommand` with information from the ticket, we want these informations to also be included when restoring the bans from the database (the ticket may no longer be required to be banned).