### PR TITLE
clientreadertestcase.py: set correct config dir for testReadStockJailFilterComplete

### DIFF
--- a/fail2ban/tests/clientreadertestcase.py
+++ b/fail2ban/tests/clientreadertestcase.py
@@ -878,7 +878,7 @@ class JailsReaderTest(LogCaptureTestCase):
 		self.assertTrue(jails.getOptions())       # reads fine
 		# grab all filter names
 		filters = set(os.path.splitext(os.path.split(a)[1])[0]
-			for a in glob.glob(os.path.join('config', 'filter.d', '*.conf'))
+			for a in glob.glob(os.path.join(CONFIG_DIR, 'filter.d', '*.conf'))
 				if not (a.endswith('common.conf') or a.endswith('-aggressive.conf')))
 		# get filters of all jails (filter names without options inside filter[...])
 		filters_jail = set(


### PR DESCRIPTION

In test case testReadStockJailFilterComplete, set configuration directory to CONFIG_DIR (/etc/fail2ban/filter.d on the target) instead of the hardcoded "config" directory. Otherwise, the config files will not be found during runtime testing.

Before submitting your PR, please review the following checklist:

- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves or describe the approach in detail
- [ ] **MAKE SURE** this PR doesn't break existing tests
- [ ] **KEEP PR small** so it could be easily reviewed
- [ ] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      (and `# failJSON`) within `fail2ban/tests/files/logs/X` file
- [ ] **PROVIDE ChangeLog** entry describing the pull request
