### PR TITLE
filter.d/apache-noscript: match a cgi-bin directory with no script name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@ ver. 1.1.2-dev-1 (20??/??/??) - development nightly edition
 
 ### Fixes
 * `filter.d/nginx-botsearch.conf` - error-log regex extended with support of journal format (gh-3732)
+* `filter.d/apache-noscript.conf` - match a request for the `cgi-bin` directory itself (no script name after it),
+  the `cgi-bin` alternative required a following path segment so `/cgi-bin/` and `/cgi-bin` were not matched (gh-4217)
 
 ### New Features and Enhancements
 

--- a/config/filter.d/apache-noscript.conf
+++ b/config/filter.d/apache-noscript.conf
@@ -17,12 +17,12 @@ before = apache-common.conf
 
 [Definition]
 
-script = /\S*(?:php(?:[45]|[.-]cgi)?|\.asp|\.exe|\.pl|\bcgi-bin/)
+script = /\S*(?:php(?:[45]|[.-]cgi)?|\.asp|\.exe|\.pl|\bcgi-bin)
 
 prefregex = ^%(_apache_error_client)s (?:AH0(?:01(?:28|30)|1(?:264|071)|2811): )?(?=(?:[Ff]ile|[Ss]cript|[Gg]ot error|stderr from) )<F-CONTENT>.+</F-CONTENT>$
 
 failregex = ^(?:(?:[Ff]ile does not exist|[Ss]cript not found or unable to stat): <script>\b|[Gg]ot error '[Pp]rimary script unknown\b)
-            ^(?:stderr from |script (?P<_q>'))<script>\S*(?(_q)'|) (?:script )?(?:does not exist|not found or unable to stat)
+            ^(?:stderr from |script (?P<_q>'))<script>\b\S*(?(_q)'|) (?:script )?(?:does not exist|not found or unable to stat)
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/apache-noscript
+++ b/fail2ban/tests/files/logs/apache-noscript
@@ -26,3 +26,6 @@
 
 # failJSON: { "time": "2024-12-18T23:58:03", "match": true , "host": "192.0.2.74", "desc": "script not found, changed log-format with stderr from (gh-3900)" }
 [Wed Dec 18 23:58:03.148113 2024] [cgi:error] [pid 16720:tid 1878] [client 192.0.2.74:35092] AH02811: stderr from /usr/lib/cgi-bin/luci: script not found or unable to stat
+
+# failJSON: { "time": "2025-07-30T16:43:26", "match": true , "host": "192.0.2.5", "desc": "stderr from a cgi-bin directory, no script name and no trailing slash (gh-4040)" }
+[Wed Jul 30 16:43:26.968908 2025] [cgi:error] [pid 147397:tid 147442] [client 192.0.2.5:33570] AH02811: stderr from /srv/http/cgi-bin: script not found or unable to stat


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [x] **LIST ISSUES** this PR resolves or describe the approach in detail
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [x] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      (and `# failJSON`) within `fail2ban/tests/files/logs/X` file
- [x] **PROVIDE ChangeLog** entry describing the pull request

---

When Apache logs an `AH02811` for a CGI *directory* rather than a script inside it, the path ends at `cgi-bin` with no trailing slash:

```
[Wed Jul 30 16:43:26.968908 2025] [cgi:error] [pid 147397:tid 147442] [client 192.0.2.5:33570] AH02811: stderr from /srv/http/cgi-bin: script not found or unable to stat
```

The `script` pattern requires `cgi-bin/`, so this never matches. gh-3900 taught the filter the `stderr from` shape, but only for paths that continue past the directory.

Using a word boundary instead of the literal slash:

```
before: 1 lines, 0 ignored, 0 matched, 1 missed
after:  1 lines, 0 ignored, 1 matched, 0 missed
```

Closes gh-4040

## Scope

The issue also asks about `no acceptable variant` (content negotiation) messages. That is a different log shape and belongs in a different filter, so it is not addressed here.

## On the widened match

`\b` also lets sibling directories match, which the old pattern excluded:

| path | before | after |
|---|---|---|
| `/srv/cgi-bin/ok.pl` | match | match |
| `/srv/http/cgi-bin:` | miss | match |
| `/srv/cgi-bin.bak` | miss | match |
| `/srv/cgi-bin-old` | miss | match |
| `/srv/nocgi-bin` | miss | miss |

Every one of these is an `AH02811 script not found or unable to stat`, i.e. a request for a script that does not exist, which is what this filter bans on. A bot probing `cgi-bin.bak` is the same behaviour as one probing `cgi-bin`. `nocgi-bin` stays excluded, which a bare `cgi-bin` without the boundary would not have done.

Happy to narrow it to `cgi-bin[:/]` if you would rather keep the match tight.

## Testing

`python3 bin/fail2ban-testcases` → `Ran 540 tests, OK (skipped=14)`.

The fixture case is asserted, not skipped: changing its expected host makes the suite fail, and reverting the filter change alone also makes it fail.

---

*Apologies for not including the checklist originally. The ChangeLog entry was genuinely missing and has now been added, the other items were already satisfied. Disclosure: written with AI assistance (Claude Code); I ran the filter against the sample lines and the test suite myself.*