### PR TITLE
filter.d/postfix.conf: Add optional "NOQUEUE:" to mdpr-ddos

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -51,6 +51,7 @@ ver. 1.1.1-dev-1 (20??/??/??) - development nightly edition
 * `filter.d/postfix.conf`:
   - consider CONNECT and other rejected commands as a valid `_pref` (gh-3800)
   - default `_daemon` in prefix-line is loosened - can match everything starting with word postfix, like `postfix-example.com/smtpd` (gh-3297)
+  - add optional `NOQUEUE:` prefix to ddos regex (gh-4072)
 * `filter.d/dropbear.conf`:
   - recognizes extra pid/timestamp if logged into stdout/journal, added `journalmatch` (gh-3597)
   - failregex extended to match different format of "Exit before auth" message (gh-3791)

--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -38,7 +38,7 @@ mdre-more = %(mdre-normal)s
 
 # Includes some of the log messages described in
 # <http://www.postfix.org/POSTSCREEN_README.html>.
-mdpr-ddos = (?:lost connection after (?!(?:DATA|AUTH)\b)[A-Z]+|disconnect(?= from \S+(?: \S+=\d+)* auth=0/(?:[1-9]|\d\d+))|(?:PREGREET \d+|HANGUP) after \S+|COMMAND (?:TIME|COUNT|LENGTH) LIMIT)
+mdpr-ddos = (?:NOQUEUE: )?(?:lost connection after (?!(?:DATA|AUTH)\b)[A-Z]+|disconnect(?= from \S+(?: \S+=\d+)* auth=0/(?:[1-9]|\d\d+))|(?:PREGREET \d+|HANGUP) after \S+|COMMAND (?:TIME|COUNT|LENGTH) LIMIT)
 mdre-ddos = ^from [^[]*\[<HOST>\]%(_port)s:?
 
 mdpr-extra = (?:%(mdpr-auth)s|%(mdpr-normal)s)

--- a/fail2ban/tests/files/logs/postfix
+++ b/fail2ban/tests/files/logs/postfix
@@ -187,6 +187,9 @@ Jun  8 23:14:28 proxy2 postfix/postscreen[473]: COMMAND TIME LIMIT from [192.0.2
 # failJSON: { "time": "2005-06-08T23:14:54", "match": true , "host": "192.0.2.26", "desc": "abusive clients hitting command limit (gh-3040)" }
 Jun  8 23:14:54 proxy2 postfix/postscreen[473]: COMMAND COUNT LIMIT from [192.0.2.26]:15592 after RCPT
 
+# failJSON: { "time": "2004-09-17T18:19:20", "match": true , "host": "192.0.2.25" }
+Sep 17 18:19:20 mxhost postfix/smtpd[12345]: NOQUEUE: lost connection after CONNECT from unknown[192.0.2.25]
+
 
 # filterOptions: [{}, {"mode": "ddos"}, {"mode": "aggressive"}]
 # failJSON: { "match": false, "desc": "don't affect lawful data (sporadical connection aborts within DATA-phase, see gh-1813 for discussion)" }


### PR DESCRIPTION
The current regex doesn't match the following log entry, seen with Postfix 3.10.2:

Sep 17 18:19:20 mxhost postfix/smtpd[12345]: NOQUEUE: lost connection after CONNECT from unknown[192.0.2.25]
Sep 17 18:19:20 mxhost postfix/smtpd[12345]: disconnect from unknown[192.0.2.25] commands=0/0

Before submitting your PR, please review the following checklist:

- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves or describe the approach in detail
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      (and `# failJSON`) within `fail2ban/tests/files/logs/X` file
- [x] **PROVIDE ChangeLog** entry describing the pull request
