### PR TITLE
Fix cloudflare-token.conf on Nixos

### DIFF
--- a/config/action.d/cloudflare-token.conf
+++ b/config/action.d/cloudflare-token.conf
@@ -55,7 +55,7 @@ actionunban = id=$(curl -s -X GET "<_cf_api_url>" \
               <_cf_api_prms> \
                   | awk -F"[,:}]" '{for(i=1;i<=NF;i++){if($i~/'id'\042/){print $(i+1)}}}' \
                   | tr -d ' "' \
-                  | head -n 1)
+                  | head -n 1); \
               if [ -z "$id" ]; then echo "<name>: id for <ip> cannot be found using target <cftarget>"; exit 0; fi; \
               curl -s -X DELETE "<_cf_api_url>/$id" \
                   <_cf_api_prms> \


### PR DESCRIPTION
fix on nixos bug:
uses unban error:
 `id for ip cannot be found using target ip`

The reason why the error occurs on nixos is that the special operating environment of nixos causes the commands before and after it to be executed separately. Subsequent commands do not inherit the previous command. Merging it solves the problem without affecting other distributions.

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
