### PR TITLE
Add to postfix accepted logs

### DIFF
--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -10,7 +10,7 @@ before = common.conf
 
 [Definition]
 
-_daemon = postfix(-\w+)?/\w+(?:/smtp[ds])?
+_daemon = postfix(-\w+)?/[^/\[:]+(?:/smtp[ds])?
 _port = (?::\d+)?
 _pref = [A-Z]{4}
 

--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -10,7 +10,7 @@ before = common.conf
 
 [Definition]
 
-_daemon = postfix(-\w+)?/[^/\[:]+(?:/smtp[ds])?
+_daemon = postfix(-\w+)?/[^/\[:\s]+(?:/smtp[ds])?
 _port = (?::\d+)?
 _pref = [A-Z]{4}
 

--- a/fail2ban/tests/files/logs/postfix
+++ b/fail2ban/tests/files/logs/postfix
@@ -154,6 +154,8 @@ Jan 14 16:18:16 xxx postfix/smtpd[14933]: warning: host[192.0.2.5]: SASL CRAM-MD
 
 # failJSON: { "time": "2005-02-10T13:26:34", "match": true , "host": "192.0.2.1" }
 Feb 10 13:26:34 srv postfix/smtpd[123]: disconnect from unknown[192.0.2.1] helo=1 auth=0/1 quit=1 commands=2/3
+# failJSON: { "time": "2005-02-10T13:26:34", "match": true , "host": "192.0.2.1" }
+Feb 10 13:26:34 srv postfix/smtp-25/smtpd[123]: disconnect from unknown[192.0.2.1] helo=1 auth=0/1 quit=1 commands=2/3
 # failJSON: { "time": "2005-02-10T13:26:34", "match": true , "host": "192.0.2.2" }
 Feb 10 13:26:34 srv postfix/smtpd[123]: disconnect from unknown[192.0.2.2] ehlo=1 auth=0/1 rset=1 quit=1 commands=3/4
 


### PR DESCRIPTION
Hey,

I use a `-o syslog_name=postfix/submission-587` setting in my postfix daemon to be able to distinguish between daemons on various ports. This results in `Mar  7 16:12:50 myhostname postfix/submission-587/smtpd[51501]: connect from unknown[2.57.122.55]:59164` loglines, that fail2regex doesn't recognize.

This patch accounts for the extra hyphens in the daemon name.