### PR TITLE
Add support for systemd socket activation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -83,6 +83,7 @@ ver. 1.1.1-dev-1 (20??/??/??) - development nightly edition
 * `filter.d/froxlor-auth.conf` - updated the regex to the new logging situation for froxlor and changed logpath in jail.conf (gh-4075).	
 
 ### New Features and Enhancements
+* `fail2ban-server` supports `systemd` socket activation (`sd_listen_fds(3)`); optional `fail2ban.socket` unit provided
 * backend `systemd` extended with new parameter `rotated` (default `false`, as prevention against "too many open files"),
   that allows to monitor only actual journals and ignore now a lot of rotated files by default; so can drastically reduce
   amount of used file descriptors, normally to 1 or 2 descriptors per jail (gh-3391)

--- a/fail2ban/server/asyncserver.py
+++ b/fail2ban/server/asyncserver.py
@@ -236,35 +236,54 @@ class AsyncServer(asyncore.dispatcher):
 		# Creates an instance of the handler class to handle the
 		# request/response on the incoming connection.
 		RequestHandler(conn, self.__transmitter)
-	
+
+	def setup_socket(self, sock, force):
+		nfds = os.environ.get("LISTEN_FDS")
+		if nfds and os.environ.get("LISTEN_PID") == str(os.getpid()):
+			# systemd socket activation (sd_listen_fds(3)): reuse an inherited,
+			# already bound and listening socket instead of creating our own.
+			names = os.environ.get("LISTEN_FDNAMES", "").split(":")
+			idx = names.index("fail2ban") if "fail2ban" in names else 0
+			idx = min(idx, int(nfds) - 1)
+			os.environ.pop("LISTEN_PID", None)
+			os.environ.pop("LISTEN_FDS", None)
+			os.environ.pop("LISTEN_FDNAMES", None)
+			logSys.info("Using socket activation, inherited socket %r", sock)
+			self.set_socket(socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, fileno=3 + idx))
+			self.socket.setblocking(False)
+			self.accepting = True
+		else:
+			# Remove socket
+			if os.path.exists(sock):
+				logSys.error("Fail2ban seems to be already running")
+				if force:
+					logSys.warning("Forcing execution of the server")
+					self._remove_sock()
+				else:
+					raise AsyncServerException("Server already running")
+			# Creates the socket.
+			self.create_socket(socket.AF_UNIX, socket.SOCK_STREAM)
+			self.set_reuse_addr()
+			try:
+				self.bind(sock)
+			except Exception: # pragma: no cover
+				raise AsyncServerException("Unable to bind socket %s" % self.__sock)
+			self.listen(1)
+			# Sets the init flag.
+			self.__init = True
+		AsyncServer.__markCloseOnExec(self.socket)
+
 	##
 	# Starts the communication server.
 	#
 	# @param sock: socket file.
 	# @param force: remove the socket file if exists.
-	
+
 	def start(self, sock, force, timeout=None, use_poll=False):
 		self.__worker = threading.current_thread()
 		self.__sock = sock
-		# Remove socket
-		if os.path.exists(sock):
-			logSys.error("Fail2ban seems to be already running")
-			if force:
-				logSys.warning("Forcing execution of the server")
-				self._remove_sock()
-			else:
-				raise AsyncServerException("Server already running")
-		# Creates the socket.
-		self.create_socket(socket.AF_UNIX, socket.SOCK_STREAM)
-		self.set_reuse_addr()
-		try:
-			self.bind(sock)
-		except Exception: # pragma: no cover
-			raise AsyncServerException("Unable to bind socket %s" % self.__sock)
-		AsyncServer.__markCloseOnExec(self.socket)
-		self.listen(1)
-		# Sets the init flag.
-		self.__init = self.__loop = self.__active = True
+		self.setup_socket(sock, force)
+		self.__loop = self.__active = True
 		# Execute on start event (server ready):
 		if self.onstart:
 			self.onstart()

--- a/fail2ban/tests/sockettestcase.py
+++ b/fail2ban/tests/sockettestcase.py
@@ -25,6 +25,7 @@ __copyright__ = "Copyright (c) 2013 Steven Hiscocks"
 __license__ = "GPL"
 
 import os
+import socket
 import sys
 import tempfile
 import threading
@@ -34,6 +35,7 @@ import unittest
 from .utils import LogCaptureTestCase
 
 from .. import protocol
+from ..server import asyncserver
 from ..server.asyncserver import asyncore, RequestHandler, loop, AsyncServer, AsyncServerException
 from ..server.utils import Utils
 from ..client.csocket import CSocket
@@ -202,6 +204,39 @@ class Socket(LogCaptureTestCase):
 		# check errors were logged:
 		self.assertLogged("Server connection was closed: test errors in poll",
 			"Too many errors - stop logging connection errors", all=True)
+
+	def testSocketActivation(self):
+		# Simulate a socket already bound/listening, handed to us as an
+		# inherited fd (systemd socket activation, sd_listen_fds(3)):
+		presock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+		presock.bind(self.sock_name)
+		presock.listen(5)
+		# dup to a fresh fd first (presock.fileno() might already be 3):
+		fd = os.dup(presock.fileno())
+		presock.close()
+		os.dup2(fd, 3)
+		os.close(fd)
+
+		self.addCleanup(os.environ.pop, "LISTEN_PID", None)
+		self.addCleanup(os.environ.pop, "LISTEN_FDS", None)
+		self.addCleanup(lambda: os.path.exists(self.sock_name) and os.remove(self.sock_name))
+		os.environ["LISTEN_PID"] = str(os.getpid())
+		os.environ["LISTEN_FDS"] = "1"
+
+		serverThread = self._createServerThread()
+		# consumed once picked up, so forked actions don't misinterpret them:
+		self.assertNotIn("LISTEN_PID", os.environ)
+		self.assertNotIn("LISTEN_FDS", os.environ)
+
+		client = Utils.wait_for(self._serverSocket, 2)
+		testMessage = ["A", "test", "message"]
+		self.assertEqual(client.send(testMessage), testMessage)
+
+		self.server.stop()
+		self._stopServerThread()
+		self.assertFalse(serverThread.is_alive())
+		# socket file is owned by the service manager, must not be removed:
+		self.assertTrue(os.path.exists(self.sock_name))
 
 	def testSocketForce(self):
 		open(self.sock_name, 'w').close() # Create sock file

--- a/files/fail2ban.socket.in
+++ b/files/fail2ban.socket.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Fail2Ban Socket
+Documentation=man:fail2ban(1)
+
+[Socket]
+ListenStream=%t/fail2ban/fail2ban.sock
+FileDescriptorName=fail2ban
+SocketMode=0600
+RuntimeDirectory=fail2ban
+
+[Install]
+WantedBy=sockets.target

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ class install_scripts_f2b(install_scripts):
 		except: # pragma: no cover
 			print('WARNING: Cannot find root-base option, check the bin-path to fail2ban-scripts in "fail2ban.service" and "fail2ban-openrc.init".')
 
-		scripts = ['fail2ban.service', 'fail2ban-openrc.init']
+		scripts = ['fail2ban.service', 'fail2ban.socket', 'fail2ban-openrc.init']
 		for script in scripts:
 			print(('Creating %s/%s (from %s.in): @BINDIR@ -> %s' % (buildroot, script, script, install_dir)))
 			with open(os.path.join(source_dir, 'files/%s.in' % script), 'r') as fn:
@@ -294,5 +294,6 @@ if sys.argv[1] == "install":
 	print("They are in \"/etc/fail2ban/\".")
 	print("")
 	print("You can also install systemd service-unit file from \"build/fail2ban.service\"")
+	print("(optionally paired with \"build/fail2ban.socket\" to enable socket activation)")
 	print("resp. corresponding init script from \"files/*-initd\".")
 	print("")


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [X] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves or describe the approach in detail
      (There were no pre-existing issues about this that I could find)
- [X] **MAKE SURE** this PR doesn't break existing tests
- [X] **KEEP PR small** so it could be easily reviewed
- [X] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      (and `# failJSON`) within `fail2ban/tests/files/logs/X` file
      (No new failregexes)
- [X] **PROVIDE ChangeLog** entry describing the pull request

---

This PR adds support for letting systemd manage fail2ban's socket's creation and lifecycle by providing the socket using fd-passing. This allows any services dependent on communicating with fail2ban via this socket to be started in parallel with fail2ban during boot, as well as making restarts more graceful by pausing incoming traffic on the socket while fail2ban restarts.