### PR TITLE
filter.d/asterisk: fix regex to match "No matching endpoint found" with retry info

### DIFF
--- a/config/filter.d/asterisk.conf
+++ b/config/filter.d/asterisk.conf
@@ -27,7 +27,8 @@ failregex = ^Registration from '[^']*' failed for '<HOST>(:\d+)?' - (?:Wrong pas
             ^hacking attempt detected '<HOST>'$
             ^SecurityEvent="(?:FailedACL|InvalidAccountID|ChallengeResponseFailed|InvalidPassword)"(?:(?:,(?!RemoteAddress=)\w+="[^"]*")*|.*?),RemoteAddress="IPV[46]/[^/"]+/<HOST>/\d+"(?:,(?!RemoteAddress=)\w+="[^"]*")*$
             ^"Rejecting unknown SIP connection from <HOST>(?::\d+)?"$
-            ^Request (?:'[^']*' )?from '(?:[^']*|.*?)' failed for '<HOST>(?::\d+)?'\s\(callid: [^\)]*\) - (?:No matching endpoint found|Not match Endpoint(?: Contact)? ACL|(?:Failed|Error) to authenticate)\s*$
+            ^Request (?:'[^']*' )?from '(?:[^']*|.*?)' failed for '<HOST>(?::\d+)?'\s\(callid: [^\)]*\) - No matching endpoint found(?:\s+after\s+\d+\s+tries\s+in\s+[\d.]+\s+ms)?\s*$
+            ^Request (?:'[^']*' )?from '(?:[^']*|.*?)' failed for '<HOST>(?::\d+)?'\s\(callid: [^\)]*\) - (?:Not match Endpoint(?: Contact)? ACL|(?:Failed|Error) to authenticate)\s*$
 
 # FreePBX (todo: make optional in v.0.10):
 #            ^(%(__prefix_line)s|\[\]\s*WARNING%(__pid_re)s:?(?:\[C-[\da-f]*\])? )[^:]+: Friendly Scanner from <HOST>$

--- a/fail2ban/tests/files/logs/asterisk
+++ b/fail2ban/tests/files/logs/asterisk
@@ -108,6 +108,8 @@ Nov 4 18:30:40 localhost asterisk[32229]: NOTICE[32257]: chan_sip.c:23417 in han
 # PJSip Errors
 # failJSON: { "time": "2016-05-06T07:08:09", "match": true, "host": "192.0.2.6" }
 [2016-05-06 07:08:09] NOTICE[17103] res_pjsip/pjsip_distributor.c: Request from '"test1" <sip:test1@2.3.4.5>' failed for '192.0.2.6:5678' (callid: deadbeef) - No matching endpoint found
+# failJSON: { "time": "2016-05-06T07:08:09", "match": true, "host": "192.0.2.7", "desc": "Test for No matching endpoint found with retry counts (pattern 1)" }
+[2016-05-06 07:08:09] NOTICE[17103] res_pjsip/pjsip_distributor.c: Request 'INVITE' from '"test2" <sip:test2@3.4.5.6>' failed for '192.0.2.7:5679' (callid: cafebabe) - No matching endpoint found after 5 tries in 2.500 ms
 
 # # FreePBX Warnings
 # #_dis_failJSON: { "time": "2016-05-06T07:08:09", "match": true, "host": "192.0.2.4" }


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves or describe the approach in detail
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [ ] **KEEP PR small** so it could be easily reviewed
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      (and `# failJSON`) within `fail2ban/tests/files/logs/X` file
- [ ] **PROVIDE ChangeLog** entry describing the pull request


## Issue
This PR fixes the regex pattern that fails to match newer Asterisk log entries for "No matching endpoint found" events.

## Current behavior
The regex doesn't match when Asterisk logs use the newer format with detailed retry information:
```
Request 'REGISTER' from '"8464" <[sip:8464@34.97.118.227](https://hoge.foo/hoge/d98e5e63-9371-4af8-9884-2d5334de7940)>' failed for '117.55.202.19:7505' (callid: 4250754195) - No matching endpoint found after 7 tries in 1.037 ms
```

## Fix
Update the regex pattern to handle both:
- Legacy format: `No matching endpoint found from '192.168.1.100' (message ignored)`
- New format: `Request 'REGISTER' from ... failed for 'IP:PORT' ... - No matching endpoint found after X tries in Y ms`
