### PR TITLE
Fix using multiple email addresses for sendmail

### DIFF
--- a/config/action.d/sendmail-common.conf
+++ b/config/action.d/sendmail-common.conf
@@ -62,7 +62,7 @@ actionunban =
 
 # Your system mail command
 #
-mailcmd = /usr/sbin/sendmail -f "<sender>" "<dest>"
+mailcmd = /usr/sbin/sendmail -f "<sender>" -t
 
 # Recipient mail address
 #

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -175,6 +175,7 @@ filter = %(__name__)s[mode=%(mode)s]
 
 # Destination email address used solely for the interpolations in
 # jail.{conf,local,d/*} configuration files.
+# comma separated list for multiple addresses
 destemail = root@localhost
 
 # Sender email address used solely for some actions


### PR DESCRIPTION
busybox sendmail wants space separated list but To: is comma separated so let sendmail just parse the email body for To:

Before submitting your PR, please review the following checklist:

- [ ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [ ] **KEEP PR small** so it could be easily reviewed.
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
