### PR TITLE
New jail for postfix: screendnsbl 

### DIFF
--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -52,6 +52,10 @@ mdre-aggressive = %(mdre-auth2)s
 mdpr-errors = too many errors after \S+
 mdre-errors = ^from [^[]*\[<HOST>\]%(_port)s$
 
+# Extra mode "screendnsbl", triggered on postfix/postscreen[<PID>]: DNSBL rank <NUM> for [<HOST>]:<PORT>
+mdpr-screendnsbl = DNSBL rank \d+
+mdre-screendnsbl = for \[<HOST>\]%(_port)s
+
 
 failregex = <mdre-<mode>>
 

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -599,6 +599,16 @@ backend  = %(postfix_backend)s
 maxretry = 1
 
 
+[postfix-screendnbl]
+
+filter   = postfix[mode=screendnsbl]
+port     = smtp,465,submission
+logpath  = %(postfix_log)s
+backend  = %(postfix_backend)s
+maxretry = 1
+bantime  = 4h
+
+
 [sendmail-auth]
 
 port    = submission,465,smtp

--- a/fail2ban/tests/files/logs/postfix
+++ b/fail2ban/tests/files/logs/postfix
@@ -178,3 +178,12 @@ Jun  8 23:14:54 proxy2 postfix/postscreen[473]: COMMAND COUNT LIMIT from [192.0.
 # filterOptions: [{}, {"mode": "ddos"}, {"mode": "aggressive"}]
 # failJSON: { "match": false, "desc": "don't affect lawful data (sporadical connection aborts within DATA-phase, see gh-1813 for discussion)" }
 Feb 18 09:50:05 xxx postfix/smtpd[42]: lost connection after DATA from good-host.example.com[192.0.2.10]
+
+
+# ---------------------------------------
+# Test-cases of postfix screendnsbl mode:
+# ---------------------------------------
+
+# filterOptions: [{"mode": "screendnsbl"}]
+# failJSON: { "time": "2023-07-01T03:55:34", "match": true , "host": "192.0.2.30" }
+Jul  1 03:55:34 xxx postfix/postscreen[188902]: DNSBL rank 6 for [192.0.2.30]:52340


### PR DESCRIPTION
this extension adds a new postfix jail which can be optionally dedicated enabled.

It is triggered by a log line like

```
Jul  1 03:55:34 xxx postfix/postscreen[188902]: DNSBL rank 6 for [192.0.2.30]:52340
```

It catches a lot of unwanted connections and log volume decreased a lot.