### PR TITLE
Update Arch Linux package URL in RELEASE

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -115,7 +115,7 @@ Pre Release
 
   * Arch Linux:
 
-    * https://www.archlinux.org/packages/community/any/fail2ban/
+    * https://www.archlinux.org/packages/extra/any/fail2ban/
 
   * Debian: Yaroslav Halchenko <debian@onerussian.com>
 


### PR DESCRIPTION
The old URL returns 404 now.