### PR TITLE
Fix roundcube login failregex for roundcube 1.4+

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@ ver. 1.1.1-dev-1 (20??/??/??) - development nightly edition
 * `filter.d/apache-overflows.conf` - consider AH10244: invalid URI path (gh-3778)
 * `filter.d/postfix.conf` - consider CONNECT and other rejected commands as a valid `_pref` (gh-3800)
 * `filter.d/recidive.conf` - restore possibility to set jail name in the filter, _jailname is positive now (gh-3769)
+* `filter.d/roundcube-auth.conf` - improved RE better matching log format of roundcube version 1.4+ (gh-3816)
 * `filter.d/sshd.conf` - adapted to conform possible new daemon name sshd-session, since OpenSSH 9.8 
   several log messages will be tagged with as originating from a process named "sshd-session" rather than "sshd" (gh-3782)
 

--- a/config/filter.d/roundcube-auth.conf
+++ b/config/filter.d/roundcube-auth.conf
@@ -15,7 +15,7 @@ before = common.conf
 
 prefregex = ^\s*(\[\])?(%(__hostname)s\s*(?:roundcube(?:\[(\d*)\])?:)?\s*(<[\w]+>)? IMAP Error)?: <F-CONTENT>.+</F-CONTENT>$
 
-failregex = ^(?:FAILED login|Login failed) for <F-USER>.*</F-USER> from <HOST>(?:(?:\([^\)]*\))?\. (?:(?! from ).)*(?: user=(?P=user))? in \S+\.php on line \d+ \(\S+ \S+\))?$
+failregex = ^(?:FAILED login|Login failed) for <F-USER>.*</F-USER></F-USER>(?:against \S+)? from <HOST>(?:(?:\([^\)]*\))?\. (?:(?! from ).)*(?: user=(?P=user))? in \S+\.php on line \d+ \(\S+ \S+\))?$
             ^(?:<[\w]+> )?Failed login for <F-USER>.*</F-USER> from <HOST> in session \w+( \(error: \d\))?$
 
 ignoreregex = 

--- a/config/filter.d/roundcube-auth.conf
+++ b/config/filter.d/roundcube-auth.conf
@@ -13,10 +13,9 @@ before = common.conf
 
 [Definition]
 
-prefregex = ^\s*(\[\])?(%(__hostname)s\s*(?:roundcube(?:\[(\d*)\])?:)?\s*(<[\w]+>)? IMAP Error)?: <F-CONTENT>.+</F-CONTENT>$
+prefregex = ^\s*(\[\])?(%(__hostname)s\s*(?:roundcube(?:\[(\d*)\])?:)?\s*(<[\w]+>)? IMAP Error)?: (?:<[\w]+> )?<F-CONTENT>.+</F-CONTENT>$
 
-failregex = ^(?:FAILED login|Login failed) for <F-USER>.*</F-USER></F-USER>(?:against \S+)? from <HOST>(?:(?:\([^\)]*\))?\. (?:(?! from ).)*(?: user=(?P=user))? in \S+\.php on line \d+ \(\S+ \S+\))?$
-            ^(?:<[\w]+> )?Failed login for <F-USER>.*</F-USER> from <HOST> in session \w+( \(error: \d\))?$
+failregex = ^(?:Login failed|(?i:Failed) login) for <F-USER>(?:(?P<simple>\S+)|.*)</F-USER> (?:against \S+ )?from <ADDR>(?:(?:\([^\)]*\))?\.(?! from ) (?(simple)(?:\S+(?! from ) )*|(?:(?! from ).)*(?: user=(?P=user))? )in \S+\.php on line \d+| in session \w+)?(?: \([^\)]*\))?$
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/roundcube-auth
+++ b/fail2ban/tests/files/logs/roundcube-auth
@@ -54,3 +54,8 @@ Jul 11 03:06:37 myhostname roundcube: IMAP Error: Login failed for admin from 12
 
 # failJSON: { "time": "2005-05-19T06:07:48", "match": true , "host": "192.0.2.1", "desc": "Roundcube logged to journald instead to a local file."}
 May 19 06:07:48 server roundcube[21296]: <crk9n97i> IMAP Error: Login failed for test from 192.0.2.1. AUTHENTICATE PLAIN: Authentication failed. in /usr/share/php5/Roundcube/rcube_imap.php on line 193 (POST /mail/?_task=login&_action=login)
+
+# Roundcube 1.5.0 (/var/log/roundcubemail/errors)
+# failJSON: { "time": "2014-12-30T19:02:34", "match": true , "host": "1.2.3.4" }
+[30-Dec-2014 13:02:34 -0500]: <3z506z6r> IMAP Error: Login failed for admin@example.com against localhost from 1.2.3.4. AUTHENTICATE PLAIN: Authentication failed. in /docroot/path/program/lib/Roundcube/rcube_imap.php on line 221 (POST /?_task=login?_task=login&_action=login)
+


### PR DESCRIPTION
roundcube change log format from 1.4 version as you can see here https://github.com/roundcube/roundcubemail/blob/e92d8e31a342653fb65d12cf5fb706cac4031841/program/lib/Roundcube/rcube_imap.php#L194