### PR TITLE
fixes GHSA-33wh-ccjc-p397: avoid catastrophic backtracking explosion for REs in domino-smtp and dovecot filter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,7 @@ ver. 1.1.1-dev-1 (20??/??/??) - development nightly edition
   to use it as before set `mode = more` for exim jail, but be aware of the consequences.
 
 ### Fixes
+* fixes catastrophic backtracking explosion for REs in domino-smtp and dovecot filters (GHSA-33wh-ccjc-p397, gh-4221)
 * fixes `systemd` bug with missing journal descriptor after rotation by reopening of journal if it is recognized as not alive (gh-3929)
 * improve threaded clean-up of all filters, new thread functions `afterStop` (to force clean-up after stop) and `done`, invoking `afterStop` once
 * ensure journal-reader is always closed (additional prevention against leaks and "too many open files"), thereby avoid sporadic segfault

--- a/config/filter.d/domino-smtp.conf
+++ b/config/filter.d/domino-smtp.conf
@@ -23,10 +23,7 @@
 
 [Definition]
 # Option:  failregex
-# Notes.:  regex to match the password failure messages in the logfile. The
-#          host must be matched by a group named "host". The tag "<HOST>" can
-#          be used for standard IP/hostname matching and is only an alias for
-#          (?:::f{4,6}:)?(?P<host>\S+)
+# Notes.:  regex to match the password failure messages in the logfile.
 # Values:  TEXT
 #
 # Sample log entries (used different time formats and an extra sample with process info in front of date)
@@ -37,9 +34,9 @@
 
 __prefix = (?:\[[^\]]+\])?\s*
 __opt_data = (?::|\s+\[[^\]]+\])
-failregex = ^%(__prefix)sSMTP Server%(__opt_data)s Authentication failed for user .*? \; connecting host \[?<HOST>\]?$
-            ^%(__prefix)ssmtp: (?:[^\[]+ )*\[?<HOST>\]? authentication failure using internet password\s*$
-            ^%(__prefix)sSMTP Server%(__opt_data)s Connection from \[?<HOST>\]? rejected for policy reasons\.
+failregex = ^%(__prefix)sSMTP Server%(__opt_data)s Authentication failed for user .*? \; connecting host \[?<ADDR>\]?$
+            ^%(__prefix)ssmtp: (?:<F-USER>(?:[^\[ ]+ )*[^\[ ]+</F-USER> )?\[?<ADDR>\]? authentication failure using internet password\s*$
+            ^%(__prefix)sSMTP Server%(__opt_data)s Connection from \[?<ADDR>\]? rejected for policy reasons\.
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.

--- a/config/filter.d/dovecot.conf
+++ b/config/filter.d/dovecot.conf
@@ -15,7 +15,7 @@ _auth_driver = [a-z\-]+
 
 _auth_worker = (?:dovecot: )?auth(?:-worker)?
 _auth_worker_info = (?:%(_auth_driver)s: )?(?:conn \w+:auth(?:-worker)? \([^\)]+\): auth(?:-worker)?<\d+>: )?
-_bypass_reject_reason = (?:: (?:\w+\([^\):]*\) \w+|[^\(]+))*
+_bypass_reject_reason = (?::(?: [^\( ]*|\([^\(]*\))*)?
 
 prefregex = ^%(__prefix_line)s(?:%(_auth_worker)s(?:\((?:\S*,<ADDR>(?:,\S*)?|[^\)]+)\))?(?:<[^>]+>)?: )?(?:%(__pam_auth)s(?:\(dovecot:auth\))?: |(?:pop3|imap|managesieve|submission)-login: )?(?:request \[\d+\]: )?(?:Info: )?%(_auth_worker_info)s<F-CONTENT>.+</F-CONTENT>$
 

--- a/fail2ban/tests/files/logs/domino-smtp
+++ b/fail2ban/tests/files/logs/domino-smtp
@@ -7,6 +7,11 @@
 # failJSON: { "time": "2016-11-07T22:21:20", "match": true , "host": "1.2.3.4" }
 2016-11-07 22:21:20   smtp: postmaster [1.2.3.4] authentication failure using internet password
 
+# failJSON: { "time": "2016-11-07T22:21:22", "match": true , "host": "192.0.2.5", "desc": "GHSA-33wh-ccjc-p397, positive case (match, no hangs)" }
+2016-11-07 22:21:22   smtp: A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A 192.0.2.5 authentication failure using internet password
+# failJSON: { "match": false, "desc": "GHSA-33wh-ccjc-p397, negative case (bypass, no hangs)" }
+2016-11-07 22:21:23   smtp: A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A 192.0.2.5
+
 # failJSON: { "time": "2018-09-19T17:25:50", "match": true , "host": "192.0.2.1", "desc":"different log-format" }
 2018-09-19 17:25:50   SMTP Server [0D14:0027-1334] Authentication failed for user Bad Hacker ; connecting host [192.0.2.1]
 # failJSON: { "time": "2018-09-19T17:25:52", "match": true , "host": "192.0.2.2", "desc":"gh-2228, rejected for policy reasons" }

--- a/fail2ban/tests/files/logs/domino-smtp
+++ b/fail2ban/tests/files/logs/domino-smtp
@@ -7,6 +7,9 @@
 # failJSON: { "time": "2016-11-07T22:21:20", "match": true , "host": "1.2.3.4" }
 2016-11-07 22:21:20   smtp: postmaster [1.2.3.4] authentication failure using internet password
 
+# failJSON: { "time": "2016-11-07T22:21:21", "match": true , "host": "192.0.2.4", "user": "user with space in name" }
+2016-11-07 22:21:21   smtp: user with space in name [192.0.2.4] authentication failure using internet password
+
 # failJSON: { "time": "2016-11-07T22:21:22", "match": true , "host": "192.0.2.5", "desc": "GHSA-33wh-ccjc-p397, positive case (match, no hangs)" }
 2016-11-07 22:21:22   smtp: A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A A 192.0.2.5 authentication failure using internet password
 # failJSON: { "match": false, "desc": "GHSA-33wh-ccjc-p397, negative case (bypass, no hangs)" }

--- a/fail2ban/tests/files/logs/dovecot
+++ b/fail2ban/tests/files/logs/dovecot
@@ -144,6 +144,11 @@ Aug 30 00:10:57 auth(info@example.com,192.0.2.110,sasl:login)<CvN+E95Uf4e7eEnj>:
 # failJSON: { "time": "2004-08-30T00:11:05", "match": true , "host": "192.0.2.110", "desc": "closed after 3 attempts (password mismatch), gh-4196" }
 Aug 30 00:11:05 imap-login: Info: Login aborted: Connection closed (auth failed, 3 attempts in 16 secs) (auth_failed): user=<info@example.com>, method=PLAIN, rip=192.0.2.110, lip=0.0.0.0, TLS, session=<CvN+E95Uf4e7eEnj>
 
+# failJSON: { "time": "2004-08-31T16:06:05", "match": true , "host": "192.0.2.111", "desc": "GHSA-33wh-ccjc-p397, positive case (match, no hangs)" }
+Aug 31 16:06:05 s166-62-100-187 dovecot: imap-login: Disconnected: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: (reason: some unknown reason) (tried to use disallowed test auth): user=<>, rip=192.0.2.111
+# failJSON: { "match": false , "desc": "GHSA-33wh-ccjc-p397, negative case (bypass, no hangs)" }
+Aug 31 16:06:06 s166-62-100-187 dovecot: imap-login: Disconnected: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: a: test no match
+
 # ---------------------------------------
 # Test-cases of aggressive mode:
 # ---------------------------------------


### PR DESCRIPTION
This PR fixes [GHSA-33wh-ccjc-p397](https://github.com/fail2ban/fail2ban/security/advisories/GHSA-33wh-ccjc-p397): avoid catastrophic backtracking explosion for REs in domino-smtp and dovecot filter.

Amend to #3370.