### PR TITLE
replace distutils for python 3.12

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,12 +47,9 @@ copyright = u'2014'
 #
 
 from fail2ban.version import version as fail2ban_version
-from distutils.version import LooseVersion
-
-fail2ban_loose_version = LooseVersion(fail2ban_version)
 
 # The short X.Y version.
-version = ".".join(str(_) for _ in fail2ban_loose_version.version[:2])
+version = ".".join(str(_) for _ in fail2ban_version.split(".")[:2])
 # The full version, including alpha/beta/rc tags.
 release = fail2ban_version
 

--- a/fail2ban/server/filterpyinotify.py
+++ b/fail2ban/server/filterpyinotify.py
@@ -24,7 +24,6 @@ __copyright__ = "Copyright (c) 2004 Cyril Jaquier, 2011-2012 Lee Clemens, 2012 Y
 __license__ = "GPL"
 
 import logging
-from distutils.version import LooseVersion
 import os
 from os.path import dirname, sep as pathsep
 
@@ -38,7 +37,7 @@ from ..helpers import getLogger
 
 
 if not hasattr(pyinotify, '__version__') \
-  or LooseVersion(pyinotify.__version__) < '0.8.3': # pragma: no cover
+  or pyinotify.__version__.split(".") < '0.8.3'.split("."): # pragma: no cover
   raise ImportError("Fail2Ban requires pyinotify >= 0.8.3")
 
 # Verify that pyinotify is functional on this system

--- a/fail2ban/server/filtersystemd.py
+++ b/fail2ban/server/filtersystemd.py
@@ -24,10 +24,9 @@ __license__ = "GPL"
 
 import os
 import time
-from distutils.version import LooseVersion
 
 from systemd import journal
-if LooseVersion(getattr(journal, '__version__', "0")) < '204':
+if getattr(journal, "__version__", "0").split(".") < "204".split("."):
 	raise ImportError("Fail2Ban requires systemd >= 204")
 
 from .failmanager import FailManagerEmpty


### PR DESCRIPTION
Python 3.12 has removed `distutils`: https://docs.python.org/3.12/whatsnew/3.12.html#removed

---

Before submitting your PR, please review the following checklist:

- [ ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
