### PR TITLE
fix: replace bare except with except Exception

### DIFF
--- a/fail2ban/client/configparserinc.py
+++ b/fail2ban/client/configparserinc.py
@@ -202,11 +202,11 @@ after = 1.conf
 				rplcmnt = 1
 				try: # set it in map-vars (consider different python versions):
 					defaults[sopt] = v
-				except:
+				except Exception:
 					# try to set in first default map (corresponding vars):
 					try:
 						defaults._maps[0][sopt] = v
-					except: # pragma: no cover
+					except Exception: # pragma: no cover
 						# no way to update vars chain map - overwrite defaults:
 						self._defaults[sopt] = v
 		return rplcmnt

--- a/fail2ban/compat/asyncore.py
+++ b/fail2ban/compat/asyncore.py
@@ -83,7 +83,7 @@ def read(obj):
         obj.handle_read_event()
     except _reraised_exceptions:
         raise
-    except:
+    except Exception:
         obj.handle_error()
 
 def write(obj):
@@ -91,7 +91,7 @@ def write(obj):
         obj.handle_write_event()
     except _reraised_exceptions:
         raise
-    except:
+    except Exception:
         obj.handle_error()
 
 def _exception(obj):
@@ -99,7 +99,7 @@ def _exception(obj):
         obj.handle_expt_event()
     except _reraised_exceptions:
         raise
-    except:
+    except Exception:
         obj.handle_error()
 
 def readwrite(obj, flags):
@@ -119,7 +119,7 @@ def readwrite(obj, flags):
             obj.handle_close()
     except _reraised_exceptions:
         raise
-    except:
+    except Exception:
         obj.handle_error()
 
 def poll(timeout=0.0, map=None):
@@ -459,7 +459,7 @@ class dispatcher:
         # sometimes a user repr method will crash.
         try:
             self_repr = repr(self)
-        except:
+        except Exception:
             self_repr = '<__repr__(self) failed for object at %0x>' % id(self)
 
         self.log_info(
@@ -563,7 +563,7 @@ def close_all(map=None, ignore_all=False):
                 raise
         except _reraised_exceptions:
             raise
-        except:
+        except Exception:
             if not ignore_all:
                 raise
     map.clear()


### PR DESCRIPTION

### Summary

Six bare `except:` clauses catch everything, including
`KeyboardInterrupt`/`SystemExit`:

- `fail2ban/client/configparserinc.py` (2) — fall back when a defaults-map
  assignment fails
- `fail2ban/compat/asyncore.py` (4) — the vendored asyncore compatibility
  layer's `handle_error()` paths (already guarded by
  `except _reraised_exceptions: raise` before the bare except)

Replace with `except Exception:` — same intended behavior (fallback /
`handle_error()`), but `KeyboardInterrupt`/`SystemExit` and programming
errors propagate instead of being routed through error handlers.

### Verification

- `python -m py_compile` on both files → OK
- `grep -c "except:"` on both files → 0 remaining bare handlers

### Files changed

- `fail2ban/client/configparserinc.py` (2 lines)
- `fail2ban/compat/asyncore.py` (4 lines)