### PR TITLE
tests for Postfix 3.9 SASL reason unavailable

### DIFF
--- a/fail2ban/tests/files/logs/postfix
+++ b/fail2ban/tests/files/logs/postfix
@@ -148,6 +148,9 @@ Jan 14 16:18:16 xxx postfix/smtpd[14933]: warning: host[192.0.2.5]: SASL CRAM-MD
 # failJSON: { "time": "2005-01-14T16:18:16", "match": true , "host": "192.0.2.5", "desc": "aggressive only" }
 Jan 14 16:18:16 xxx postfix/smtpd[14933]: warning: host[192.0.2.5]: SASL CRAM-MD5 authentication failed: Invalid authentication mechanism
 
+# failJSON: { "time": "2004-11-04T09:11:01", "match": true , "host": "192.0.2.152", "desc": "reason unavailable" }
+Nov  4 09:11:01 mail postfix/smtpd[1234]: warning: unknown[192.0.2.152]: SASL LOGIN authentication failed: (reason unavailable), sasl_username=admin
+
 # ---------------------------------------
 # Test-cases of postfix DDOS mode:
 # ---------------------------------------


### PR DESCRIPTION
SASL auth failure message changed with Postfix 3.9 Include additional test log

https://github.com/vdukhovni/postfix/commit/17dbfb9b8b9b483a23ea84dcd272c6d4010ad74b

Before submitting your PR, please review the following checklist:

- [x] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
 **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed.
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
