### PR TITLE
Fix Dropbear filter when logging to STDOUT

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,8 @@ ver. 1.1.1-dev-1 (20??/??/??) - development nightly edition
 * `filter.d/freeswitch.conf` - bypass some new info in prefix before [WARNING] (changed default `_pref_line`),
   FreeSWITCH log line prefix has changed in newer versions (gh-3143)
 * `filter.d/postfix.conf` - consider CONNECT and other rejected commands as a valid `_pref` (gh-3800)
+* `filter.d/dropbear.conf`:
+  - recognizes extra pid/timestamp if logged into stdout/journal, added `journalmatch` (gh-3597)
 * `filter.d/recidive.conf` - restore possibility to set jail name in the filter, _jailname is positive now (gh-3769)
 * `filter.d/roundcube-auth.conf` - improved RE better matching log format of roundcube version 1.4+ (gh-3816)
 * `filter.d/sshd.conf`:

--- a/config/filter.d/dropbear.conf
+++ b/config/filter.d/dropbear.conf
@@ -23,13 +23,15 @@ before = common.conf
 
 _daemon = dropbear
 
-prefregex = ^%(__prefix_line)s<F-CONTENT>(?:[Ll]ogin|[Bb]ad|[Ee]xit).+</F-CONTENT>$
+prefregex = ^%(__prefix_line)s(\[\d+\] [A-Z][a-z]+ \d\d \d\d:\d\d:\d\d )?<F-CONTENT>(?:[Ll]ogin|[Bb]ad|[Ee]xit).+</F-CONTENT>$
 
 failregex = ^[Ll]ogin attempt for nonexistent user ('.*' )?from <HOST>:\d+$
             ^[Bb]ad (PAM )?password attempt for .+ from <HOST>(:\d+)?$
             ^[Ee]xit before auth \(user '.+', \d+ fails\): Max auth tries reached - user '.+' from <HOST>:\d+\s*$
 
 ignoreregex = 
+
+journalmatch = _SYSTEMD_UNIT=dropbear.service + _COMM=dropbear
 
 # DEV Notes:
 #

--- a/config/filter.d/dropbear.conf
+++ b/config/filter.d/dropbear.conf
@@ -23,7 +23,7 @@ before = common.conf
 
 _daemon = dropbear
 
-prefregex = ^%(__prefix_line)s(\[\d+\] [A-Z][a-z]+ \d\d \d\d:\d\d:\d\d )?<F-CONTENT>(?:[Ll]ogin|[Bb]ad|[Ee]xit).+</F-CONTENT>$
+prefregex = ^%(__prefix_line)s(?:\[\d+\] \w{2,3} [\d:\s]+)?<F-CONTENT>(?:[Ll]ogin|[Bb]ad|[Ee]xit).+</F-CONTENT>$
 
 failregex = ^[Ll]ogin attempt for nonexistent user ('.*' )?from <HOST>:\d+$
             ^[Bb]ad (PAM )?password attempt for .+ from <HOST>(:\d+)?$

--- a/fail2ban/tests/files/logs/dropbear
+++ b/fail2ban/tests/files/logs/dropbear
@@ -13,3 +13,6 @@ Jul 27 01:04:12 fail2ban-test dropbear[1335]: Bad password attempt for 'root' fr
 Jul 27 01:04:22 fail2ban-test dropbear[1335]: Exit before auth (user 'root', 10 fails): Max auth tries reached - user 'root' from 1.2.3.4:60588
 # failJSON: { "time": "2005-07-27T01:18:59", "match": true , "host": "1.2.3.4" }
 Jul 27 01:18:59 fail2ban-test dropbear[1477]: Login attempt for nonexistent user from 1.2.3.4:60794
+
+# failJSON: { "time": "2005-07-10T23:53:52", "match": true , "host": "1.2.3.4" }
+Jul 10 23:53:52 fail2ban-test dropbear[825]: [825] Jul 10 23:53:52 Bad password attempt for 'root' from 1.2.3.4:52289

--- a/fail2ban/tests/files/logs/dropbear
+++ b/fail2ban/tests/files/logs/dropbear
@@ -14,5 +14,5 @@ Jul 27 01:04:22 fail2ban-test dropbear[1335]: Exit before auth (user 'root', 10 
 # failJSON: { "time": "2005-07-27T01:18:59", "match": true , "host": "1.2.3.4" }
 Jul 27 01:18:59 fail2ban-test dropbear[1477]: Login attempt for nonexistent user from 1.2.3.4:60794
 
-# failJSON: { "time": "2005-07-10T23:53:52", "match": true , "host": "1.2.3.4" }
+# failJSON: { "time": "2005-07-10T23:53:52", "match": true , "host": "1.2.3.4", "desc": "extra pid/timestamp may be logged into journal, gh-3597" }
 Jul 10 23:53:52 fail2ban-test dropbear[825]: [825] Jul 10 23:53:52 Bad password attempt for 'root' from 1.2.3.4:52289


### PR DESCRIPTION
Since Debian Bookworm, the distribution ships Dropbear with a native systemd service instead of the default upstream init.d service, and accordingly uses the `-F` and `-E` flags, to run it in foreground and have it logging to STDOUT instead of syslog.

As usual, timestamps and also the PID are now included by the log message emitted by Dropbear, in addition to the systemd journal log prefix.

The Dropbear filter hence does not match anymore. This commit adds the PID and timestamp as optional pattern between prefix and fail log text, to support Dropbear on Debian Bookworm and newer (and likely new versions of other distros) without breaking the old pattern when running Dropbear without `-E` flag.

Additionally, for performance reasons, this commit adds a `journalmatch` entry, matching Debian's and Fedora's `dropbear.service` with `dropbear` executable/identifier, the most likely match for a Dropbear systemd service.

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file

- [x] I can add a line to https://github.com/fail2ban/fail2ban/blob/master/fail2ban/tests/files/logs/dropbear, but is there a way to get this `failJSON`?