### PR TITLE
feat: support interval in nftables.conf

### DIFF
--- a/config/action.d/nftables.conf
+++ b/config/action.d/nftables.conf
@@ -6,6 +6,8 @@
 # 			made active on all ports from original iptables.conf
 # Modified: Alexander Belykh <albel727@ngs.ru>
 #                       adapted for nftables
+# Modified: Alex Garel
+#      support ip interval
 #
 # This is a included configuration file and includes the definitions for the nftables
 # used in all nftables based actions by default.
@@ -55,7 +57,7 @@ _nft_for_proto-multiport-done = done
 _nft_list = <nftables> -a list chain <table_family> <table> <chain>
 _nft_get_handle_id = grep -oP '@<addr_set>\s+.*\s+\Khandle\s+(\d+)$'
 
-_nft_add_set = <nftables> add set <table_family> <table> <addr_set> \{ type <addr_type>\; \}
+_nft_add_set = <nftables> add set <table_family> <table> <addr_set> \{ type <addr_type>\; flags interval \; \}
               <_nft_for_proto-<type>-iter>
               <nftables> add rule <table_family> <table> <chain> %(rule_stat)s
               <_nft_for_proto-<type>-done>


### PR DESCRIPTION
Adding the "flags interval;" in addr-set definition enables the manual ban of ip addresses interval using a subnet mask (eg: 10.0.0.0/24).

Relates to: 
- #927

