### PR TITLE
Add an nft ipset backend for firewalld-ipset

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -55,6 +55,8 @@ ver. 1.1.1-dev-1 (20??/??/??) - development nightly edition
   by substitution of rich rule (gh-3815)
 * `filter.d/proxmox.conf` - add support to Proxmox Web GUI (gh-2966)
 * `filter.d/openvpn.conf` - new filter and jail for openvpn recognizing failed TLS handshakes (gh-2702)
+* `action.d/firewallcmd-ipset.conf` - add an nft ipset backend, which replaces
+the outdated iptables based ipset backend
 
 ver. 1.1.0 (2024/04/25) - object-found--norad-59479-cospar-2024-069a--altitude-36267km
 -----------

--- a/config/action.d/firewallcmd-ipset.conf
+++ b/config/action.d/firewallcmd-ipset.conf
@@ -7,7 +7,15 @@
 # This is for ipset protocol 6 (and hopefully later) (ipset v6.14).
 # Use ipset -V to see the protocol and version.
 #
+# This also supports nftables ipsets, which supercedes the older ipset
+# protocol since kernel version 3.13
+#
+# using the default firewall-cmd command set is quite slow at adding a large
+# number of ip addresses (at startup and shutdown for example), so using the
+# ipset or nftables backends may improve performance quite a lot.
+#
 # IPset was a feature introduced in the linux kernel 2.6.39 and 3.0.0 kernels.
+# nftables was a feature introduced in the linkux kernel 3.13.
 #
 # If you are running on an older kernel you make need to patch in external
 # modules.
@@ -19,12 +27,10 @@ before = firewallcmd-common.conf
 [Definition]
 
 actionstart = <ipsbackend_<ipsetbackend>/actionstart>
-              firewall-cmd --direct --add-rule <family> filter <chain> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
 
 actionflush = <ipsbackend_<ipsetbackend>/actionflush>
 
-actionstop = firewall-cmd --direct --remove-rule <family> filter <chain> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
-             <actionflush>
+actionstop = <actionflush>
              <ipsbackend_<ipsetbackend>/actionstop>
 
 actionban = <ipsbackend_<ipsetbackend>/actionban>
@@ -36,23 +42,44 @@ actionunban = <ipsbackend_<ipsetbackend>/actionunban>
 [ipsbackend_ipset]
 
 actionstart = ipset -exist create <ipmset> <ipsettype> timeout <default-ipsettime> maxelem <maxelem> <familyopt>
+              firewall-cmd --direct --add-rule <family> filter <chain> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
 
 actionflush = ipset flush <ipmset>
 
-actionstop = ipset destroy <ipmset> 2>/dev/null || { sleep 1; ipset destroy <ipmset>; }
+actionstop = firewall-cmd --direct --remove-rule <family> filter <chain> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
+             ipset destroy <ipmset> 2>/dev/null || { sleep 1; ipset destroy <ipmset>; }
 
 actionban = ipset -exist add <ipmset> <ip> timeout <ipsettime>
 
 actionunban = ipset -exist del <ipmset> <ip>
 
+[ipsbackend_nftables]
+# TODO: Currently only works with allports, add support for multiport
+actionstart = firewall-cmd --permanent --new-ipset=<ipmset> --type=<ipsettype> --option=maxelem=<maxelem>
+              firewall-cmd --reload
+              firewall-cmd --zone=<blockzone> --add-source=ipset:<ipmset>
+
+actionflush = nft flush set inet firewalld <ipmset>
+
+actionstop = firewall-cmd --zone=<blockzone> --remove-source=ipset:<ipmset>
+             firewall-cmd --permanent --delete-ipset=<ipmset>
+             firewall-cmd --reload
+
+actionban = nft add element inet firewalld <ipmset> { <ip> }
+
+actionunban = nft delete element inet firewalld <ipmset> { <ip> }
+
+
 [ipsbackend_firewalld]
 
 actionstart = firewall-cmd --direct --new-ipset=<ipmset> --type=<ipsettype> --option=timeout=<default-ipsettime> --option=maxelem=<maxelem> <firewalld_familyopt>
+              firewall-cmd --direct --add-rule <family> filter <chain> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
 
 # TODO: there doesn't seem to be an explicit way to invoke the ipset flush function using firewall-cmd
 actionflush = 
 
-actionstop = firewall-cmd --direct --delete-ipset=<ipmset>
+actionstop = firewall-cmd --direct --remove-rule <family> filter <chain> 0 <actiontype> -m set --match-set <ipmset> src -j <blocktype>
+             firewall-cmd --direct --delete-ipset=<ipmset>
 
 actionban = firewall-cmd --ipset=<ipmset> --add-entry=<ip>
 
@@ -94,9 +121,14 @@ timeout-bantime = $([ "<bantime>" -le 2147483 ] && echo "<bantime>" || echo 0)
 
 # Option: ipsetbackend
 # Notes.: defines the backend of ipset used for match-set (firewalld or ipset)
-# Values: firewalld or ipset
+# Values: firewalld, nftables or ipset
 # Default: ipset
-ipsetbackend = ipset
+ipsetbackend = nftables
+
+# Option:  blockzone
+# Notes    firewalld zone to use when blocking targets. Common values are block and drop.
+# Values:  STRING
+blockzone = block
 
 # Option: actiontype
 # Notes.: defines additions to the blocking rule
@@ -128,5 +160,5 @@ firewalld_familyopt = --option=family=inet6
 
 # DEV NOTES:
 #
-# Author: Edgar Hoch, Daniel Black, Sergey Brester and Mihail Politaev
+# Author: Edgar Hoch, Daniel Black, Sergey Brester, Mihail Politaev and Sebastian Pauka
 # firewallcmd-new / iptables-ipset-proto6 combined for maximum goodness


### PR DESCRIPTION
This PR adds a nftables-ipset backend to the `firewalld-ipset` action. Previously, this backend supported either using `firewall-cmd` directly or the iptables based `ipset` command. Running `firewall-cmd` is painfully slow for adding/removing large numbers of IP addresses, hence using `ipset` or `nft` is preferable for this purpose.

In addition, we allow setting the action via the normal firewalld zones, since the nftables-ipset backend is compatible with the firewalld ipsets.

TODO:
- [ ] Initial version only supports allports, should add support for multiport via a ip,port ipset.