### PR TITLE
Adjust sshd.conf filter for OpenSSH 9.8

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,8 @@ ver. 1.1.1-dev-1 (20??/??/??) - development nightly edition
   - rename `ipsettype` to `ipsetbackend` (gh-2620), parameter `ipsettype` will be used now to the real set type (gh-3760)
 * `filter.d/apache-overflows.conf` - consider AH10244: invalid URI path (gh-3778)
 * `filter.d/recidive.conf` - restore possibility to set jail name in the filter, _jailname is positive now (gh-3769)
+* `filter.d/sshd.conf` - adapted to conform possible new daemon name sshd-session, since OpenSSH 9.8 
+  several log messages will be tagged with as originating from a process named "sshd-session" rather than "sshd" (gh-3782)
 
 ### New Features and Enhancements
 * `action.d/*-ipset.conf`:

--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -16,7 +16,7 @@ before = common.conf
 
 [DEFAULT]
 
-_daemon = sshd
+_daemon = (?:sshd(?:-session)?)
 
 # optional prefix (logged from several ssh versions) like "error: ", "error: PAM: " or "fatal: "
 __pref = (?:(?:error|fatal): (?:PAM: )?)?

--- a/config/filter.d/sshd.conf
+++ b/config/filter.d/sshd.conf
@@ -16,7 +16,7 @@ before = common.conf
 
 [DEFAULT]
 
-_daemon = (?:sshd(?:-session)?)
+_daemon = sshd(?:-session)?
 
 # optional prefix (logged from several ssh versions) like "error: ", "error: PAM: " or "fatal: "
 __pref = (?:(?:error|fatal): (?:PAM: )?)?

--- a/fail2ban/tests/config/filter.d/zzz-sshd-obsolete-multiline.conf
+++ b/fail2ban/tests/config/filter.d/zzz-sshd-obsolete-multiline.conf
@@ -9,7 +9,7 @@ before = ../../../../config/filter.d/common.conf
 
 [DEFAULT]
 
-_daemon = sshd
+_daemon = sshd(?:-session)?
 
 # optional prefix (logged from several ssh versions) like "error: ", "error: PAM: " or "fatal: "
 __pref = (?:(?:error|fatal): (?:PAM: )?)?

--- a/fail2ban/tests/files/logs/sshd
+++ b/fail2ban/tests/files/logs/sshd
@@ -20,6 +20,9 @@ Feb 25 14:34:10 belka sshd[31603]: Failed password for invalid user ROOT from aa
 # failJSON: { "time": "2005-02-25T14:34:11", "match": true , "host": "aaaa:bbbb:cccc:1234::1:1" }
 Feb 25 14:34:11 belka sshd[31603]: Failed password for invalid user ROOT from aaaa:bbbb:cccc:1234::1:1
 
+# failJSON: { "time": "2005-07-03T14:59:17", "match": true , "host": "192.0.2.1", "desc": "new log with session in daemon prefix, gh-3782" }
+Jul  3 14:59:17 host sshd-session[1571]: Failed password for root from 192.0.2.1 port 56502 ssh2
+
 #3
 # failJSON: { "time": "2005-01-05T01:31:41", "match": true , "host": "1.2.3.4" }
 Jan  5 01:31:41 www sshd[1643]: ROOT LOGIN REFUSED FROM 1.2.3.4


### PR DESCRIPTION
OpenSSH released version 9.8 yesterday that fixes a critical vulnerability. It also implements a potential new daemon name we need to monitor for.

> * [sshd(8)](https://man.openbsd.org/sshd.8): several log messages have changed. In particular, some
   log messages will be tagged with as originating from a process
   named "sshd-session" rather than "sshd".

This change might be worth backporting.

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
