### PR TITLE
Add filter for nginx HTTP errors (4xx and 5xx)

### DIFF
--- a/config/filter.d/nginx-http-errors.conf
+++ b/config/filter.d/nginx-http-errors.conf
@@ -1,0 +1,7 @@
+# Nginx client and server errors (HTTP 4xx or 5xx)
+#
+# Author: David Cook
+# Inspired by https://serverfault.com/a/849859/959055
+
+[Definition]
+failregex = <HOST> -.*"(GET|POST|HEAD).*HTTP.*" [4-5][0-9][0-9]


### PR DESCRIPTION
An excessive number of HTTP errors is likely abuse of some kind. 
This may include application login errors, if the app responds with an appropriate HTTP status code.

We use this filter to manage abusive traffic on a production server, so I wanted to contribute it for general use. 
This filter seems rather rudimentary compared to other built-in filters, so I'm open to any feedback about it. 
I see that fail2ban's focus is on "authentication errors", so maybe this is too general. But it seems useful enough as an optional filter.

If agreed, I am happy to go ahead and add tests.

Before submitting your PR, please review the following checklist:

- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves or describe the approach in detail
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [ ] **KEEP PR small** so it could be easily reviewed
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      (and `# failJSON`) within `fail2ban/tests/files/logs/X` file
- [ ] **PROVIDE ChangeLog** entry describing the pull request

ChangeLog: use PR title.