### PR TITLE
Enable multi line support. Doesn't work with versions < 0.9

### DIFF
--- a/config/filter.d/softethervpn.conf
+++ b/config/filter.d/softethervpn.conf
@@ -1,9 +1,16 @@
 # Fail2Ban filter for SoftEtherVPN
 # Detecting unauthorized access to SoftEtherVPN
 # typically logged in /usr/local/vpnserver/security_log/*/sec.log, or in syslog, depending on configuration
+# Config for versions < 0.9 made by quixrick (https://reddit.com/u/quixrick) and jonisc
+# Further reference: http://www.vpnusers.com/viewtopic.php?f=7&t=6375&sid=76707e8a5a16b0c9486a39ba34763901
+
+#Enable multi line support. Doesn't work with versions < 0.9
+[Init]
+maxlines = 2
 
 [INCLUDES]
 before = common.conf
 
 [Definition]
-failregex = ^%(__prefix_line)s(?:(?:\([\d\-]+ [\d:.]+\) )?<SECURITY_LOG>: )?Connection "[^"]+": User authentication failed. The user name that has been provided was "<F-USER>(?:[^"]+|.+)</F-USER>", from <ADDR>\.$
+datepattern = ^%%Y-%%m-%%d %%H:%%M:%%S.%%f
+failregex = IP address: <HOST>.*\n.*User authentication failed.*


### PR DESCRIPTION
This is my first pull request. I'm sorry if I did it wrong. In short, the current configuration is not working because SoftEtherVPN devs changed the log format. I'm not sure from which version onwards.

The current log looks like the following:

```
2024-01-23 20:36:33.809 The connection "CID-21" (IP address: 8.8.8.8, Host name: google-dns.com, Port number: 55947, Client name: "SoftEther VPN Client", Version: 4.42, Build: 9798) is attempting to connect to the Virtual Hub. The auth type provided is "Password authentication" and the user name is "admin".
2024-01-23 20:36:33.809 Connection "CID-21": User authentication failed. The user name that has been provided was "admin".
```
