### PR TITLE
Change journalmatch postfix

### DIFF
--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -76,6 +76,6 @@ ignoreregex =
 
 [Init]
 
-journalmatch = _SYSTEMD_UNIT=postfix@-.service
+journalmatch = _SYSTEMD_UNIT=postfix.service _SYSTEMD_UNIT=postfix@-.service
 
 # Author: Cyril Jaquier

--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -76,6 +76,6 @@ ignoreregex =
 
 [Init]
 
-journalmatch = _SYSTEMD_UNIT=postfix.service
+journalmatch = _SYSTEMD_UNIT=postfix@-.service
 
 # Author: Cyril Jaquier


### PR DESCRIPTION
On Debian 12, Postfix operates through several sub-services rather than a single service. The general _SYSTEMD_UNIT=postfix.service in Fail2Ban only tracks basic service start-stop activities, missing out on detailed logs. To capture the full scope of Postfix's activities, targeting a more specific systemd unit like postfix@-.service in Fail2Ban is essential for effective monitoring and security.