### PR TITLE
docs: Improve INCLUDES section documentation in jail.conf.5

### DIFF
--- a/man/jail.conf.5
+++ b/man/jail.conf.5
@@ -87,6 +87,28 @@ indicates that the specified file is to be parsed before the current file.
 .TP
 .B after
 indicates that the specified file is to be parsed after the current file.
+.PP
+The [INCLUDES] section allows you to include configuration files relative to the directory of the current configuration file. Multiple files can be specified by separating them with whitespace. Globbing patterns using '*' and '?' are supported.
+.PP
+Examples:
+.RS
+.nf
+# Include a single file before the current configuration
+[INCLUDES]
+before = common.conf
+
+# Include multiple files
+[INCLUDES]
+before = common.conf paths-debian.conf
+after = custom.local
+
+# Include files matching a glob pattern
+[INCLUDES]
+before = /etc/fail2ban/paths-*.conf
+.fi
+.RE
+.PP
+Note: If an included file does not exist, fail2ban will currently ignore it without warning. Ensure that file paths are correct to avoid misconfigurations.
 .RE
 
 Using Python "string interpolation" mechanisms, other definitions are allowed and can later be used within other definitions as %(name)s.


### PR DESCRIPTION
## Summary

This PR addresses issue #4076 by improving the documentation for the `[INCLUDES]` section in the jail.conf man page.

## Changes

- Added explanation that included files are resolved relative to the configuration directory
- Documented support for multiple files (space-separated) and globbing patterns
- Provided practical examples for common use cases:
  - Including a single file
  - Including multiple files with both `before` and `after`
  - Using glob patterns to include multiple matching files
- Added a note about the current behavior when included files don't exist

## Rationale

The current documentation only briefly mentions the `before` and `after` directives without explaining:
1. How file paths are resolved
2. That multiple files can be included
3. That globbing is supported
4. What happens when files are missing

This has led to confusion for users trying to modularize their fail2ban configurations.

## Testing

- Verified the man page syntax is correct
- Examples follow the same format as other sections in the man page

Closes #4076

Please let me know if you'd like any adjustments! 😊