### PR TITLE
Updated Group-Office filters for version 6.7 and up

### DIFF
--- a/config/filter.d/groupoffice-lost-password.conf
+++ b/config/filter.d/groupoffice-lost-password.conf
@@ -1,0 +1,7 @@
+# Fail2Ban filter for Group-Office lost password requests
+# logpath must be the webserver error log
+
+[Definition]
+
+failregex = Lost password request from IP: '<HOST>'$
+ignoreregex =

--- a/config/filter.d/groupoffice.conf
+++ b/config/filter.d/groupoffice.conf
@@ -1,14 +1,7 @@
 # Fail2Ban filter for Group-Office
-#
-# Enable logging with:
-# $config['info_log']='/home/groupoffice/log/info.log';
-#
+# logpath must be the webserver error log
 
 [Definition]
 
-failregex = ^\[\]LOGIN FAILED for user: "\S+" from IP: <HOST>$
-
+failregex = Password authentication failed for '\S+' from IP: '<HOST>'$
 ignoreregex =
-
-# Author: Daniel Black
-

--- a/config/filter.d/groupoffice.conf
+++ b/config/filter.d/groupoffice.conf
@@ -1,4 +1,4 @@
-# Fail2Ban filter for Group-Office
+# Fail2Ban filter for Group-Office authentication failures
 # logpath must be the webserver error log
 
 [Definition]

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -450,7 +450,13 @@ logpath  = /var/log/horde/horde.log
 [groupoffice]
 
 port     = http,https
-logpath  = /home/groupoffice/log/info.log
+logpath  = /var/log/apache2/error.log
+
+[groupoffice-lost-password]
+
+port     = http,https
+logpath  = /var/log/apache2/error.log
+maxretry = 100
 
 
 [sogo-auth]

--- a/fail2ban/tests/files/logs/groupoffice
+++ b/fail2ban/tests/files/logs/groupoffice
@@ -1,4 +1,4 @@
 # failJSON: { "time": "2024-03-26T07:59:08", "match": true, "host": "192.168.65.1" }
-localhost [Tue Mar 26 07:59:08 2024] [notice] [pid 1662] [client 192.168.65.1:17672] Password authentication failed for 'johndoe' from IP: '192.168.65.1'
+localhost [Tue Mar 26 07:59:08 2024] [notice] [pid 1662] [client 192.168.65.1:17672] Password authentication failed for '192.168.100.100' from IP: '192.168.65.1'
 # failJSON: { "time": "2024-03-26T08:17:24", "match": false, "host": "192.168.65.1" }
 localhost [Tue Mar 26 08:17:24 2024] [notice] [pid 90] [client 192.168.65.1:17733] Lost password request from IP: '192.168.65.1'

--- a/fail2ban/tests/files/logs/groupoffice-lost-password
+++ b/fail2ban/tests/files/logs/groupoffice-lost-password
@@ -1,4 +1,4 @@
-# failJSON: { "time": "2024-03-26T07:59:08", "match": true, "host": "192.168.65.1" }
+# failJSON: { "time": "2024-03-26T07:59:08", "match": false, "host": "192.168.65.1" }
 localhost [Tue Mar 26 07:59:08 2024] [notice] [pid 1662] [client 192.168.65.1:17672] Password authentication failed for 'johndoe' from IP: '192.168.65.1'
-# failJSON: { "time": "2024-03-26T08:17:24", "match": false, "host": "192.168.65.1" }
+# failJSON: { "time": "2024-03-26T08:17:24", "match": true, "host": "192.168.65.1" }
 localhost [Tue Mar 26 08:17:24 2024] [notice] [pid 90] [client 192.168.65.1:17733] Lost password request from IP: '192.168.65.1'


### PR DESCRIPTION
I've changed the filters for current stable Group-Office releases and updated the test case.

Sorry for my inexperience with python. I could not get the tests to run so I didn't test them. I forked the repo, installed it but it keeps saying the test doesn't exist in the jail.conf while it is there.

I hope this can be included!

Thanks,
Merijn Schering