### PR TITLE
XDPDropper action

### DIFF
--- a/config/action.d/xdpdropper.conf
+++ b/config/action.d/xdpdropper.conf
@@ -1,0 +1,24 @@
+# Fail2Ban configuration file
+#
+# XDPDropper action to add or remove clients via eBPF XDP
+#
+# Author: Jack Coleman <alphajack at tuta dot io>
+# Date: 2023-08-11
+# Info: https://github.com/renanqts/xdpdropper 
+
+[Init]
+# protocol used to reach the xdpdropper instance (http or https)
+xdpd_scheme = http
+
+# address of the xdpdropper instance
+xdpd_host = 127.0.0.1
+
+# port of the xdpdropper instance
+xdpd_port = 8080
+
+[Definition]
+actionstart =
+actionstop  =
+actioncheck = curl -s <xdpd_scheme>://<xdpd_host>:<xdpd_port>/health
+actionban   = curl -s -d '{"ip":"<ip>"}' -X POST -H "Content-Type: application/json" <xdpd_scheme>://<xdpd_host>:<xdpd_port>/drop
+actionunban = curl -s -d '{"ip":"<ip>"}' -X DELETE -H "Content-Type: application/json" <xdpd_scheme>://<xdpd_host>:<xdpd_port>/drop


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file

#  XDPDropper action

Adding a new action that allows to ban clients via eBPF XDP, resulting in more efficient packet dropping.  
Ideally, this would be better than nftables ingress hook in case of DDOS attacks.

This action requires a configured instance of [XDPDropper](https://github.com/renanqts/xdpdropper). For Arch Linux users, I created an easy to install [package](https://aur.archlinux.org/packages/xdpdropper) in the AUR, that should be trivial to adapt to other distros.

References:

- https://github.com/renanqts/xdpdropper
- https://aur.archlinux.org/packages/xdpdropper
- https://blog.cloudflare.com/how-to-drop-10-million-packets/
- https://wiki.nftables.org/wiki-nftables/index.php/Nftables_families

