### PR TITLE
Feature/systemd-journal lighttpd-auth

### DIFF
--- a/config/filter.d/lighttpd-auth.conf
+++ b/config/filter.d/lighttpd-auth.conf
@@ -4,7 +4,8 @@
 [Definition]
 
 failregex = ^\s*(?:: )?\(?(?:http|mod)_auth\.c\.\d+\) (?:password doesn\'t match for (?:\S+|.*?) username:\s+<F-USER>(?:\S+|.*?)</F-USER>\s*|digest: auth failed(?: for\s+<F-ALT_USER>(?:\S+|.*?)</F-ALT_USER>\s*)?: (?:wrong password|uri mismatch \([^\)]*\))|get_password failed),? IP: <HOST>\s*$
+            ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]) lighttpd\[\d+\]: \s*(?:: )?\(?(?:http|mod)_auth\.c\.\d+\) (?:password doesn\'t match for (?:\S+|.*?) username:\s+<F-USER>(?:\S+|.*?)</F-USER>\s*|digest: auth failed(?: for\s+<F-ALT_USER>(?:\S+|.*?)</F-ALT_USER>\s*)?: (?:wrong password|uri mismatch \([^\)]*\))|get_password failed),? IP: <HOST>\s*$
 
-ignoreregex = 
+ignoreregex =
 
 # Author: Francois Boulogne <fboulogne@april.org>

--- a/fail2ban/tests/files/logs/lighttpd-auth
+++ b/fail2ban/tests/files/logs/lighttpd-auth
@@ -12,3 +12,6 @@
 2021-09-30 17:44:37: (mod_auth.c.791) digest: auth failed for  tester : wrong password, IP: 192.0.2.3
 # failJSON: { "time": "2021-09-30T17:44:37", "match": true , "host": "192.0.2.4", "desc": "gh-3116" }
 2021-09-30 17:44:37: (mod_auth.c.791) digest: auth failed: uri mismatch (/uri1 != /uri2), IP: 192.0.2.4
+
+# systemd-journal
+2025-03-04T02:11:57.602061 ip-172-31-3-150.ap-southeast-2.compute.internal lighttpd[764]: (mod_auth.c.853) password doesn't match for / username: user1 IP: 122.251.111.211


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [X] **CHOOSE CORRECT BRANCH**: if filing a bugfix/enhancement
      against certain release version, choose `0.9`, `0.10` or `0.11` branch,
      for dev-edition use `master` branch
- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [X] **LIST ISSUES** this PR resolves
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [X] **KEEP PR small** so it could be easily reviewed.
- [X] **AVOID** making unnecessary stylistic changes in unrelated code
- [X] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      within `fail2ban/tests/files/logs/X` file

Issue reported by me via https://sourceforge.net/p/fail2ban/mailman/message/59155472/

Test result after the change:

```
[ec2-user@ip-172-31-3-150 fail2ban]$ fail2ban-regex systemd-journal lighttpd-auth
Running tests
=============
Use             jail : lighttpd-auth
Use         systemd journal
Use         encoding : UTF-8
Use    journal match : _SYSTEMD_UNIT=lighttpd.service + _COMM=lighttpd
Results
=======
Failregex: 12 total
|-  #) [# of hits] regular expression
|   2) [12] ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]) lighttpd\[\d+\]: \s*(?:: )?\(?(?:http|mod)_auth\.c\.\d+\) (?:password doesn\'t match for (?:\S+|.*?) username:\s+<F-USER>(?:\S+|.*?)</F-USER>\s*|digest: auth failed(?: for\s+<F-ALT_USER>(?:\S+|.*?)</F-ALT_USER>\s*)?: (?:wrong password|uri mismatch \([^\)]*\))|get_password failed),? IP: <HOST>\s*$
`-
Ignoreregex: 0 total
Lines: 52 lines, 0 ignored, 12 matched, 40 missed
[processed in 0.01 sec]
Missed line(s): too many to print.  Use --print-all-missed to print all 40 lines
```