### PR TITLE
NGINX bad request enhancement

### DIFF
--- a/config/filter.d/nginx-bad-request.conf
+++ b/config/filter.d/nginx-bad-request.conf
@@ -5,7 +5,7 @@
 
 # The request often doesn't contain a method, only some encoded garbage
 # This will also match requests that are entirely empty
-failregex = ^<HOST> - \S+ \[\] "[^"]*" 400
+failregex = ^<HOST> - \S+ \[\] "[^"]*" [4-5]0[0-9]
 
 datepattern = {^LN-BEG}%%ExY(?P<_sep>[-/.])%%m(?P=_sep)%%d[T ]%%H:%%M:%%S(?:[.,]%%f)?(?:\s*%%z)?
               ^[^\[]*\[({DATE})

--- a/fail2ban/tests/files/logs/nginx-bad-request
+++ b/fail2ban/tests/files/logs/nginx-bad-request
@@ -21,3 +21,6 @@
 
 # failJSON: { "time": "2014-12-12T22:59:02", "match": true , "host": "2.5.2.5" }
 2.5.2.5 - tomcat [12/Dec/2014:22:59:02 +0100] "GET /cgi-bin/tools/tools.pl HTTP/1.1" 400 162 "-" "-" "-"
+
+# failJSON: { "time": "2014-12-12T22:59:02", "match": true , "host": "192.168.144.1" }
+192.168.144.1 - - [12/Dec/2014:22:59:02 +0100] "GET /adsf HTTP/1.1" 404 118 "-" "-" "-"


### PR DESCRIPTION
Enhance the NGINX bad request filter for real world attack situations

Enhancing the searching regex for 3 common situations:

1. Clients or bots trying to access resources not being hosted to explore critical files. -> Error 404 is returned

2. Clients or bots trying to exploit services by pinging URIs with methods not allowed (i.e. POST instead of GET) -> Error 405 is returned

3. Clients or bots explore dynamic hosted sites by randomly sending parameters to exploit the API (for all APIs from old CGI to REST service proxied) -> Error 50x is returned
The latter is the weekest criteria bc. the return code is at best a expected exception and then defined by the API designer or at worst depending on the system behind. CGI for example let nginx throw 519 on harsh errors (which is not covered by the regex at all)

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file



If desired I can provide similar to the Apache filter also
