### PR TITLE
Add Cockpit web management interface filter

### DIFF
--- a/config/filter.d/cockpit.conf
+++ b/config/filter.d/cockpit.conf
@@ -1,0 +1,63 @@
+# Fail2Ban filter for Cockpit web-based server management
+#
+# Cockpit is a web-based graphical interface for servers.
+# It is included by default in many Linux distributions including
+# Fedora, RHEL, CentOS, Rocky, AlmaLinux, and Ubuntu.
+#
+# Authentication failures are typically logged via PAM to the system
+# auth log (e.g., /var/log/auth.log or /var/log/secure) or to
+# the systemd journal.
+#
+# To enable Cockpit logging, ensure that Cockpit is configured to
+# use PAM authentication (default).
+#
+# Jail example:
+#    [cockpit]
+#    enabled = true
+#    port = http,https,9090
+#    filter = cockpit
+#    logpath = %(syslog_authpriv)s
+#    backend = %(syslog_backend)s
+#    maxretry = 3
+#    bantime = 1h
+
+[INCLUDES]
+
+before = common.conf
+
+[Definition]
+
+_daemon = cockpit-(?:session|ws)
+
+prefregex = ^%(__prefix_line)s<F-CONTENT>.+</F-CONTENT>$
+
+failregex = ^pam_unix\(cockpit:auth\): authentication failure; (?:\S+=\S*\s+)*rhost=<ADDR>(?:\s+user=<F-USER>\S+</F-USER>)?\s*$
+            ^pam_sss\(cockpit:auth\): authentication failure; (?:\S+=\S*\s+)*rhost=<ADDR>(?:\s+user=<F-USER>\S+</F-USER>)?\s*$
+            ^pam_ldap\(cockpit:auth\): authentication failure; (?:\S+=\S*\s+)*rhost=<ADDR>(?:\s+user=<F-USER>\S+</F-USER>)?\s*$
+
+ignoreregex =
+
+journalmatch = _SYSTEMD_UNIT=cockpit.socket + _COMM=cockpit-session
+               _SYSTEMD_UNIT=cockpit.socket + _COMM=cockpit-ws
+
+# DEV Notes:
+#
+# Typical Cockpit authentication failure log lines:
+#
+# pam_unix (default on most systems):
+#   cockpit-session[12345]: pam_unix(cockpit:auth): authentication failure;
+#     logname= uid=0 euid=0 tty= ruser= rhost=192.0.2.1  user=admin
+#
+# pam_sss (SSSD/FreeIPA):
+#   cockpit-session[12345]: pam_sss(cockpit:auth): authentication failure;
+#     logname= uid=0 euid=0 tty= ruser= rhost=192.0.2.1  user=admin
+#
+# pam_ldap:
+#   cockpit-session[12345]: pam_ldap(cockpit:auth): authentication failure;
+#     logname= uid=0 euid=0 tty= ruser= rhost=192.0.2.1  user=admin
+#
+# Note: PAM log lines include key=value pairs before rhost= with varying
+# content (logname, uid, euid, tty, ruser). The regex uses
+# (?:\S+=\S*\s+)* to match these flexibly.
+#
+# Author: Mohamed Solaiman

--- a/fail2ban/tests/files/logs/cockpit
+++ b/fail2ban/tests/files/logs/cockpit
@@ -1,0 +1,29 @@
+# Cockpit authentication failures from /var/log/auth.log or journal
+
+#1 PAM auth failure with user
+# failJSON: { "time": "2005-03-08T09:37:44", "match": true , "host": "192.0.2.1", "user": "admin" }
+Mar  8 09:37:44 server cockpit-session[12345]: pam_unix(cockpit:auth): authentication failure; logname= uid=0 euid=0 tty= ruser= rhost=192.0.2.1  user=admin
+
+#2 PAM auth failure without user
+# failJSON: { "time": "2005-03-09T03:32:27", "match": true , "host": "192.0.2.2" }
+Mar  9 03:32:27 server cockpit-session[23456]: pam_unix(cockpit:auth): authentication failure; logname= uid=0 euid=0 tty= ruser= rhost=192.0.2.2 
+
+#3 PAM SSSD auth failure
+# failJSON: { "time": "2005-03-10T14:15:30", "match": true , "host": "192.0.2.3", "user": "testuser" }
+Mar 10 14:15:30 server cockpit-session[34567]: pam_sss(cockpit:auth): authentication failure; logname= uid=0 euid=0 tty= ruser= rhost=192.0.2.3  user=testuser
+
+#4 PAM LDAP auth failure
+# failJSON: { "time": "2005-03-11T08:22:11", "match": true , "host": "192.0.2.4", "user": "ldapuser" }
+Mar 11 08:22:11 server cockpit-session[45678]: pam_ldap(cockpit:auth): authentication failure; logname= uid=0 euid=0 tty= ruser= rhost=192.0.2.4  user=ldapuser
+
+#5 IPv6 rhost
+# failJSON: { "time": "2005-03-12T16:45:00", "match": true , "host": "::1", "user": "root" }
+Mar 12 16:45:00 server cockpit-session[56789]: pam_unix(cockpit:auth): authentication failure; logname= uid=0 euid=0 tty= ruser= rhost=::1  user=root
+
+#6 Successful login should NOT match (negative test)
+# failJSON: { "time": "2005-03-13T11:20:33", "match": false }
+Mar 13 11:20:33 server cockpit-session[67890]: pam_unix(cockpit:auth): authentication success; logname= uid=0 euid=0 tty= ruser= rhost=192.0.2.10  user=validuser
+
+#7 SSH PAM failure should NOT match (wrong service, negative test)
+# failJSON: { "time": "2005-03-14T08:00:00", "match": false }
+Mar 14 08:00:00 server sshd[78901]: pam_unix(sshd:auth): authentication failure; logname= uid=0 euid=0 tty= ruser= rhost=192.0.2.1  user=admin


### PR DESCRIPTION
## Summary

Adds a new fail2ban filter for **Cockpit**, the popular web-based server management interface that is included by default in many Linux distributions (Fedora, RHEL, CentOS, Rocky, AlmaLinux, Ubuntu).

Cockpit is one of the most widely deployed web-based server management tools, yet fail2ban does not include a filter for it. This leaves servers running Cockpit vulnerable to brute-force authentication attacks without fail2ban protection.

## Changes

### New Filter: `config/filter.d/cockpit.conf`

Matches authentication failures from multiple PAM modules:
- `pam_unix` (default on most systems)
- `pam_sss` (SSSD/FreeIPA environments)
- `pam_ldap` (LDAP authentication)

Features:
- Uses `prefregex` for efficient prefix matching
- Extracts remote host (`rhost`) and username from PAM log lines
- Includes `journalmatch` for systemd journal backend support
- Only matches the `cockpit` PAM service (won't accidentally match sshd or other services)

### Test Samples: `fail2ban/tests/files/logs/cockpit`

Includes positive and negative test cases:
- pam_unix auth failure with/without username
- pam_sss (SSSD) auth failure
- pam_ldap auth failure
- IPv6 rhost support
- Negative tests: authentication success, wrong PAM service

## Example Jail Configuration

```ini
[cockpit]
enabled = true
port = http,https,9090
filter = cockpit
logpath = %(syslog_authpriv)s
backend = %(syslog_backend)s
maxretry = 3
bantime = 1h
```

## Typical Log Lines Matched

```
Mar  8 09:37:44 server cockpit-session[12345]: pam_unix(cockpit:auth): authentication failure; logname= uid=0 euid=0 tty= ruser= rhost=192.0.2.1  user=admin
Mar 10 14:15:30 server cockpit-session[34567]: pam_sss(cockpit:auth): authentication failure; logname= uid=0 euid=0 tty= ruser= rhost=192.0.2.3  user=testuser
```

## Testing

Regex patterns have been validated against typical Cockpit log output. The filter follows the same patterns as existing filters like `proxmox.conf` for PAM-based authentication matching.