### PR TITLE
fix: replace 20 bare except clauses with except Exception

### DIFF
--- a/fail2ban/client/configparserinc.py
+++ b/fail2ban/client/configparserinc.py
@@ -202,7 +202,7 @@ after = 1.conf
 				rplcmnt = 1
 				try: # set it in map-vars (consider different python versions):
 					defaults[sopt] = v
-				except:
+				except Exception:
 					# try to set in first default map (corresponding vars):
 					try:
 						defaults._maps[0][sopt] = v

--- a/fail2ban/compat/asyncore.py
+++ b/fail2ban/compat/asyncore.py
@@ -83,7 +83,7 @@ def read(obj):
         obj.handle_read_event()
     except _reraised_exceptions:
         raise
-    except:
+    except Exception:
         obj.handle_error()
 
 def write(obj):
@@ -91,7 +91,7 @@ def write(obj):
         obj.handle_write_event()
     except _reraised_exceptions:
         raise
-    except:
+    except Exception:
         obj.handle_error()
 
 def _exception(obj):
@@ -99,7 +99,7 @@ def _exception(obj):
         obj.handle_expt_event()
     except _reraised_exceptions:
         raise
-    except:
+    except Exception:
         obj.handle_error()
 
 def readwrite(obj, flags):
@@ -119,7 +119,7 @@ def readwrite(obj, flags):
             obj.handle_close()
     except _reraised_exceptions:
         raise
-    except:
+    except Exception:
         obj.handle_error()
 
 def poll(timeout=0.0, map=None):
@@ -459,7 +459,7 @@ class dispatcher:
         # sometimes a user repr method will crash.
         try:
             self_repr = repr(self)
-        except:
+        except Exception:
             self_repr = '<__repr__(self) failed for object at %0x>' % id(self)
 
         self.log_info(
@@ -563,7 +563,7 @@ def close_all(map=None, ignore_all=False):
                 raise
         except _reraised_exceptions:
             raise
-        except:
+        except Exception:
             if not ignore_all:
                 raise
     map.clear()

--- a/fail2ban/helpers.py
+++ b/fail2ban/helpers.py
@@ -36,7 +36,7 @@ import importlib
 try:
 	import ctypes
 	_libcap = ctypes.CDLL('libcap.so.2')
-except:
+except Exception:
 	_libcap = None
 
 
@@ -187,7 +187,7 @@ def __stopOnIOError(logSys=None, logHndlr=None): # pragma: no cover
 	if logging.exitOnIOError:
 		try:
 			sys.stderr.close()
-		except:
+		except Exception:
 			pass
 		sys.exit(0)
 

--- a/fail2ban/server/failregex.py
+++ b/fail2ban/server/failregex.py
@@ -94,7 +94,7 @@ R_MAP = {
 try:
 	re.search("^re(?i:val)$", "reVAL")
 	R_GLOB2LOCFLAGS = ( re.compile(r"(?<!\\)\((?:\?:)?(\(\?[a-z]+)\)"), r"\1:" )
-except:
+except Exception:
 	R_GLOB2LOCFLAGS = ()
 
 def mapTag2Opt(tag):

--- a/fail2ban/server/filtersystemd.py
+++ b/fail2ban/server/filtersystemd.py
@@ -194,7 +194,7 @@ class FilterSystemd(JournalFilter): # pragma: systemd no cover
 				ja = self.__jrnlargs
 				super(journal.Reader, self.__journal).__init__(
 					ja.get('flags', 0), ja.get('path'), ja.get('files'), ja.get('namespace'))
-			except:
+			except Exception:
 				# cannot reopen in that way, so simply recreate reader:
 				self.closeJournal()
 				self.__journal = journal.Reader(**self.__jrnlargs)

--- a/fail2ban/server/ipdns.py
+++ b/fail2ban/server/ipdns.py
@@ -204,7 +204,7 @@ class DNSUtils:
 		# try to obtain from network interfaces if possible (implemented for this platform):
 		try:
 			ips = IPAddrSet([a for ni, a in DNSUtils._NetworkInterfacesAddrs()])
-		except:
+		except Exception:
 			ips = IPAddrSet()
 		# cache and return :
 		DNSUtils.CACHE_nameToIp.set(DNSUtils._getNetIntrfIPs_key, ips)
@@ -257,7 +257,7 @@ class DNSUtils:
 			with open('/proc/sys/net/ipv6/conf/all/disable_ipv6', 'rb') as f:
 				# if 1 - disabled, 0 - enabled
 				return not int(f.read())
-		except:
+		except Exception:
 			pass
 		s = None
 		try:

--- a/fail2ban/server/server.py
+++ b/fail2ban/server/server.py
@@ -939,7 +939,7 @@ class Server:
 					os.close(fd)
 				except OSError:   # ERROR (ignore)
 					pass
-		except:
+		except Exception:
 			try:
 				maxfd = os.sysconf("SC_OPEN_MAX")
 			except (AttributeError, ValueError):

--- a/fail2ban/tests/actiontestcase.py
+++ b/fail2ban/tests/actiontestcase.py
@@ -241,14 +241,14 @@ class CommandActionTest(LogCaptureTestCase):
 		setattr(self.__action, 'ac', "<a><b>")
 		setattr(self.__action, 'ab', "<ac>")
 		setattr(self.__action, 'x?family=inet6', "")
-		# produce self-referencing properties except:
+		# produce self-referencing properties except Exception:
 		self.assertRaisesRegex(ValueError, r"properties contain self referencing definitions",
 			lambda: self.__action.replaceTag("<a><b>", 
 				self.__action._properties, conditional="family=inet4")
 		)
 		# remote self-referencing in props:
 		delattr(self.__action, 'ac')
-		# produce self-referencing query except:
+		# produce self-referencing query except Exception:
 		self.assertRaisesRegex(ValueError, r"possible self referencing definitions in query",
 			lambda: self.__action.replaceTag("<x"*30+">"*30,
 				self.__action._properties, conditional="family=inet6")

--- a/fail2ban/tests/filtertestcase.py
+++ b/fail2ban/tests/filtertestcase.py
@@ -70,11 +70,11 @@ def open(*args):
 def _killfile(f, name):
 	try:
 		f.close()
-	except:
+	except Exception:
 		pass
 	try:
 		os.unlink(name)
-	except:
+	except Exception:
 		pass
 
 	# there might as well be the .bak file

--- a/fail2ban/tests/misctestcase.py
+++ b/fail2ban/tests/misctestcase.py
@@ -43,7 +43,7 @@ class HelpersTest(unittest.TestCase):
 	def testFormatExceptionInfoBasic(self):
 		try:
 			raise ValueError("Very bad exception")
-		except:
+		except Exception:
 			name, args = formatExceptionInfo()
 			self.assertEqual(name, "ValueError")
 			self.assertEqual(args, "Very bad exception")
@@ -51,7 +51,7 @@ class HelpersTest(unittest.TestCase):
 	def testFormatExceptionConvertArgs(self):
 		try:
 			raise ValueError("Very bad", None)
-		except:
+		except Exception:
 			name, args = formatExceptionInfo()
 			self.assertEqual(name, "ValueError")
 			# might be fragile due to ' vs "


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance. Bare except catches SystemExit, KeyboardInterrupt, and GeneratorExit which is rarely intended.