### PR TITLE
Add ELLIO action

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -76,6 +76,8 @@ ver. 1.1.1-dev-1 (20??/??/??) - development nightly edition
 * `filter.d/froxlor-auth.conf` - updated the regex to the new logging situation for froxlor and changed logpath in jail.conf (gh-4075).	
 
 ### New Features and Enhancements
+* `action.d/ellio.conf` - new action to send blocked IPs to ELLIO EDL (External Dynamic List) Management for centralized
+  IP blocking and multi-firewall deployment
 * backend `systemd` extended with new parameter `rotated` (default `false`, as prevention against "too many open files"),
   that allows to monitor only actual journals and ignore now a lot of rotated files by default; so can drastically reduce
   amount of used file descriptors, normally to 1 or 2 descriptors per jail (gh-3391)

--- a/config/action.d/ellio.conf
+++ b/config/action.d/ellio.conf
@@ -1,0 +1,79 @@
+# Fail2ban action configuration for ELLIO API
+#
+# This action sends blocked IPs to ELLIO's EDL (External Dynamic List) Management Platform
+# for centralized IP blocking and distribution across multiple firewalls.
+#
+# Usage in jail.conf or jail.local:
+#   action = ellio-api[api_key="your_api_key",
+#                      ruleset_id="your_ruleset_id",
+#                      expires_in_days="14"]
+#
+# Author: ELLIO Technology Integration
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
+# Values:  CMD
+#
+actionstart =
+
+# Option:  actionstop
+# Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
+# Values:  CMD
+#
+actionstop =
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+actioncheck =
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    <ip>  IP address
+#          <failures>  number of failures
+#          <time>  unix timestamp of the ban time
+#          <name> name of the jail
+# Values:  CMD
+# 
+# Using https://docs.ellio.tech/edl-management/API/add-rule to dynamicaly populate IP Ruleset
+actionban = curl -s -o /dev/null -X POST \
+            -H "accept: application/json" \
+            -H "X-API-Key: <api_key>" \
+            -H "Content-Type: application/json" \
+            -d '{"conflict_resolution": "extend", "expires_in_days": <expires_in_days>, "ip": "<ip>", "name": "<name> - <failures> failures - banned at '"$(date --date=@<time> +'%%Y-%%m-%%d %%H:%%M:%%S')"'"}' \
+            <_ellio_api_url>
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    <ip>  IP address
+#          <failures>  number of failures
+#          <time>  unix timestamp of the ban time
+# Values:  CMD
+#
+# Note: We'll leave this empty as the rules will expire automatically. When this intergration is deployed to multiple machines unbanning is not advised. 
+actionunban =
+
+# API endpoint URL
+_ellio_api_url = https://api.ellio.tech/v1/edl/ip-rulesets/<ruleset_id>/rules
+
+[Init]
+
+# Option:  api_key
+# Notes:   Your ELLIO API key for authentication (required)
+# Values:  STRING  Default: None
+api_key = 
+
+# Option:  ruleset_id
+# Notes:   The ruleset ID where blocked IPs will be added (required)
+# Values:  STRING  Default: None
+ruleset_id = 
+
+# Option:  expires_in_days
+# Notes:   Number of days before the IP block expires
+# Values:  INTEGER  Default: 14
+expires_in_days = 14


### PR DESCRIPTION
Add ELLIO action to push banned IPs for EDL IP Rulesets, using it as a source for blocking across multiple EDLs (External Dynamic Lists).
