### PR TITLE
Change Regex Recidive and journalmatch For Systemd Match

### DIFF
--- a/config/filter.d/recidive.conf
+++ b/config/filter.d/recidive.conf
@@ -19,7 +19,7 @@
 # common.local
 before = common.conf
 
-[Definition]
+[DEFAULT]
 
 _daemon = (?:fail2ban(?:-server|\.actions)\s*)
 
@@ -27,7 +27,20 @@ _daemon = (?:fail2ban(?:-server|\.actions)\s*)
 # this filter 'recidive', or supply another name with `filter = recidive[_jailname="jail"]`
 _jailname = recidive
 
+failregex = ^%(__prefix_line)s(?:\s*fail2ban\.actions\s*%(__pid_re)s?:\s+)?NOTICE\s+\[(?!%(_jailname)s\])(?:.*)\]\s+Ban\s+<HOST>\s*$
+
+[lt_short]
+_daemon = (?:fail2ban(?:-server|\.actions)?\s*)
 failregex = ^%(__prefix_line)s(?:\s*fail2ban(?:\.actions)?\s*%(__pid_re)s?:\s+)?(?:NOTICE\s+)?\[(?!%(_jailname)s\])(?:.*)\]\s+Ban\s+<HOST>\s*$
+
+[lt_journal]
+_daemon = <lt_short/_daemon>
+failregex = <lt_short/failregex>
+
+[Definition]
+
+_daemon = <lt_<logtype>/_daemon>
+failregex = <lt_<logtype>/failregex>
 
 datepattern = ^{DATE}
 

--- a/config/filter.d/recidive.conf
+++ b/config/filter.d/recidive.conf
@@ -27,12 +27,12 @@ _daemon = (?:fail2ban(?:-server|\.actions)\s*)
 # this filter 'recidive', or supply another name with `filter = recidive[_jailname="jail"]`
 _jailname = recidive
 
-failregex = ^%(__prefix_line)s(?:\s*fail2ban\.actions\s*%(__pid_re)s?:\s+)?NOTICE\s+\[(?!%(_jailname)s\])(?:.*)\]\s+Ban\s+<HOST>\s*$
+failregex = ^%(__prefix_line)s(?:\s*fail2ban(?:\.actions)?\s*%(__pid_re)s?:\s+)?(?:NOTICE\s+)?\[(?!%(_jailname)s\])(?:.*)\]\s+Ban\s+<HOST>\s*$
 
 datepattern = ^{DATE}
 
 ignoreregex = 
 
-journalmatch = _SYSTEMD_UNIT=fail2ban.service PRIORITY=5
+journalmatch = _SYSTEMD_UNIT=fail2ban.service
 
 # Author: Tom Hendrikx, modifications by Amir Caspi 

--- a/fail2ban/tests/files/logs/recidive
+++ b/fail2ban/tests/files/logs/recidive
@@ -17,3 +17,8 @@ Sep 16 00:44:55 spaceman fail2ban.actions: NOTICE [jail] Ban 10.0.0.7
 Jan 16 17:11:25 testorg fail2ban.actions[6605]: NOTICE [postfix-auth] Ban 192.0.2.1
 # failJSON: { "time": "2005-03-05T08:41:28", "match": true , "host": "192.0.2.2", "desc": "SYSLOG / systemd-journal with daemon-name" }
 Mar 05 08:41:28 test.org fail2ban-server[11524]: fail2ban.actions        [11524]: NOTICE  [postfix-auth] Ban 192.0.2.2
+
+# filterOptions: {"logtype": "journal"}
+
+# failJSON: { "match": true , "host": "192.0.2.3", "desc": "systemd-journal short variant, gh-3693" }
+host fail2ban[15699]: [postfix-sasl] Ban 192.0.2.3


### PR DESCRIPTION
**Proposed Changes due to Two Issues with Fail2Ban/Logging/Recidive under SYSTEMD:**

1. Issue with Original Regex in SYSTEMD Logs:

The original regex used by Fail2Ban does not match the log format when logging under SYSTEMD. The SYSTEMD log entries look like this:

Mar 10 10:50:07 namemachine fail2ban[15699]: [postfix-sasl] Ban 99.99.99.99

However, the original regex expects entries to contain .actions and NOTICE, which are not present in these logs. Therefore, I propose modifying the regex to make .actions and NOTICE optional, ensuring compatibility with SYSTEMD log formats.

2. Default Ban Priority Issue:

On my newly installed system (debian12), Fail2Ban is logging bans with priority level 4, not the expected level 5. Instead of specifying a particular priority level in journalmatch, I suggest using a more general approach:

journalmatch = _SYSTEMD_UNIT=fail2ban.service

This change will avoid specifying the priority level, reducing the potential need for future adjustments if the default priority level changes again. Additionally, omitting the priority level does not significantly increase the number of lines to analyze and offers more flexibility for future log format changes.