### PR TITLE
Wrap email content to comply with SMTP line length limit (RFC 5321)

### DIFF
--- a/config/action.d/helpers-common.conf
+++ b/config/action.d/helpers-common.conf
@@ -4,7 +4,8 @@
 #   _grep_logs_args = 'test'
 #   (printf %%b "Log-excerpt contains 'test':\n"; %(_grep_logs)s; printf %%b "Log-excerpt contains 'test':\n") | mail ...
 #
-_grep_logs = logpath="<logpath>"; grep <grepopts> %(_grep_logs_args)s $logpath | <greplimit>
+# Wrap log lines to 900 chars to comply with SMTP line length limit (RFC 5321: max 998 chars)
+_grep_logs = logpath="<logpath>"; grep <grepopts> %(_grep_logs_args)s $logpath | fold -sw 900 | <greplimit>
 # options `-wF` used to match only whole words and fixed string (not as pattern)
 _grep_logs_args = -wF "<ip>"
 

--- a/config/action.d/mail-whois-common.conf
+++ b/config/action.d/mail-whois-common.conf
@@ -11,7 +11,8 @@ after = mail-whois-common.local
 
 [DEFAULT]
 #original character set of whois output will be sent to mail program
-_whois = whois <ip> || echo "missing whois program"
+# Wrap whois output to 900 chars to comply with SMTP line length limit (RFC 5321: max 998 chars)
+_whois = whois <ip> | fold -sw 900 || echo "missing whois program"
 
 # use heuristics to convert charset of whois output to a target
 # character set before sending it to a mail program


### PR DESCRIPTION
Fixes #3665

## Problem

Long lines in whois output and log excerpts can exceed SMTP's maximum line length of 998 characters (RFC 5321), causing emails to bounce when sent via certain mail servers.

## Solution

Add `fold -sw 900` to wrap lines at 900 characters with word-based splitting:
- `_whois` command in `mail-whois-common.conf`
- `_grep_logs` in `helpers-common.conf`

The `fold` command with `-s` flag breaks lines at word boundaries when possible, preserving readability. Using `fold` instead of `cut` ensures multi-byte UTF-8 characters are handled correctly (as discussed in the issue).

## Testing

The fix has been tested locally:
- `fold -sw 900` properly wraps long lines
- Word boundaries are preserved where spaces exist
- Multi-byte UTF-8 characters remain intact

## Notes

Setting width to 900 (instead of 998) provides safety margin for potential line prefixes or formatting changes.