### PR TITLE
Improve INCLUDES section documentation in jail.conf

### DIFF
--- a/config/jail.conf
+++ b/config/jail.conf
@@ -32,6 +32,41 @@
 
 [INCLUDES]
 
+# The INCLUDES section controls which configuration files are loaded before
+# or after this file. This is primarily used to load platform-specific log
+# file paths that vary between Linux distributions.
+#
+# Directive "before": The referenced file is loaded BEFORE the current file.
+#   Values in the current file will override those in the "before" file.
+#   This is useful for providing defaults that can be overridden.
+#
+# Directive "after": The referenced file is loaded AFTER the current file.
+#   Values in the "after" file will override those in the current file.
+#   This is useful for user customizations that should take precedence.
+#
+# The paths-<distro>.conf files define default log file locations for each
+# distribution (e.g., /var/log/auth.log on Debian vs /var/log/secure on Fedora).
+# They also set distribution-specific backend preferences (e.g., systemd).
+#
+# Available paths files (select the one matching your distribution):
+#   paths-debian.conf    - Debian, Ubuntu, and derivatives
+#   paths-fedora.conf    - Fedora, RHEL, CentOS, Rocky, AlmaLinux
+#   paths-opensuse.conf  - openSUSE, SLES
+#   paths-arch.conf      - Arch Linux, Manjaro
+#   paths-freebsd.conf   - FreeBSD
+#   paths-osx.conf       - macOS
+#
+# To customize paths for your setup, create a paths-overrides.local file
+# (referenced by "after" in paths-common.conf) or override individual
+# variables in your jail.local file under the [DEFAULT] section.
+#
+# Example - switch to Fedora paths:
+#   before = paths-fedora.conf
+#
+# Example - override a specific log path in jail.local:
+#   [DEFAULT]
+#   sshd_log = /custom/path/to/sshd.log
+#
 #before = paths-distro.conf
 before = paths-debian.conf
 
@@ -977,7 +1012,7 @@ logpath = %(syslog_local0)s
 banaction = %(banaction_allports)s
 
 [monitorix]
-port	= 8080
+port    = 8080
 logpath = /var/log/monitorix-httpd
 
 [dante]


### PR DESCRIPTION
## Summary

Fixes #4174

The `[INCLUDES]` section in `jail.conf` previously had minimal documentation, making it unclear to users how distribution-specific paths are loaded and how to customize them for their setup.

## Changes

Added comprehensive documentation to the `[INCLUDES]` section explaining:

1. **`before` vs `after` directives** - How each directive works and their precedence rules ("before" files are loaded first and can be overridden; "after" files override the current file)

2. **Purpose of paths-\<distro\>.conf files** - What they provide (distribution-specific log file locations and backend preferences)

3. **List of all available distribution paths files** - Debian, Fedora, openSUSE, Arch, FreeBSD, and macOS with descriptions of which distributions they cover

4. **Customization guidance** - How users can create `paths-overrides.local` or override individual variables in `jail.local`

5. **Practical examples** - Switching to Fedora paths, overriding a specific log path

## Motivation

The lack of clear documentation has been a source of confusion for users who:
- Don't know which paths file to select for their distribution
- Don't understand the difference between `before` and `after` includes
- Don't know how to properly customize log file paths

This is a documentation-only change with no functional impact.