### PR TITLE
Add Discord webhook notification action

### DIFF
--- a/config/action.d/discord-webhook.conf
+++ b/config/action.d/discord-webhook.conf
@@ -1,0 +1,51 @@
+# Fail2Ban configuration file for Discord Webhook notifications
+#
+# Author: JY
+#
+#
+# [Usage]
+#
+# To enable this action, add the following to your jail.local file:
+#
+# [DEFAULT]
+# action = %(action_)s
+#          discord-webhook[webhook="YOUR_DISCORD_WEBHOOK_URL"]
+#
+# Or for a specific jail:
+#
+# [sshd]
+# action = discord-webhook[webhook="YOUR_DISCORD_WEBHOOK_URL"]
+#
+
+[Definition]
+
+# Option:  actionstart
+actionstart = curl -X POST -H "Content-Type: application/json" \
+            -d '{"content": ":white_check_mark: [Fail2Ban] Jail **<name>** has been started on **<fq-hostname>**."}' \
+            <webhook>
+
+# Option:  actionstop
+actionstop = curl -X POST -H "Content-Type: application/json" \
+           -d '{"content": ":octagonal_sign: [Fail2Ban] Jail **<name>** has been stopped on **<fq-hostname>**."}' \
+           <webhook>
+
+# Option:  actioncheck
+actioncheck =
+
+# Option:  actionban
+actionban = curl -X POST -H "Content-Type: application/json" \
+          -d '{"content": ":lock: [Fail2Ban] **BANNED** \n**Jail:** <name>\n**IP:** <ip>\n**Failures:** <failures>\n**Host:** <fq-hostname>"}' \
+          <webhook>
+
+# Option:  actionunban
+actionunban = curl -X POST -H "Content-Type: application/json" \
+            -d '{"content": ":unlock: [Fail2Ban] **UNBANNED** \n**Jail:** <name>\n**IP:** <ip>\n**Host:** <fq-hostname>"}' \
+            <webhook>
+
+[Init]
+
+# Default name of the jail
+name = default
+
+# Discord Webhook URL (Override this in your jail.local)
+webhook = https://discord.com/api/webhooks/your-default-webhook


### PR DESCRIPTION
Description
This PR introduces a new action configuration `config/action.d/discord-webhook.conf` to enable real-time security notifications via **Discord Webhooks**.

This integration allows Fail2ban to send instant alerts to a Discord channel when:
- A Jail is started or stopped.
- An IP address is banned (includes Jail name, IP, and failure count).
- An IP address is unbanned.

### Usage
To enable this action, users simply need to add the following configuration to their `jail.local` file:

[DEFAULT]
# Define the action and provide your Discord Webhook URL
action = discord-webhook[webhook="YOUR_DISCORD_WEBHOOK_URL"]

# Or enable it for a specific jail:
[sshd]
enabled = true
action = discord-webhook[webhook="YOUR_DISCORD_WEBHOOK_URL"]