### PR TITLE
Update murmur.conf

### DIFF
--- a/config/filter.d/murmur.conf
+++ b/config/filter.d/murmur.conf
@@ -15,17 +15,14 @@ _usernameregex = [^>]+
 __prefix_journal = (?:\S+\s+%(_daemon)s\[\d+\]:(?:\s+\<W\>[\d\-]+ [\d:]+.\d+)?)
 
 __prefix_line = %(__prefix_journal)s?
+																										 
+maxlines = 2																																							  
 
-_prefix = %(__prefix_line)s\s+\d+ => <\d+:%(_usernameregex)s\(-1\)> Rejected connection from <HOST>:\d+:
+failregex = ^\s*\d+ => <.*> Rejected connection from <HOST>:\d+: Invalid server password$
+            ^\s*\d+ => <.*> Rejected connection from <HOST>:\d+: Wrong certificate or password for existing user$
+            ^\s*\d+ => <.*> New connection: <HOST>:\d+\s+^\s*\d+ => <.*> Connection closed: Error during SSL handshake: error:.*:wrong version number \[\d+\]$ignoreregex =
 
-prefregex = ^%(_prefix)s <F-CONTENT>.+</F-CONTENT>$
-
-failregex = ^Invalid server password$
-            ^Wrong certificate or password for existing user$
-
-ignoreregex =
-
-datepattern = ^<W>{DATE}
+datepattern = ^<\w>%%Y-%%m-%%d %%H:%%M:%%S\.%%f
 
 journalmatch = _SYSTEMD_UNIT=murmurd.service + _COMM=murmurd
 


### PR DESCRIPTION
Support for multiline logging.
This will catch cases where the exception is thrown on the next line. Ie, these:

<W>2024-11-13 07:29:21.851 1 => <0:(-1)> New connection: 91.238.000.00:65070
<W>2024-11-13 07:29:21.859 1 => <0:(-1)> Connection closed: Error during SSL handshake: error:0A00010B:SSL routines::wrong version number [13]

Before submitting your PR, please review the following checklist:

- [X ] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [X ] **LIST ISSUES** this PR resolves
- [X ] **MAKE SURE** this PR doesn't break existing tests
- [X ] **KEEP PR small** so it could be easily reviewed.
- [X ] **AVOID** making unnecessary stylistic changes in unrelated code
- [X ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file
