### PR TITLE
make pf.conf actionban kill all source tracking and state entries originating from banned IP address

### DIFF
--- a/config/action.d/pf.conf
+++ b/config/action.d/pf.conf
@@ -69,7 +69,7 @@ actioncheck = <pfctl> -sr | grep -q <tablename>-<name>
 #          <time>  unix timestamp of the ban time
 # Values:  CMD
 #
-actionban = <pfctl> -t <tablename>-<name> -T add <ip>
+actionban = <pfctl> -k <ip> -K <ip> -t <tablename>-<name> -T add <ip>
 
 
 # Option:  actionunban


### PR DESCRIPTION
FreeBSD/pf creates state entries for established connections such as an ongoing brute force attack.  new packets matching an existing state entry bypass all rules including the fail2ban rules untill the state entry expires.  I have observed wordpress attacks hammering away for upto 15 minutes _after_ the offending IP has been added to the apropos f2b pf block table. this patch adds <pfctl> options to kill all source tracking and state entries originating from banned IP address at the same time the IP is added to the block table:
```
actionban = <pfctl> -k <ip> -K <ip> -t <tablename>-<name> -T add <ip>
```
with this patch the same wordpress attacks were stopped cold at the same time the IP address was blocked.

the resulting pfctl options were also tested from the CLI for correctness.