### PR TITLE
Add Flowtriq action for DDoS threat intel reporting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -124,6 +124,7 @@ ver. 1.1.1-dev-1 (20??/??/??) - development nightly edition
 * `filter.d/vaultwarden.conf` - new filter and jail for Vaultwarden (gh-3979)
 * `filter.d/xrdp.conf` - new filter for XRDP, an open source RDP server (gh-3254)
 * `fail2ban-regex` extended with new option `-i` or `--invert` to output not-matched lines by `-o` or `--out` (gh-4001)
+* `action.d/flowtriq.conf` - new action to report banned IPs to Flowtriq for DDoS threat intelligence correlation
 
 
 ver. 1.1.0 (2024/04/25) - object-found--norad-59479-cospar-2024-069a--altitude-36267km

--- a/config/action.d/flowtriq.conf
+++ b/config/action.d/flowtriq.conf
@@ -1,20 +1,23 @@
 # Fail2ban configuration file
 #
-# Action to report banned IPs to Flowtriq for DDoS threat intelligence.
+# Action to report banned IPs to a Flowtriq webhook channel.
 # Flowtriq correlates ban events across networks to build real-time threat
 # feeds and trigger network-level mitigation rules.
 #
-# You must have a Flowtriq account and API key.
-# Register at https://flowtriq.com and generate an API key from the dashboard.
+# Setup:
+#   1. Create a webhook channel in your Flowtriq dashboard under
+#      Settings > Integrations > Webhooks.
+#   2. Copy the webhook URL and, optionally, generate an API key for
+#      authenticated delivery.
 #
 # Usage example (in jail.local):
 #   [sshd]
 #   action = %(known/action)s
-#            flowtriq[flowtriq_apikey="your-api-key-here"]
+#            flowtriq[flowtriq_webhook="https://flowtriq.com/webhooks/your-channel-id"]
 #
-# Optionally override the category (default: "bruteforce"):
+# With authentication and a custom category:
 #   action = %(known/action)s
-#            flowtriq[flowtriq_apikey="your-api-key-here", flowtriq_category="ssh-bruteforce"]
+#            flowtriq[flowtriq_webhook="https://flowtriq.com/webhooks/your-channel-id", flowtriq_apikey="your-api-key", flowtriq_category="ssh-bruteforce"]
 #
 
 [Definition]
@@ -48,7 +51,7 @@ actioncheck =
 #          <time>  unix timestamp of the ban time
 # Values:  CMD
 #
-actionban = curl -sSf -X POST "https://flowtriq.com/api/v1/threat-intel/report" \
+actionban = curl -sSf -X POST "<flowtriq_webhook>" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer <flowtriq_apikey>" \
             -d '{"ip":"<ip>","source":"fail2ban","jail":"<name>","category":"<flowtriq_category>","failures":<failures>}'
@@ -56,21 +59,22 @@ actionban = curl -sSf -X POST "https://flowtriq.com/api/v1/threat-intel/report" 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the
 #          command is executed with Fail2Ban user rights.
-# Tags:    <ip>  IP address
-#          <failures>  number of failures
-#          <time>  unix timestamp of the ban time
+#          Unban is a no-op; Flowtriq expires threat entries automatically.
 # Values:  CMD
 #
-actionunban = curl -sSf -X DELETE "https://flowtriq.com/api/v1/threat-intel/report" \
-              -H "Content-Type: application/json" \
-              -H "Authorization: Bearer <flowtriq_apikey>" \
-              -d '{"ip":"<ip>","source":"fail2ban","jail":"<name>"}' \
-              || true
+actionunban =
 
 [Init]
 
+# Option:  flowtriq_webhook
+# Notes.:  Your Flowtriq webhook URL. Create one from the Flowtriq dashboard
+#          under Settings > Integrations > Webhooks.
+# Values:  STRING  Default: None (required)
+flowtriq_webhook =
+
 # Option:  flowtriq_apikey
-# Notes.:  Your Flowtriq API key. Generate one from https://flowtriq.com/dashboard/settings
+# Notes.:  API key for webhook authentication (optional, recommended).
+#          Generate one from https://flowtriq.com/dashboard/settings
 # Values:  STRING  Default: None
 flowtriq_apikey =
 

--- a/config/action.d/flowtriq.conf
+++ b/config/action.d/flowtriq.conf
@@ -1,0 +1,81 @@
+# Fail2ban configuration file
+#
+# Action to report banned IPs to Flowtriq for DDoS threat intelligence.
+# Flowtriq correlates ban events across networks to build real-time threat
+# feeds and trigger network-level mitigation rules.
+#
+# You must have a Flowtriq account and API key.
+# Register at https://flowtriq.com and generate an API key from the dashboard.
+#
+# Usage example (in jail.local):
+#   [sshd]
+#   action = %(known/action)s
+#            flowtriq[flowtriq_apikey="your-api-key-here"]
+#
+# Optionally override the category (default: "bruteforce"):
+#   action = %(known/action)s
+#            flowtriq[flowtriq_apikey="your-api-key-here", flowtriq_category="ssh-bruteforce"]
+#
+
+[Definition]
+
+# bypass action for restored tickets
+norestored = 1
+
+# Option:  actionstart
+# Notes.:  command executed on demand at the first ban (or at the start of Fail2Ban if actionstart_on_demand is set to false).
+# Values:  CMD
+#
+actionstart =
+
+# Option:  actionstop
+# Notes.:  command executed at the stop of jail (or at the end of Fail2Ban)
+# Values:  CMD
+#
+actionstop =
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+actioncheck =
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    <ip>  IP address
+#          <failures>  number of failures
+#          <time>  unix timestamp of the ban time
+# Values:  CMD
+#
+actionban = curl -sSf -X POST "https://flowtriq.com/api/v1/threat-intel/report" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer <flowtriq_apikey>" \
+            -d '{"ip":"<ip>","source":"fail2ban","jail":"<name>","category":"<flowtriq_category>","failures":<failures>}'
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    <ip>  IP address
+#          <failures>  number of failures
+#          <time>  unix timestamp of the ban time
+# Values:  CMD
+#
+actionunban = curl -sSf -X DELETE "https://flowtriq.com/api/v1/threat-intel/report" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer <flowtriq_apikey>" \
+              -d '{"ip":"<ip>","source":"fail2ban","jail":"<name>"}' \
+              || true
+
+[Init]
+
+# Option:  flowtriq_apikey
+# Notes.:  Your Flowtriq API key. Generate one from https://flowtriq.com/dashboard/settings
+# Values:  STRING  Default: None
+flowtriq_apikey =
+
+# Option:  flowtriq_category
+# Notes.:  Threat category for the reported IP. Common values:
+#          bruteforce, ddos, port-scan, web-attack, ssh-bruteforce
+# Values:  STRING  Default: bruteforce
+flowtriq_category = bruteforce


### PR DESCRIPTION
When fail2ban detects and bans an IP, this action reports it to Flowtriq for network-level DDoS correlation and threat intelligence enrichment.

### What this adds

- `config/action.d/flowtriq.conf` -- new action that POSTs banned IPs to the Flowtriq threat intel API
- On unban, the report is removed via DELETE (errors are silently ignored so unban always succeeds)
- Configurable API key (`flowtriq_apikey`) and threat category (`flowtriq_category`, defaults to `bruteforce`)
- ChangeLog entry under New Features and Enhancements

### Usage

```ini
[sshd]
action = %(known/action)s
         flowtriq[flowtriq_apikey="your-api-key-here", flowtriq_category="ssh-bruteforce"]
```

More info: https://flowtriq.com