### PR TITLE
Update named-refused.conf

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,7 @@ ver. 1.0.3-dev-1 (20??/??/??) - development nightly edition
   - filter can bypass additional timestamp or pid that may be logged via systemd-journal or syslog-ng (gh-3060)
   - rewrite host line regex for all varied exim's log_selector states (gh-3263)
   - fixed "dropped: too many ..." regex, also matching unrecognized commands now (gh-3502)
+* `filter.d/named-refused.conf` - denied allows any reason in parenthesis as suffix (gh-3697)
 * `filter.d/nginx-forbidden.conf` - new filter to ban forbidden locations, e. g. using `deny` directive (gh-2226)
 * `filter.d/sshd.conf`:
   - avoid double counting for "maximum authentication attempts exceeded" (gh-3502)

--- a/config/filter.d/named-refused.conf
+++ b/config/filter.d/named-refused.conf
@@ -37,7 +37,7 @@ _category_re = (?:%(_category)s: )?
 # this can be optional (for instance if we match named native log files)
 __line_prefix=\s*(?:\S+ %(__daemon_combs_re)s\s+)?%(_category_re)s
 
-prefregex = ^%(__line_prefix)s(?:(?:error|info):\s*)?client(?: @\S*)? <HOST>#\S+(?: \([\S.]+\))?: <F-CONTENT>.+</F-CONTENT>\s(?:denied|\(NOTAUTH\))\s*$
+prefregex = ^%(__line_prefix)s(?:(?:error|info):\s*)?client(?: @\S*)? <HOST>#\S+(?: \([\S.]+\))?: <F-CONTENT>.+</F-CONTENT>\s(?:denied|denied \(allow-query-cache did not match\)|\(NOTAUTH\))\s*$
 
 failregex = ^(?:view (?:internal|external): )?query(?: \(cache\))?
             ^zone transfer

--- a/config/filter.d/named-refused.conf
+++ b/config/filter.d/named-refused.conf
@@ -37,7 +37,7 @@ _category_re = (?:%(_category)s: )?
 # this can be optional (for instance if we match named native log files)
 __line_prefix=\s*(?:\S+ %(__daemon_combs_re)s\s+)?%(_category_re)s
 
-prefregex = ^%(__line_prefix)s(?:(?:error|info):\s*)?client(?: @\S*)? <HOST>#\S+(?: \([\S.]+\))?: <F-CONTENT>.+</F-CONTENT>\s(?:denied|denied \(allow-query-cache did not match\)|\(NOTAUTH\))\s*$
+prefregex = ^%(__line_prefix)s(?:(?:error|info):\s*)?client(?: @\S*)? <HOST>#\S+(?: \([\S.]+\))?: <F-CONTENT>.+</F-CONTENT>\s(?:denied(?: \([^\)]*\))?|\(NOTAUTH\))\s*$
 
 failregex = ^(?:view (?:internal|external): )?query(?: \(cache\))?
             ^zone transfer

--- a/fail2ban/tests/files/logs/named-refused
+++ b/fail2ban/tests/files/logs/named-refused
@@ -18,6 +18,8 @@ Aug 17 08:20:22 catinthehat named[2954]: client 223.252.23.219#56275: zone trans
 # BIND9 ver: BIND 9.9.3-rpz2+rl.13208.13-P2-RedHat-9.9.3-4.P2.el6 (Extended Support Version)
 # failJSON: { "time": "2013-08-23T10:32:56", "match": true , "host": "82.207.95.42" }
 23-Aug-2013 10:32:56.621 client 82.207.95.42#40278 (redginseng.com.ua): query (cache) 'redginseng.com.ua/A/IN' denied
+# failJSON: { "time": "2013-08-23T18:41:28", "match": true , "host": "192.0.2.3", "desc": "denied with allow-query-cache did not match, gh-2697" }
+23-Aug-2013 18:41:28.090 client @0x7f7c95c76968 192.0.2.3#60683 (example.com): query (cache) 'example.com/A/IN' denied (allow-query-cache did not match)
 
 # failJSON: { "time": "2013-08-27T17:49:45", "match": true , "host": "59.167.242.100" }
 27-Aug-2013 17:49:45.330 client 59.167.242.100#44281 (watt.kiev.ua): zone transfer 'watt.kiev.ua/AXFR/IN' denied


### PR DESCRIPTION
Debian 12 Bind v9.18.x
```
# fail2ban-regex -vv /var/log/named/security.log /etc/fail2ban/filter.d/named-refused.conf

Running tests
=============

Use   failregex filter file : bind9, basedir: /etc/fail2ban
Real  filter options : {'logtype': 'file'}
Use         log file : /var/log/named/security.log-test
Use         encoding : UTF-8


Results
=======

Prefregex: 2 total
|  ^\s*(?:\S+ (?:(?:\[\d+\])?:\s+\(?named(?:-\w+)?(?:\(\S+\))?\)?:?|\(?named(?:-\w+)?(?:\(\S+\))?\)?:?(?:\[\d+\])?:)\s+)?(?:(?!error|info)[\w-]+: )?(?:(?:error|info):\s*)?client(?: @\S*)? (?:\[?(?:(?:::f{4,6}:)?(?P<ip4>(?:\d{1,3}\.){3}\d{1,3})|(?P<ip6>(?:[0-9a-fA-F]{1,4}::?|::){1,7}(?:[0-9a-fA-F]{1,4}|(?<=:):)))\]?|(?P<dns>[\w\-.^_]*\w))#\S+(?: \([\S.]+\))?: (?P<content>.+)\s(?:denied|\(NOTAUTH\))\s*$
|      {'ip4': 'y.y.y.y', 'ip6': None, 'dns': None, 'content': "query '7.48.168.192.in-addr.arpa/PTR/IN'"}
|      {'ip4': 'z.z.z.z', 'ip6': None, 'dns': None, 'content': "query 'version.bind/TXT/CH'"}
`-

Failregex: 0 total
|-  #) [# of hits] regular expression
|   1) [0] ^client @\S+ <HOST>#\S+ \(\S+\): query \(cache\) '.*' denied \(allow-query-cache did not match\)
|   2) [0] ^client @\S+ <HOST>#\S+ \(\S+\): query '.*' denied
`-

Ignoreregex: 0 total

Lines: 6 lines, 0 ignored, 0 matched, 6 missed
[processed in 0.03 sec]

|- Missed line(s):
|  15-Mar-2024 17:10:00.997 client @0x7f7c94456368 y.y.y.y#46951 (7.48.168.192.in-addr.arpa): query '7.48.168.192.in-addr.arpa/PTR/IN' denied
|  15-Mar-2024 18:36:22.776 client @0x7f7c8b5b3d68 z.z.z.z#61000 (version.bind): query 'version.bind/TXT/CH' denied
|  15-Mar-2024 18:41:28.090 client @0x7f7c95c76968 x.x.x.x#60683 (remontti.com.br): query (cache) 'remontti.com.br/A/IN' denied (allow-query-cache did not match)
|  19-Mar-2024 18:26:05.543 client @0x7effb001d168 x.x.x.x#38559 (remontti.com.br): query (cache) 'remontti.com.br/A/IN' denied (allow-query-cache did not match)
`-
```