### PR TITLE
filter.d/postfix: catch "hostname ... does not resolve to address" in aggressive mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -65,6 +65,7 @@ ver. 1.1.1-dev-1 (20??/??/??) - development nightly edition
   - add optional `NOQUEUE:` prefix to ddos regex (gh-4072)
   - internal parameter `_pref` is renamed to `_cmd`, `_pref` matches now optional prefix like `NOQUEUE: ` etc
   - modes `ddos` and `aggressive` extended to match `rate limit exceeded` for connection or message delivery request rates (gh-3265, gh-4073)
+  - modes `aggressive` extended to match `hostname does not resolve to address` (gh-4218, gh-4078)
 * `filter.d/dropbear.conf`:
   - recognizes extra pid/timestamp if logged into stdout/journal, added `journalmatch` (gh-3597)
   - failregex extended to match different format of "Exit before auth" message (gh-3791)

--- a/config/filter.d/postfix.conf
+++ b/config/filter.d/postfix.conf
@@ -59,6 +59,7 @@ mdad-extra =
 mdpr-aggressive = (?:%(mdpr-auth)s|%(mdpr-normal)s|%(mdpr-ddos)s)
 mdre-aggressive = %(mdre-auth2)s
                   %(mdre-normal)s
+                  ^hostname \S+ does not resolve to address <ADDR>
 mdad-aggressive = %(mdad-ddos)s
 
 mdpr-errors = too many errors after \S+

--- a/fail2ban/tests/files/logs/postfix
+++ b/fail2ban/tests/files/logs/postfix
@@ -154,6 +154,9 @@ Jan 14 16:18:16 xxx postfix/smtpd[14933]: warning: host[192.0.2.5]: SASL CRAM-MD
 # failJSON: { "time": "2004-11-04T09:11:01", "match": true , "host": "192.0.2.152", "user": "admin", "desc": "reason unavailable" }
 Nov  4 09:11:01 mail postfix/smtpd[1234]: warning: unknown[192.0.2.152]: SASL LOGIN authentication failed: (reason unavailable), sasl_username=admin
 
+# failJSON: { "match": true , "host": "192.0.2.44", "desc": "hostname does not resolve to address, aggressive only (gh-4078)" }
+Aug 14 10:00:01 mail postfix/smtpd[1234]: warning: hostname bad.example.com does not resolve to address 192.0.2.44: Name or service not known
+
 # ---------------------------------------
 # Test-cases of postfix DDOS mode:
 # ---------------------------------------
@@ -198,7 +201,3 @@ Sep 19 12:10:58 hostname postfix/smtpd[14059]: warning: Message delivery request
 # filterOptions: [{}, {"mode": "ddos"}, {"mode": "aggressive"}]
 # failJSON: { "match": false, "desc": "don't affect lawful data (sporadical connection aborts within DATA-phase, see gh-1813 for discussion)" }
 Feb 18 09:50:05 xxx postfix/smtpd[42]: lost connection after DATA from good-host.example.com[192.0.2.10]
-
-# filterOptions: [{"mode": "aggressive"}]
-# failJSON: { "match": true , "host": "192.0.2.44", "desc": "hostname does not resolve to address, aggressive only (gh-4078)" }
-Aug 14 10:00:01 mail postfix/smtpd[1234]: warning: hostname bad.example.com does not resolve to address 192.0.2.44: Name or service not known

--- a/fail2ban/tests/files/logs/postfix
+++ b/fail2ban/tests/files/logs/postfix
@@ -198,3 +198,7 @@ Sep 19 12:10:58 hostname postfix/smtpd[14059]: warning: Message delivery request
 # filterOptions: [{}, {"mode": "ddos"}, {"mode": "aggressive"}]
 # failJSON: { "match": false, "desc": "don't affect lawful data (sporadical connection aborts within DATA-phase, see gh-1813 for discussion)" }
 Feb 18 09:50:05 xxx postfix/smtpd[42]: lost connection after DATA from good-host.example.com[192.0.2.10]
+
+# filterOptions: [{"mode": "aggressive"}]
+# failJSON: { "match": true , "host": "192.0.2.44", "desc": "hostname does not resolve to address, aggressive only (gh-4078)" }
+Aug 14 10:00:01 mail postfix/smtpd[1234]: warning: hostname bad.example.com does not resolve to address 192.0.2.44: Name or service not known


### PR DESCRIPTION
Postfix logs this when a client's reverse DNS does not resolve back to its address:

```
warning: hostname bad.example.com does not resolve to address 192.0.2.44: Name or service not known
```

The `warning:` prefix is already accepted via `mdpr-auth`, so the prefregex matches; only the failregex was missing.

This is the regex you gave in gh-4078, which @keestux confirmed works. It is added to `mdre-aggressive` only — a legitimate sender with broken rDNS trips this message, so it would be a false-positive source in the default mode.

Closes gh-4078

## Verification

```
stock,   mode=aggressive : 0 matched, 1 missed
patched, mode=aggressive : 1 matched, 0 missed
patched, default mode    : 0 matched, 1 missed   <- unchanged, as intended
```

Adjacent warnings do not newly match:

| line | matches |
|---|---|
| `hostname X does not resolve to address 192.0.2.7` | yes |
| `hostname X verification failed` | no |
| `192.0.2.9: address not listed for hostname X` | no |
| `connect from unknown[192.0.2.8]` | no |

`<ADDR>` rather than `<HOST>` since the tail is always an IP here.

`python3 bin/fail2ban-testcases` → `Ran 540 tests, OK (skipped=14)`.

The fixture is asserted, not skipped: changing its expected host fails the suite, and so does reverting the filter change on its own.

One question — you wrote this as a jail-local config rather than a filter change, so if you meant it to stay user-side, say the word and I will close this.
