### PR TITLE
Line-wrap long messages in smtp.py

### DIFF
--- a/config/action.d/smtp.py
+++ b/config/action.d/smtp.py
@@ -19,7 +19,8 @@
 
 import socket
 import smtplib
-from email.mime.text import MIMEText
+import email.policy
+from email.message import EmailMessage
 from email.utils import formatdate, formataddr
 
 from fail2ban.server.actions import ActionBase, CallingMap
@@ -151,7 +152,8 @@ class SMTPAction(ActionBase):
 			See Python `smtplib` for full list of other possible
 			exceptions.
 		"""
-		msg = MIMEText(text)
+		msg = EmailMessage(policy=email.policy.SMTP)
+		msg.set_content(text)
 		msg['Subject'] = subject
 		msg['From'] = formataddr((self.fromname, self.fromaddr))
 		msg['To'] = self.toaddr


### PR DESCRIPTION
Pretty small change, and this shouldn't change the content of any message, just helps in deliverability for anyone who does use this action instead of sendmail. Details below.


### Problem

If `smtp.py` is set up as an action that includes "matches", and the log lines are very long (e.g. > 1,000) then some SMTP hosts will reject it. Some may even reject at 78 chars.  Example error responses:

```
500 Line too long (see RFC5321 4.5.3.1.6)
550 Maximum line length excxeeded (RFC 5322 2.1.1)
```


If one has very long log lines (e.g. with JSON logs), this is easy to trip when configured with `smtp.py[ ... matches="ipjailmatches"]`

_why_ this happens is described below in **Background**

### Proposed Solution

replacing `MIMEText` with `EmailMessage`.

The python docs call out the mime area as legacy/compat and recommends the higher-level message constructors. The semantic difference being that this is technically a "subpart" of a message, one mime part, and is not meant to be used as a full message. The _practical_ difference being even smaller: EmailMessage defaults will do the `"quoted-printable"` for you. 


### Background

Essentially, over SMTP (which is sent line-by-line), we want to "soft-wrap" lines below the limit.  So for a line of text that is 3000 chars, if we send it as-is, SMTP servers may reject it.  To do it "the right" way, you do  two things:

- set the header `Content-Transfer-Encoding: quoted-printable`
- send only like 76 characters per line, and end with `=` for lines that are "not done", just like you would escape a newline in a bash script with `\` at the end 

The person receiving the email doesn't see the soft wraps and equal signs. The email is put back together. This is just for transmission encoding.


### Alternatives

Another way to achieve the same:

```python
from email import charset

# ...

ch = charset.Charset()
ch.body_encoding = charset.QP # quoted-printable
msg = MIMEText(text, 'plain', ch)
```

This will also do the soft-wrapping.


### Demonstration

**current message handling**:
```py
#!/usr/bin/env python

from email.mime.text import MIMEText

longmsg = "my matches:\n" + "f"*1200
msg = MIMEText(longmsg)
print(msg.as_string())
```

<details>
<summary>output:</summary>

```
Content-Type: text/plain; charset="us-ascii"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit

my matches:
ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
```

</details>

---

**proposed**:
```py
#!/usr/bin/env python
import email.policy
from email.message import EmailMessage

longmsg = "my matches:\n" + "f"*1200
msg = EmailMessage(policy=email.policy.SMTP)
msg.set_content(longmsg)
print(msg.as_string())
```

<details>
<summary>output:</summary>

```
Content-Type: text/plain; charset="utf-8"
Content-Transfer-Encoding: quoted-printable
MIME-Version: 1.0

my matches:
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff=
fffffffffffffffffffffffffffffffffffffffffffff
```

</details>


(note: I don't think specifying the `policy` argument is even required to get the wrapping functionality required here, but it is good practice)