### PR TITLE
Add regex pattern for missing AORs in asterisk.conf

### DIFF
--- a/config/filter.d/asterisk.conf
+++ b/config/filter.d/asterisk.conf
@@ -28,6 +28,7 @@ failregex = ^Registration from '[^']*' failed for '<HOST>(:\d+)?' - (?:Wrong pas
             ^SecurityEvent="(?:FailedACL|InvalidAccountID|ChallengeResponseFailed|InvalidPassword)"(?:(?:,(?!RemoteAddress=)\w+="[^"]*")*|.*?),RemoteAddress="IPV[46]/[^/"]+/<HOST>/\d+"(?:,(?!RemoteAddress=)\w+="[^"]*")*$
             ^"Rejecting unknown SIP connection from <HOST>(?::\d+)?"$
             ^Request (?:'[^']*' )?from '(?:[^']*|.*?)' failed for '<HOST>(?::\d+)?'\s\(callid: [^\)]*\) - (?:No matching endpoint found|Not match Endpoint(?: Contact)? ACL|(?:Failed|Error) to authenticate)\b[^']*$
+            ^Endpoint '.+' \(<HOST>:\d+\) has no configured AORs$
 
 # FreePBX (todo: make optional in v.0.10):
 #            ^(%(__prefix_line)s|\[\]\s*WARNING%(__pid_re)s:?(?:\[C-[\da-f]*\])? )[^:]+: Friendly Scanner from <HOST>$


### PR DESCRIPTION
Add another regex to capture cracking attempts of an Asterisk server.

Sample lines:

```
[Jul 20 20:27:26] WARNING[2895239] res_pjsip_registrar.c: Endpoint 'anonymous' (37.49.227.95:29768) has no configured AORs
[Jul 20 23:10:36] WARNING[2959593] res_pjsip_registrar.c: Endpoint 'anonymous' (37.49.227.95:29783) has no configured AORs
[Jul 21 05:58:51] WARNING[3017962] res_pjsip_registrar.c: Endpoint 'anonymous' (135.181.4.158:59379) has no configured AORs
[Jul 21 12:02:47] WARNING[3065390] res_pjsip_registrar.c: Endpoint 'anonymous' (45.61.184.184:56621) has no configured AORs
[Jul 21 12:10:42] WARNING[3065883] res_pjsip_registrar.c: Endpoint 'anonymous' (135.181.4.158:53174) has no configured AORs
[Jul 21 16:29:14] WARNING[3100912] res_pjsip_registrar.c: Endpoint 'anonymous' (51.254.175.198:52151) has no configured AORs
```

If you wanted to be more conservative, you could only match for `anonymous` with:

```
            ^Endpoint 'anonymous' \(<HOST>:\d+\) has no configured AORs$
```

But I don't really see the point of that myself.