### PR TITLE
Update sendmail-reject.conf

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -55,6 +55,11 @@ ver. 1.1.1-dev-1 (20??/??/??) - development nightly edition
   - failregex extended to match different format of "Exit before auth" message (gh-3791)
 * `filter.d/recidive.conf` - restore possibility to set jail name in the filter, _jailname is positive now (gh-3769)
 * `filter.d/roundcube-auth.conf` - improved RE better matching log format of roundcube version 1.4+ (gh-3816)
+* `filter.d/sendmail-reject.conf`: (gh-4020)
+  - support `<F-MLFID>` for BSD-style logfiles
+  - add match for `User unknown` to default
+  - the relay field may not always have a hostname before the ip address
+  - mode `aggressive` enables match for `lost input channel` and `Cannot resolve PTR record`
 * `filter.d/sshd.conf`:
   - adapted to conform possible new daemon name sshd-session, since OpenSSH 9.8 
     several log messages will be tagged with as originating from a process named "sshd-session" rather than "sshd" (gh-3782)

--- a/config/filter.d/sendmail-reject.conf
+++ b/config/filter.d/sendmail-reject.conf
@@ -20,10 +20,10 @@ before = common.conf
 [Definition]
 
 _daemon = (?:(sm-(mta|acceptingconnections)|sendmail))
-__prefix_line = %(known/__prefix_line)s<F-MLFID>(?:\w{14,20}: )?</F-MLFID>
-prefregex = ^%(__prefix_line)s<F-CONTENT>.+</F-CONTENT>$
-
+__prefix_line = %(known/__prefix_line)s(?:\w{14,20}: )?
 addr = (?:(?:IPv6:)?<IP6>|<IP4>)
+
+prefregex = ^\s*(?:<mail\.[^\>]+> )?<F-MLFID>%(__prefix_line)s</F-MLFID><F-CONTENT>.+</F-CONTENT>$
 
 cmnfailre = ^ruleset=check_rcpt, arg1=(?P<email><\S+@\S+>), relay=(\S+ )?\[%(addr)s\](?: \(may be forged\))?, reject=(?:550 5\.7\.1(?: (?P=email)\.\.\.)?(?: Relaying denied\.)? (?:IP name possibly forged \[(\d+\.){3}\d+\]|Proper authentication required\.|IP name lookup failed \[(\d+\.){3}\d+\]|Fix reverse DNS for \S+)|[45]5[13] [45]\.1\.8(?: (?P=email)\.\.\.)? Domain of sender address \S+ does not (?:exist|resolve)|550 5\.[71]\.1 (?P=email)\.\.\. (Rejected: .*|User unknown))$
             ^ruleset=check_relay(?:, arg\d+=\S*)*, relay=(\S+ )?\[%(addr)s\](?: \(may be forged\))?, reject=421 4\.3\.2 (Connection rate limit exceeded\.|Too many open connections\.)$

--- a/config/filter.d/sendmail-reject.conf
+++ b/config/filter.d/sendmail-reject.conf
@@ -22,6 +22,11 @@ before = common.conf
 _daemon = (?:(sm-(mta|acceptingconnections)|sendmail))
 __prefix_line = %(known/__prefix_line)s(?:\w{14,20}: )?
 addr = (?:(?:IPv6:)?<IP6>|<IP4>)
+# mta_dname -- matches name of MTA daemon (typically specified in DAEMON_OPTIONS),
+# normally something without spaces like MTA-v4 or Deamon0, etc. If it'd contain spaces, one can
+# rewrite it in jail using  `filter = %(known/filter)s[mta_dname="[^,]+"]` or in .local overwrite
+# of the filter. (we would not use catch-alls here to satisfy obscure artificial case).
+mta_dname = \S+
 
 prefregex = ^\s*(?:<mail\.[^\>]+> )?<F-MLFID>%(__prefix_line)s</F-MLFID><F-CONTENT>.+</F-CONTENT>$
 
@@ -30,14 +35,14 @@ cmnfailre = ^ruleset=check_rcpt, arg1=(?P<email><\S+@\S+>), relay=(\S+ )?\[%(add
             ^rejecting commands from (\S* )?\[%(addr)s\] due to pre-greeting traffic after \d+ seconds$
             ^(?:\S+ )?\[%(addr)s\]: (?:(?i)expn|vrfy) \S+ \[rejected\]$
             ^<[^@]+@[^>]+>\.\.\. (?:No such user here|User unknown)$
-            ^<F-NOFAIL>from=<[^@]+@[^>]+></F-NOFAIL>, size=\d+, class=\d+, nrcpts=\d+,(?: bodytype=\w+,)? proto=E?SMTP, daemon=\S+, relay=(?:\S+ )?\[%(addr)s\]$
+            ^<F-NOFAIL>from=<[^@]+@[^>]+></F-NOFAIL>, size=\d+, class=\d+, nrcpts=\d+,(?: bodytype=\w+,)? proto=E?SMTP, daemon=%(mta_dname)s, relay=(?:\S+ )?\[%(addr)s\]$
 
 mdre-normal =
 
 mdre-extra = ^(?:\S+ )?\[%(addr)s\](?: \(may be forged\))? did not issue \S+ during connection
 
 mdre-aggressive = %(mdre-extra)s
-                  ^lost input channel from (?:\S+ )?\[%(addr)s\] to .*? after rcpt$
+                  ^lost input channel from (?:\S+ )?\[%(addr)s\] to %(mta_dname)s after rcpt$
                   ^ruleset=check_rcpt, arg1=(?P<email><\S+@\S+>), relay=(?:\S+ )?\[%(addr)s\](?: \(may be forged\))?, reject=(?:450 4\.4\.0(?: (?P=email)\.\.\.)?(?: Relaying temporarily denied\.)?(?: Cannot resolve PTR record for (\d+\.){3}\d+))$
 
 failregex = %(cmnfailre)s

--- a/config/filter.d/sendmail-reject.conf
+++ b/config/filter.d/sendmail-reject.conf
@@ -20,23 +20,25 @@ before = common.conf
 [Definition]
 
 _daemon = (?:(sm-(mta|acceptingconnections)|sendmail))
-__prefix_line = %(known/__prefix_line)s(?:\w{14,20}: )?
-addr = (?:(?:IPv6:)?<IP6>|<IP4>)
+__prefix_line = %(known/__prefix_line)s<F-MLFID>(?:\w{14,20}: )?</F-MLFID>
+prefregex = ^%(__prefix_line)s<F-CONTENT>.+</F-CONTENT>$
 
-prefregex = ^<F-MLFID>%(__prefix_line)s</F-MLFID><F-CONTENT>.+</F-CONTENT>$
+addr = (?:(?:IPv6:)?<IP6>|<IP4>)
 
 cmnfailre = ^ruleset=check_rcpt, arg1=(?P<email><\S+@\S+>), relay=(\S+ )?\[%(addr)s\](?: \(may be forged\))?, reject=(?:550 5\.7\.1(?: (?P=email)\.\.\.)?(?: Relaying denied\.)? (?:IP name possibly forged \[(\d+\.){3}\d+\]|Proper authentication required\.|IP name lookup failed \[(\d+\.){3}\d+\]|Fix reverse DNS for \S+)|[45]5[13] [45]\.1\.8(?: (?P=email)\.\.\.)? Domain of sender address \S+ does not (?:exist|resolve)|550 5\.[71]\.1 (?P=email)\.\.\. (Rejected: .*|User unknown))$
             ^ruleset=check_relay(?:, arg\d+=\S*)*, relay=(\S+ )?\[%(addr)s\](?: \(may be forged\))?, reject=421 4\.3\.2 (Connection rate limit exceeded\.|Too many open connections\.)$
             ^rejecting commands from (\S* )?\[%(addr)s\] due to pre-greeting traffic after \d+ seconds$
             ^(?:\S+ )?\[%(addr)s\]: (?:(?i)expn|vrfy) \S+ \[rejected\]$
-            ^<[^@]+@[^>]+>\.\.\. No such user here$
-            ^<F-NOFAIL>from=<[^@]+@[^>]+></F-NOFAIL>, size=\d+, class=\d+, nrcpts=\d+, bodytype=\w+, proto=E?SMTP, daemon=\S+, relay=\S+ \[%(addr)s\]$
+            ^<[^@]+@[^>]+>\.\.\. (?:No such user here|User unknown)$
+            ^<F-NOFAIL>from=<[^@]+@[^>]+></F-NOFAIL>, size=\d+, class=\d+, nrcpts=\d+,(?: bodytype=\w+,)? proto=E?SMTP, daemon=\S+, relay=(?:\S+ )?\[%(addr)s\]$
 
 mdre-normal =
 
 mdre-extra = ^(?:\S+ )?\[%(addr)s\](?: \(may be forged\))? did not issue \S+ during connection
 
 mdre-aggressive = %(mdre-extra)s
+                  ^lost input channel from (?:\S+ )?\[%(addr)s\] to .*? after rcpt$
+                  ^ruleset=check_rcpt, arg1=(?P<email><\S+@\S+>), relay=(?:\S+ )?\[%(addr)s\](?: \(may be forged\))?, reject=(?:450 4\.4\.0(?: (?P=email)\.\.\.)?(?: Relaying temporarily denied\.)?(?: Cannot resolve PTR record for (\d+\.){3}\d+))$
 
 failregex = %(cmnfailre)s
             <mdre-<mode>>
@@ -63,6 +65,8 @@ journalmatch = SYSLOG_IDENTIFIER=sm-mta + _SYSTEMD_UNIT=sendmail.service
 # Note the capture <F-MLFID>, includes both the __prefix_lines (which includes
 # the sendmail PID), but also the `\w{14}` which the the sendmail assigned 
 # mail ID (todo: check this is necessary, possible obsolete).
+# Avoid moving <F-MLFID> into the entire prefregex because the grouped messages we 
+# need have different syslog levels (info vs notice) that break the group if BSD verbose format is set
 #
 # Author: Daniel Black, Fabian Wenk and Sergey Brester aka sebres.
 # Rewritten using prefregex by Serg G. Brester.

--- a/fail2ban/tests/files/logs/sendmail-reject
+++ b/fail2ban/tests/files/logs/sendmail-reject
@@ -125,8 +125,8 @@ Mar 29 22:51:46 server sm-mta[50438]: 06QDQnNf050438: example.com [IPv6:2001:DB8
 
 # filterOptions: {"mode": "aggressive"}
 
-# failJSON: { "time": "2005-06-17T13:03:43", "match": true, "host": "127.0.0.1" }
-Jun 17 13:03:43 <mail.notice> robin sm-mta[26864]: 55HH324M026864: lost input channel from localhost [127.0.0.1] to MTA-v4 after rcpt
+# failJSON: { "time": "2005-07-31T13:03:43", "match": true, "host": "139.162.120.196" }
+Jul 31 13:03:43 <mail.notice> alarmpi sm-mta[24291]: 56VFYCxS024291: lost input channel from mail.aqicn.org [139.162.120.196] to MTA-v4 after rcpt
 
 # failJSON: { "time": "2005-06-18T08:05:17", "match": true, "host": "45.125.66.67" }
 Jun 18 08:05:17 <mail.notice> myhost sm-mta[17002]: 55IC59VD017002: ruleset=check_rcpt, arg1=<spameri@tiscali.it>, relay=[45.125.66.67], reject=450 4.4.0 <spameri@tiscali.it>... Relaying temporarily denied. Cannot resolve PTR record for 45.125.66.67

--- a/fail2ban/tests/files/logs/sendmail-reject
+++ b/fail2ban/tests/files/logs/sendmail-reject
@@ -86,8 +86,6 @@ Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026251: <anatoliy@domain.com>
 Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026252: <artem@domain.com>... No such user here
 # failJSON: { "match": false }
 Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026252: <anto@domain.com>... No such user here
-# failJSON: { "match": false, "desc": "Add User unknown" }
-Jun 17 14:37:39 <mail.notice> robin sm-mta[2794]: 55HIbcGI002794: <baduser@yourhost.com>... User unknown
 
 # failJSON: { "match": false }
 Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026254: <davaojk25@domain.com>... No such user here
@@ -99,10 +97,10 @@ Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026252: <anton@domain.com>...
 # failJSON: { "match": false, "desc": "Different mail ID shouldn't match" }
 Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026255: from=<anton@domain.com>, size=0, class=0, nrcpts=0, bodytype=8BITMIME, proto=ESMTP, daemon=MTA, relay=163.23.32.95.dsl-dynamic.vsi.ru [95.32.23.163]
 
+# failJSON: { "match": false, "desc": "Add User unknown" }
+Jun 17 14:37:39 <mail.notice> robin sm-mta[2794]: 55HIbcGI002794: <baduser@yourhost.com>... User unknown
 # failJSON: { "time": "2005-06-17T14:37:39", "match": true, "host": "192.168.1.45", "desc": "BSD style log format with no hostname for the relay." }
 Jun 17 14:37:39 <mail.info> robin sm-mta[2794]: 55HIbcGI002794: from=<root@yourhost.com>, size=108, class=0, nrcpts=0, proto=ESMTP, daemon=MTA-v4, relay=[192.168.1.45]
-
-
 
 # filterOptions: {"mode": "extra"}
 

--- a/fail2ban/tests/files/logs/sendmail-reject
+++ b/fail2ban/tests/files/logs/sendmail-reject
@@ -86,6 +86,8 @@ Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026251: <anatoliy@domain.com>
 Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026252: <artem@domain.com>... No such user here
 # failJSON: { "match": false }
 Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026252: <anto@domain.com>... No such user here
+# failJSON: { "match": false, "desc": "Add User unknown" }
+Jun 17 14:37:39 <mail.notice> robin sm-mta[2794]: 55HIbcGI002794: <baduser@yourhost.com>... User unknown
 
 # failJSON: { "match": false }
 Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026254: <davaojk25@domain.com>... No such user here
@@ -96,6 +98,11 @@ Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026254: from=<davaojk25@domai
 Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026252: <anton@domain.com>... No such user here
 # failJSON: { "match": false, "desc": "Different mail ID shouldn't match" }
 Nov  3 11:35:30 Microsoft sendmail[26254]: rA37ZTSC026255: from=<anton@domain.com>, size=0, class=0, nrcpts=0, bodytype=8BITMIME, proto=ESMTP, daemon=MTA, relay=163.23.32.95.dsl-dynamic.vsi.ru [95.32.23.163]
+
+# failJSON: { "time": "2005-06-17T14:37:39", "match": true, "host": "192.168.1.45", "desc": "BSD style log format with no hostname for the relay." }
+Jun 17 14:37:39 <mail.info> robin sm-mta[2794]: 55HIbcGI002794: from=<root@yourhost.com>, size=108, class=0, nrcpts=0, proto=ESMTP, daemon=MTA-v4, relay=[192.168.1.45]
+
+
 
 # filterOptions: {"mode": "extra"}
 
@@ -115,3 +122,12 @@ Mar 29 22:51:43 server sendmail[3529565]: xA32R2PQ3529565: [192.0.2.2] did not i
 Mar 29 22:51:45 server sm-mta[50437]: 06QDQnNf050437: example.com [192.0.2.3] did not issue MAIL/EXPN/VRFY/ETRN during connection to IPv4
 # failJSON: { "time": "2005-03-29T22:51:46", "match": true , "host": "2001:DB8::1", "desc": "IPv6" }
 Mar 29 22:51:46 server sm-mta[50438]: 06QDQnNf050438: example.com [IPv6:2001:DB8::1] did not issue MAIL/EXPN/VRFY/ETRN during connection to IPv6
+
+# filterOptions: {"mode": "aggressive"}
+
+# failJSON: { "time": "2005-06-17T13:03:43", "match": true, "host": "127.0.0.1" }
+Jun 17 13:03:43 <mail.notice> robin sm-mta[26864]: 55HH324M026864: lost input channel from localhost [127.0.0.1] to MTA-v4 after rcpt
+
+# failJSON: { "time": "2005-06-18T08:05:17", "match": true, "host": "45.125.66.67" }
+Jun 18 08:05:17 <mail.notice> myhost sm-mta[17002]: 55IC59VD017002: ruleset=check_rcpt, arg1=<spameri@tiscali.it>, relay=[45.125.66.67], reject=450 4.4.0 <spameri@tiscali.it>... Relaying temporarily denied. Cannot resolve PTR record for 45.125.66.67
+


### PR DESCRIPTION
Fixes:

- change the F-MLFID to only capture the sendmail sequence number rather than the full prefix line because when using BSD verbose the multiline messages come in with different pri and will break the group (e.g. <mail.info> and <mail.notice>)
- add regex for lost input channel messages and update it for the current sendmail (after mail vs after rcpt)

[sample.txt](https://github.com/user-attachments/files/20782189/sample.txt)
