### PR TITLE
remove website from documentation / information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,7 @@ email details to fail2ban-vulnerabilities at lists dot sourceforge dot net .
 
 ### You need some new features, you found bugs?
 visit [Issues](https://github.com/fail2ban/fail2ban/issues)
-and if your issue is not yet known -- file a bug report. See
-[Fail2Ban wiki](http://www.fail2ban.org/wiki/index.php/HOWTO_Seek_Help)
-on further instructions.
+and if your issue is not yet known -- file a bug report.
 
 ### You would like to troubleshoot or discuss?
 join the [mailing list](https://lists.sourceforge.net/lists/listinfo/fail2ban-users)

--- a/DEVELOP
+++ b/DEVELOP
@@ -18,8 +18,8 @@ well as a web-based Git repository browser and an issue tracker.
 
 If you are familiar with Python and you have a bug fix or a feature that you
 would like to add to Fail2Ban, the best way to do so it to use the GitHub Pull
-Request feature. You can find more details on the Fail2Ban wiki
-(http://www.fail2ban.org/wiki/index.php/Get_Involved)
+Request feature. You can find more details on the Fail2Ban developer docs.
+(https://fail2ban.readthedocs.io/)
 
 Pull Requests
 =============

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ mechanisms if you really want to protect services.
 ------|------
 
 This README is a quick introduction to Fail2Ban. More documentation, FAQ, and HOWTOs
-to be found on fail2ban(1) manpage, [Wiki](https://github.com/fail2ban/fail2ban/wiki),
-[Developers documentation](https://fail2ban.readthedocs.io/)
-and the website: https://www.fail2ban.org
+to be found on fail2ban(1) manpage, [Wiki](https://github.com/fail2ban/fail2ban/wiki) and the [Developers documentation](https://fail2ban.readthedocs.io/)
 
 Installation:
 -------------

--- a/RELEASE
+++ b/RELEASE
@@ -160,27 +160,6 @@ Pre Release
 
 * Upload source/binaries to sourceforge http://sourceforge.net/projects/fail2ban/
 
-* Run the following and update the wiki with output::
-
-    python -c 'import fail2ban.protocol; fail2ban.protocol.printWiki()'
-
-  * page: http://www.fail2ban.org/wiki/index.php/Commands
-
-
-* Update:
-
-  * http://www.fail2ban.org/wiki/index.php?title=Template:Fail2ban_Versions&action=edit
-
-  * http://www.fail2ban.org/wiki/index.php?title=Template:Fail2ban_News&action=edit
-    * move old bits to http://www.fail2ban.org/wiki/index.php?title=Template:Fail2ban_OldNews&action=edit
-
-  * http://www.fail2ban.org/wiki/index.php/ChangeLog
-  * http://www.fail2ban.org/wiki/index.php/Requirements (Check requirement)
-  * http://www.fail2ban.org/wiki/index.php/Features
-
-* See if any filters are upgraded:
-  http://www.fail2ban.org/wiki/index.php/Special:AllPages
-
 * Email users and development list of release
 
 * notify distributors

--- a/files/cacti/README
+++ b/files/cacti/README
@@ -28,8 +28,6 @@ Contact:
 You need some new features, you found bugs or you just
 appreciate this program, you can contact me at:
 
-Website: http://www.fail2ban.org
-
 Cyril Jaquier: <cyril.jaquier@fail2ban.org>
 
 License:


### PR DESCRIPTION
This PR removes references to the website in documentation / information / procedures. In it's current form the "website" does just redirect to the GH repo and is mostly useless. Were possible I tried to link resources I know of instead.

The corresponding issue #2580 is already open for over five years, I don't think that the website will be back soon or that if and when it comes back all of the more specific links will work.

I did not touch any references in source files, even in comments.
