### PR TITLE
Added firewallcmd-rich-rules_new.conf which supports multiport and allports types

### DIFF
--- a/config/action.d/firewallcmd-rich-rules_new.conf
+++ b/config/action.d/firewallcmd-rich-rules_new.conf
@@ -1,0 +1,58 @@
+# Fail2Ban configuration file
+#
+# Author: Donald Yandt 
+# Changed by: Ivan Prokudin
+# 
+# Because of the rich rule commands requires firewalld-0.3.1+
+# This action uses firewalld rich-rules which gives you a cleaner iptables since it stores rules according to zones and not
+# by chain. So for an example all deny rules will be listed under <zone>_deny. 
+#
+# If you use the --permanent rule you get a xml file in /etc/firewalld/zones/<zone>.xml that can be shared and parsed easliy
+#
+# Example commands to view rules:
+# firewall-cmd [--zone=<zone>] --list-rich-rules
+# firewall-cmd [--zone=<zone>] --list-all
+# firewall-cmd [--zone=zone] --query-rich-rule='rule'
+
+[INCLUDES]
+
+before = firewallcmd-common.conf
+
+[Definition]
+
+# Option:  type
+# Notes.:  type of the action.
+# Values:  [ multiport | allports ]  Default: multiport
+#
+type = multiport
+
+actionstart = 
+
+actionstop = 
+
+actioncheck = 
+
+#you can also use zones and/or service names. 
+#
+# zone example: 
+# firewall-cmd --zone=<zone> --add-rich-rule="rule family='ipv4' source address='<ip>' port port='<port>' protocol='<protocol>' <rich-blocktype>"
+#
+# service name example:
+# firewall-cmd --zone=<zone> --add-rich-rule="rule family='ipv4' source address='<ip>' service name='<service>' <rich-blocktype>"
+#
+# Because rich rules can only handle single or a range of ports we must split ports and execute the command for each port. Ports can be single and ranges separated by a comma or space for an example: http, https, 22-60, 18 smtp 
+
+_fwcmd_rich_rule-multiport = rule family='<family>' source address='<ip>' port port='$p' protocol='<protocol>' %(rich-suffix)s
+_fwcmd_rich_rule-allports = rule family='<family>' source address='<ip>' %(rich-suffix)s
+
+_fwcmd_rich_rule_cmd_add-multiport = ports="<port>"; for p in $(echo $ports | tr ", " " "); do firewall-cmd --add-rich-rule="%(_fwcmd_rich_rule-multiport)s"; done
+_fwcmd_rich_rule_cmd_add-allports = firewall-cmd --add-rich-rule="%(_fwcmd_rich_rule-allports)s"
+
+actionban = <_fwcmd_rich_rule_cmd_add-<type>>
+
+_fwcmd_rich_rule_cmd_remove-multiport = ports="<port>"; for p in $(echo $ports | tr ", " " "); do firewall-cmd --remove-rich-rule="%(_fwcmd_rich_rule-multiport)s"; done
+_fwcmd_rich_rule_cmd_remove-allports = firewall-cmd --remove-rich-rule="%(_fwcmd_rich_rule-allports)s"
+
+actionunban = <_fwcmd_rich_rule_cmd_remove-<type>> 
+
+rich-suffix = <rich-blocktype>


### PR DESCRIPTION
The direct interface used in regular firewallcmd actions has been deprecated. So I updated firewallcmd-rich-rules.conf to support type={multiport,allports}