### PR TITLE
Use systemd as default backend for Debian in .deb packages

### DIFF
--- a/config/paths-debian.conf
+++ b/config/paths-debian.conf
@@ -13,6 +13,7 @@ banaction = nftables
 banaction_allports = nftables[type=allports]
 
 sshd_backend = systemd
+postfix_backend = systemd
 
 syslog_mail = /var/log/mail.log
 


### PR DESCRIPTION
Even though it was added to the `master` branch when merging #3527 (in 0b255a8), it is missing from the `debian` branch.