### PR TITLE
files/fail2ban-openrc.init.in: start after nftables

### DIFF
--- a/files/fail2ban-openrc.init.in
+++ b/files/fail2ban-openrc.init.in
@@ -44,7 +44,7 @@ retry="30"
 
 depend() {
 	use logger
-	after iptables
+	after iptables nftables
 }
 
 checkconfig() {


### PR DESCRIPTION
The `after iptables` clause in the OpenRC service script's `depend()` function causes fail2ban to start after iptables, if iptables is scheduled to start. Here we add `after nftables` as well: nftables is the successor to iptables, and fail2ban supports it out-of-the-box. If nftables is scheduled to start, we want to wait until it's done before starting fail2ban.
