### PR TITLE
OpenRC: support supervise-daemon

### DIFF
--- a/files/fail2ban-openrc.conf
+++ b/files/fail2ban-openrc.conf
@@ -1,2 +1,8 @@
 # For available options, please run "fail2ban-server --help".
 #FAIL2BAN_OPTIONS="-x"
+
+# fail2ban runs under both the classic start-stop-daemon and the more
+# modern supervise-daemon. Below we default to supervise-daemon, but
+# only if $supervisor is unset. If you prefer start-stop-daemon,
+# comment out the following line.
+: ${supervisor:=supervise-daemon}

--- a/files/fail2ban-openrc.init.in
+++ b/files/fail2ban-openrc.init.in
@@ -31,15 +31,25 @@ FAIL2BAN_RUNDIR="/run/${RC_SVCNAME}"
 FAIL2BAN_SOCKET="${FAIL2BAN_RUNDIR}/${RC_SVCNAME}.sock"
 
 # The fail2ban-client program is also capable of starting and stopping
-# the server, but things are simpler if we let start-stop-daemon do it.
+# the server, but things are simpler if we let the supervisor do it.
 command="@BINDIR@/fail2ban-server"
-pidfile="${FAIL2BAN_RUNDIR}/${RC_SVCNAME}.pid"
 
 # We force the pidfile/socket location in this service script because
 # we're taking responsibility for ensuring that their parent directory
 # exists and has the correct permissions (which we can't do if the
 # user is allowed to change them).
-command_args="${FAIL2BAN_OPTIONS} -p ${pidfile} -s ${FAIL2BAN_SOCKET}"
+case "${supervisor}" in
+	supervise-daemon)
+		# Run in the foreground.
+		FAIL2BAN_OPTIONS="${FAIL2BAN_OPTIONS} -f"
+		;;
+	*)
+		# Run in the background and create a pidfile.
+		pidfile="${FAIL2BAN_RUNDIR}/${RC_SVCNAME}.pid"
+		FAIL2BAN_OPTIONS="${FAIL2BAN_OPTIONS} -p ${pidfile}"
+		;;
+esac
+command_args="${FAIL2BAN_OPTIONS} -s ${FAIL2BAN_SOCKET}"
 retry="30"
 
 depend() {
@@ -48,7 +58,7 @@ depend() {
 }
 
 checkconfig() {
-    "${command}" ${command_args} --test
+	"${command}" ${command_args} --test
 }
 
 start_pre() {


### PR DESCRIPTION
The next major version of OpenRC will likely default to the "supervise-daemon" supervisor that expects daemons to run in the foreground (like systemd). The supervisor is controlled by the `$supervisor` variable however so in the meantime we can support both with a case statement.

Gentoo shortcut for testing:

```
EGIT_OVERRIDE_REPO_FAIL2BAN_FAIL2BAN=https://github.com/orlitzky/fail2ban.git  EGIT_OVERRIDE_BRANCH_FAIL2BAN_FAIL2BAN=supervise-daemon ACCEPT_KEYWORDS="**" emerge -v1 =net-analyzer/fail2ban-9999
```

cc: @thesamesam