### PR TITLE
action.d/*ipset*: make maxelem ipset option configurable through banaction arguments

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ ver. 1.0.3-dev-1 (20??/??/??) - development nightly edition
 ### Fixes
 * circumvent SEGFAULT in a python's socket module by getaddrinfo with disabled IPv6 (gh-3438)
 * `action.d/cloudflare-token.conf` - fixes gh-3479, url-encode args by unban
+* `action.d/*ipset*`: make `maxelem` ipset option configurable through banaction arguments
 
 ### New Features and Enhancements
 * better auto-detection for IPv6 support (`allowipv6 = auto` by default), trying to check sysctl net.ipv6.conf.all.disable_ipv6

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,7 +13,7 @@ ver. 1.0.3-dev-1 (20??/??/??) - development nightly edition
 ### Fixes
 * circumvent SEGFAULT in a python's socket module by getaddrinfo with disabled IPv6 (gh-3438)
 * `action.d/cloudflare-token.conf` - fixes gh-3479, url-encode args by unban
-* `action.d/*ipset*`: make `maxelem` ipset option configurable through banaction arguments
+* `action.d/*ipset*`: make `maxelem` ipset option configurable through banaction arguments (gh-3564)
 
 ### New Features and Enhancements
 * better auto-detection for IPv6 support (`allowipv6 = auto` by default), trying to check sysctl net.ipv6.conf.all.disable_ipv6

--- a/config/action.d/firewallcmd-ipset.conf
+++ b/config/action.d/firewallcmd-ipset.conf
@@ -35,7 +35,7 @@ actionunban = <ipstype_<ipsettype>/actionunban>
 
 [ipstype_ipset]
 
-actionstart = ipset -exist create <ipmset> hash:ip timeout <default-ipsettime> <familyopt>
+actionstart = ipset -exist create <ipmset> hash:ip timeout <default-ipsettime> maxelem <maxelem> <familyopt>
 
 actionflush = ipset flush <ipmset>
 
@@ -47,7 +47,7 @@ actionunban = ipset -exist del <ipmset> <ip>
 
 [ipstype_firewalld]
 
-actionstart = firewall-cmd --direct --new-ipset=<ipmset> --type=hash:ip --option=timeout=<default-ipsettime> <firewalld_familyopt>
+actionstart = firewall-cmd --direct --new-ipset=<ipmset> --type=hash:ip --option=timeout=<default-ipsettime> --option=maxelem=<maxelem> <firewalld_familyopt>
 
 # TODO: there doesn't seem to be an explicit way to invoke the ipset flush function using firewall-cmd
 actionflush = 
@@ -76,6 +76,12 @@ default-ipsettime = 0
 # Notes:  specifies ticket timeout (handled ipset timeout only)
 # Values:  [ NUM ]  Default: 0 (managed by fail2ban by unban)
 ipsettime = 0
+
+# Option: maxelem
+# Notes:  maximal number of elements which can be stored in the ipset
+#         You may want to increase this for long-duration/high-volume jails
+# Values: [ NUM ] Default: 65536
+maxelem = 65536
 
 # expresion to caclulate timeout from bantime, example:
 # banaction = %(known/banaction)s[ipsettime='<timeout-bantime>']

--- a/config/action.d/iptables-ipset-proto4.conf
+++ b/config/action.d/iptables-ipset-proto4.conf
@@ -27,7 +27,7 @@ before = iptables.conf
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
 # Values:  CMD
 #
-actionstart = ipset --create f2b-<name> iphash
+actionstart = ipset --create f2b-<name> maxelem <maxelem> iphash
               <_ipt_add_rules>
 
 
@@ -64,3 +64,11 @@ actionunban = ipset --test f2b-<name> <ip> && ipset --del f2b-<name> <ip>
 # Several capabilities used internaly:
 
 rule-jump = -m set --match-set f2b-<name> src -j <blocktype>
+
+[Init]
+
+# Option: maxelem
+# Notes:  maximal number of elements which can be stored in the ipset
+#         You may want to increase this for long-duration/high-volume jails
+# Values: [ NUM ] Default: 65536
+maxelem = 65536

--- a/config/action.d/iptables-ipset.conf
+++ b/config/action.d/iptables-ipset.conf
@@ -24,7 +24,7 @@ before = iptables.conf
 # Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
 # Values:  CMD
 #
-actionstart = ipset -exist create <ipmset> hash:ip timeout <default-ipsettime> <familyopt>
+actionstart = ipset -exist create <ipmset> hash:ip timeout <default-ipsettime> maxelem <maxelem> <familyopt>
               <_ipt_add_rules>
 
 # Option:  actionflush
@@ -75,6 +75,12 @@ default-ipsettime = 0
 # Notes:  specifies ticket timeout (handled ipset timeout only)
 # Values:  [ NUM ]  Default: 0 (managed by fail2ban by unban)
 ipsettime = 0
+
+# Option: maxelem
+# Notes:  maximal number of elements which can be stored in the ipset
+#         You may want to increase this for long-duration/high-volume jails
+# Values: [ NUM ] Default: 65536
+maxelem = 65536
 
 # expresion to caclulate timeout from bantime, example:
 # banaction = %(known/banaction)s[ipsettime='<timeout-bantime>']

--- a/config/action.d/shorewall-ipset-proto6.conf
+++ b/config/action.d/shorewall-ipset-proto6.conf
@@ -51,7 +51,7 @@
 # Values:  CMD
 #
 actionstart = if ! ipset -quiet -name list f2b-<name> >/dev/null;
-              then ipset -quiet -exist create f2b-<name> hash:ip timeout <default-ipsettime>;
+              then ipset -quiet -exist create f2b-<name> hash:ip timeout <default-ipsettime> maxelem <maxelem>;
               fi
 
 # Option:  actionstop
@@ -91,3 +91,11 @@ ipsettime = 0
 # expresion to caclulate timeout from bantime, example:
 # banaction = %(known/banaction)s[ipsettime='<timeout-bantime>']
 timeout-bantime = $([ "<bantime>" -le 2147483 ] && echo "<bantime>" || echo 0)
+
+[Init]
+
+# Option: maxelem
+# Notes:  maximal number of elements which can be stored in the ipset
+#         You may want to increase this for long-duration/high-volume jails
+# Values: [ NUM ] Default: 65536
+maxelem = 65536

--- a/fail2ban/tests/servertestcase.py
+++ b/fail2ban/tests/servertestcase.py
@@ -1597,12 +1597,12 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					"`done`",
 				),
 				'ip4-start': (
-					"`ipset -exist create f2b-j-w-iptables-ipset hash:ip timeout 0 `",
+					"`ipset -exist create f2b-j-w-iptables-ipset hash:ip timeout 0 maxelem 65536 `",
 					"`{ iptables -w -C INPUT -p $proto -m multiport --dports http -m set --match-set f2b-j-w-iptables-ipset src -j REJECT --reject-with icmp-port-unreachable >/dev/null 2>&1; } || "
 					 "{ iptables -w -I INPUT -p $proto -m multiport --dports http -m set --match-set f2b-j-w-iptables-ipset src -j REJECT --reject-with icmp-port-unreachable; }`",
 				), 
 				'ip6-start': (
-					"`ipset -exist create f2b-j-w-iptables-ipset6 hash:ip timeout 0 family inet6`",
+					"`ipset -exist create f2b-j-w-iptables-ipset6 hash:ip timeout 0 maxelem 65536 family inet6`",
 					"`{ ip6tables -w -C INPUT -p $proto -m multiport --dports http -m set --match-set f2b-j-w-iptables-ipset6 src -j REJECT --reject-with icmp6-port-unreachable >/dev/null 2>&1; } || "
 					 "{ ip6tables -w -I INPUT -p $proto -m multiport --dports http -m set --match-set f2b-j-w-iptables-ipset6 src -j REJECT --reject-with icmp6-port-unreachable; }`",
 				),
@@ -1646,12 +1646,12 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 					"`done`",
 				),
 				'ip4-start': (
-					"`ipset -exist create f2b-j-w-iptables-ipset-ap hash:ip timeout 0 `",
+					"`ipset -exist create f2b-j-w-iptables-ipset-ap hash:ip timeout 0 maxelem 65536 `",
 					"`{ iptables -w -C INPUT -p $proto -m set --match-set f2b-j-w-iptables-ipset-ap src -j REJECT --reject-with icmp-port-unreachable >/dev/null 2>&1; } || "
 					 "{ iptables -w -I INPUT -p $proto -m set --match-set f2b-j-w-iptables-ipset-ap src -j REJECT --reject-with icmp-port-unreachable; }",
 				), 
 				'ip6-start': (
-					"`ipset -exist create f2b-j-w-iptables-ipset-ap6 hash:ip timeout 0 family inet6`",
+					"`ipset -exist create f2b-j-w-iptables-ipset-ap6 hash:ip timeout 0 maxelem 65536 family inet6`",
 					"`{ ip6tables -w -C INPUT -p $proto -m set --match-set f2b-j-w-iptables-ipset-ap6 src -j REJECT --reject-with icmp6-port-unreachable >/dev/null 2>&1; } || "
 					 "{ ip6tables -w -I INPUT -p $proto -m set --match-set f2b-j-w-iptables-ipset-ap6 src -j REJECT --reject-with icmp6-port-unreachable; }",
 				),
@@ -1979,11 +1979,11 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 			('j-w-fwcmd-ipset', 'firewallcmd-ipset[name=%(__name__)s, port="http", protocol="tcp", chain="<known/chain>"]', {
 				'ip4': (' f2b-j-w-fwcmd-ipset ',), 'ip6': (' f2b-j-w-fwcmd-ipset6 ',),
 				'ip4-start': (
-					"`ipset -exist create f2b-j-w-fwcmd-ipset hash:ip timeout 0 `",
+					"`ipset -exist create f2b-j-w-fwcmd-ipset hash:ip timeout 0 maxelem 65536 `",
 					"`firewall-cmd --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m multiport --dports http -m set --match-set f2b-j-w-fwcmd-ipset src -j REJECT --reject-with icmp-port-unreachable`",
 				), 
 				'ip6-start': (
-					"`ipset -exist create f2b-j-w-fwcmd-ipset6 hash:ip timeout 0 family inet6`",
+					"`ipset -exist create f2b-j-w-fwcmd-ipset6 hash:ip timeout 0 maxelem 65536 family inet6`",
 					"`firewall-cmd --direct --add-rule ipv6 filter INPUT_direct 0 -p tcp -m multiport --dports http -m set --match-set f2b-j-w-fwcmd-ipset6 src -j REJECT --reject-with icmp6-port-unreachable`",
 				),
 				'flush': (
@@ -2015,11 +2015,11 @@ class ServerConfigReaderTests(LogCaptureTestCase):
 			('j-w-fwcmd-ipset-ap', 'firewallcmd-ipset[name=%(__name__)s, actiontype=<allports>, protocol="tcp", chain="<known/chain>"]', {
 				'ip4': (' f2b-j-w-fwcmd-ipset-ap ',), 'ip6': (' f2b-j-w-fwcmd-ipset-ap6 ',),
 				'ip4-start': (
-					"`ipset -exist create f2b-j-w-fwcmd-ipset-ap hash:ip timeout 0 `",
+					"`ipset -exist create f2b-j-w-fwcmd-ipset-ap hash:ip timeout 0 maxelem 65536 `",
 					"`firewall-cmd --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m set --match-set f2b-j-w-fwcmd-ipset-ap src -j REJECT --reject-with icmp-port-unreachable`",
 				), 
 				'ip6-start': (
-					"`ipset -exist create f2b-j-w-fwcmd-ipset-ap6 hash:ip timeout 0 family inet6`",
+					"`ipset -exist create f2b-j-w-fwcmd-ipset-ap6 hash:ip timeout 0 maxelem 65536 family inet6`",
 					"`firewall-cmd --direct --add-rule ipv6 filter INPUT_direct 0 -p tcp -m set --match-set f2b-j-w-fwcmd-ipset-ap6 src -j REJECT --reject-with icmp6-port-unreachable`",
 				),
 				'flush': (


### PR DESCRIPTION
- previously there was no way to override this value and ipsets would stop being updated when full (Hash is full, cannot add more elements)
- preserve ipset's default value of 65536
- update tests
- Closes #3549

--------------

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file

------------------

- I get a few test failures locally when running `./bin/fail2ban-testcases`, these failures also occur on `master`
- Should I backport this to the `1.0` branch?