### PR TITLE
add space to output of "fail2ban-client get dbpurgeage"

### DIFF
--- a/fail2ban/client/beautifier.py
+++ b/fail2ban/client/beautifier.py
@@ -178,7 +178,7 @@ class Beautifier:
 					msg = "Database currently disabled"
 				else:
 					msg = "Current database purge age is:\n"
-					msg += "`- %iseconds" % response
+					msg += "`- %i seconds" % response
 			elif len(inC) < 3:
 				pass # to few cmd args for below
 			elif inC[2] in ("logpath", "addlogpath", "dellogpath"):


### PR DESCRIPTION
When running ```fail2ban-client get dbpurgeage```, I noticed there is no space between the value and the string "dbpurgeage" in the output.  This PR fixes that.

BEFORE:
```
# fail2ban-client get dbpurgeage
Current database purge age is:
`- 86400seconds
```

AFTER:
```
# fail2ban-client get dbpurgeage
Current database purge age is:
`- 86400 seconds
```

While preparing the patch, I noticed the apostrophe ` at the beginning of the line which seems out of place.  I noticed its presence in a number of other places in the code, so I wonder if it's intentional.  If not, I'd be happy to prepare another PR.  Let me know.