### PR TITLE
fix: fail config test on invalid directives without '='

### DIFF
--- a/fail2ban/client/configparserinc.py
+++ b/fail2ban/client/configparserinc.py
@@ -31,7 +31,7 @@ from ..helpers import getLogger
 
 # SafeConfigParser deprecated from Python 3.2 (renamed to ConfigParser)
 from configparser import ConfigParser as SafeConfigParser, BasicInterpolation, \
-	InterpolationMissingOptionError, NoOptionError, NoSectionError
+	InterpolationMissingOptionError, NoOptionError, NoSectionError, ParsingError
 
 # And interpolation of __name__ was simply removed, thus we need to
 # decorate default interpolator to handle it
@@ -215,6 +215,26 @@ after = 1.conf
 	def share_config(self):
 		return self._cfg_share
 
+	@staticmethod
+	def _logParsingError(e):
+		"""Log configparser.ParsingError with a clear invalid-directive warning."""
+		logSys.error("Invalid configuration syntax: %s", e)
+		for lineno, line in getattr(e, 'errors', ()) or ():
+			# line is already repr()'d by configparser
+			logSys.warning(
+				"Invalid directive in %s, line %s: %s (option lines must be 'name = value')",
+				getattr(e, 'source', '<unknown>'), lineno, line)
+
+	def _readSharedFile(self, cfg, filename):
+		"""Read a single config file; treat parse errors like unreadable files."""
+		try:
+			return cfg.read(filename, get_includes=False)
+		except ParsingError as e:
+			# Same idea as UnicodeDecodeError handling: don't apply a partial
+			# file and surface a clear error so `fail2ban-client -t` fails.
+			self._logParsingError(e)
+			return []
+
 	def _getSharedSCPWI(self, filename):
 		SCPWI = SafeConfigParserWithIncludes
 		# read single one, add to return list, use sharing if possible:
@@ -224,14 +244,14 @@ after = 1.conf
 			cfg, i = self._cfg_share.get(hashv, (None, None))
 			if cfg is None:
 				cfg = SCPWI(share_config=self._cfg_share)
-				i = cfg.read(filename, get_includes=False)
+				i = self._readSharedFile(cfg, filename)
 				self._cfg_share[hashv] = (cfg, i)
 			elif logSys.getEffectiveLevel() <= logLevel:
 				logSys.log(logLevel, "    Shared file: %s", filename)
 		else:
 			# don't have sharing:
 			cfg = SCPWI()
-			i = cfg.read(filename, get_includes=False)
+			i = self._readSharedFile(cfg, filename)
 		return (cfg, i)
 
 	def _getIncludes(self, filenames, seen=[]):

--- a/fail2ban/tests/fail2banclienttestcase.py
+++ b/fail2ban/tests/fail2banclienttestcase.py
@@ -842,6 +842,18 @@ class Fail2banServerTest(Fail2banClientServerBase):
 			"Read jails configuration failed.",
 			"ERROR: test configuration failed", all=True)
 
+		# bare line without '=' (e.g. forgotten 'ignoreip =') must fail config test:
+		self.pruneLog("[test-phase 1b]")
+		_write_file(pjoin(cfg, "jail.local"), "w",
+			"[DEFAULT]",
+			"192.168.1.10 10.0.0.2",
+			"bantime = 3600")
+		self.execCmd(FAILED, startparams, "-t")
+		self.assertLogged("Invalid directive",
+			"Could not read config files",
+			"Read jails configuration failed.",
+			"ERROR: test configuration failed", all=True)
+
 
 	@with_tmpdir
 	def testKillAfterStart(self, tmp):


### PR DESCRIPTION
## Problem
A bare line in `jail.local` (for example an IP list where `ignoreip =` was accidentally omitted) is not a valid config directive. Users expect `fail2ban-client -t` to report this clearly and fail the configuration test.

## Fix
Catch `configparser.ParsingError` while loading shared config files in `SafeConfigParserWithIncludes`. Log a clear **invalid directive** warning (filename, line, content) and treat the file as unread so the existing "Could not read config files" path fails the test—consistent with how unreadable/decoding-error files are handled.

## Test plan
- [x] `python3 bin/fail2ban-testcases fail2ban.tests.fail2banclienttestcase.Fail2banServerTest.testServerTestFailStart`
- [x] `python3 bin/fail2ban-testcases fail2ban.tests.clientreadertestcase`
- Manual: jail.local with `[DEFAULT]` / `192.168.1.10 10.0.0.2` / `bantime = 3600` → `fail2ban-client -t` exits non-zero and logs `Invalid directive`

Fixes #4207