### PR TITLE
filter.d/nginx-botsearch: support the journal log format

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ ver. 1.1.2-dev-1 (20??/??/??) - development nightly edition
 -----------
 
 ### Fixes
+* `filter.d/nginx-botsearch.conf` - error-log regex extended with support of journal format (gh-3732)
 
 ### New Features and Enhancements
 

--- a/config/filter.d/nginx-botsearch.conf
+++ b/config/filter.d/nginx-botsearch.conf
@@ -5,11 +5,12 @@
 
 # Load regexes for filtering
 before = botsearch-common.conf
+         nginx-error-common.conf
 
 [Definition]
 
 failregex = ^<HOST> \- \S+ \[\] \"(GET|POST|HEAD) \/<block> \S+\" 404 .+$
-            ^ \[error\] \d+#\d+: \*\d+ (\S+ )?\"\S+\" (failed|is not found) \(2\: No such file or directory\), client\: <HOST>\, server\: \S*\, request: \"(GET|POST|HEAD) \/<block> \S+\"\, .*?$
+            ^%(__prefix_line)s(\S+ )?\"\S+\" (failed|is not found) \(2\: No such file or directory\), client\: <HOST>\, server\: \S*\, request: \"(GET|POST|HEAD) \/<block> \S+\"\, .*?$
 
 ignoreregex = 
 

--- a/fail2ban/tests/files/logs/nginx-botsearch
+++ b/fail2ban/tests/files/logs/nginx-botsearch
@@ -33,3 +33,11 @@
 
 # failJSON: { "time": "2015-01-21T15:02:27", "match": true , "host": "5.7.9.2" }
 2015/01/21 15:02:27 [error] 2833#0: *16813 "/var/www/site/roundcube/" is not found (2: No such file or directory), client: 5.7.9.2, server: localhost, request: "GET /roundcube/ HTTP/1.1", host: "1.2.3.4"
+
+# filterOptions: [{"logtype": "journal"}]
+
+# failJSON: { "match": true, "host": "5.7.9.2", "desc": "systemd journal message, gh-3732" }
+host nginx[2833]: 2015/01/21 10:56:10 [error] 2833#0: *16336 open() "/var/www/site/cgi-bin/php4" failed (2: No such file or directory), client: 5.7.9.2, server: localhost, request: "GET /cgi-bin/php4 HTTP/1.1", host: "1.2.3.4"
+
+# failJSON: { "match": true, "host": "5.7.9.2", "desc": "systemd journal message, is not found variant, gh-3732" }
+host nginx[2833]: 2015/01/21 15:02:27 [error] 2833#0: *16813 "/var/www/site/roundcube/" is not found (2: No such file or directory), client: 5.7.9.2, server: localhost, request: "GET /roundcube/ HTTP/1.1", host: "1.2.3.4"


### PR DESCRIPTION
`nginx-botsearch` misses every error-log line when nginx logs to the systemd journal, because its regex hardcodes the file-format prefix:

```
^ \[error\] \d+#\d+: \*\d+ 
```

```
$ fail2ban-regex '<journal line>' config/filter.d/nginx-botsearch.conf[logtype=journal]

before: Lines: 1 lines, 0 ignored, 0 matched, 1 missed
after:  Lines: 1 lines, 0 ignored, 1 matched, 0 missed
```

The plain file format still matches with the default `logtype=file`, `1 matched, 0 missed` before and after.

## The fix

`nginx-error-common.conf` and `%(__prefix_line)s`, which is exactly what gh-3646 (commit `e03df480`) did for `nginx-forbidden`, `nginx-http-auth` and `nginx-limit-req`. `nginx-botsearch` was simply left out of that pass.

## On the other filter in the issue

gh-3732 names both `nginx-bad-request.conf` and `nginx-botsearch.conf`. I only changed the latter, deliberately: `nginx-bad-request` matches the **access** log (`^<HOST> - \S+ \[\] "[^"]*" 400`), which has no error-log prefix to parameterise, so `__prefix_line` does not apply to it. If you want journal support there it is a different change and I did not want to bundle a guess with a verified fix.

## Verification

Two journal-format lines added to `fail2ban/tests/files/logs/nginx-botsearch` under `# filterOptions: [{"logtype": "journal"}]`.

They are not invented. They are the file-format sample lines already in that file, re-prefixed with `host nginx[2833]: `, the same convention upstream used in `nginx-http-auth:22` and `nginx-limit-req:29`.

With the filter change stashed and the new lines in place:

```
AssertionError: nginx-botsearch{'logtype': 'journal'}: True is not false : Line not matched when should have
on: fail2ban/tests/files/logs/nginx-botsearch:40
FAILED (failures=1)
```

Restored:

```
Ran 1 test in 0.008s
OK
```

`fail2ban-testcases --no-network samples` is 100 tests OK, and the full run is 541 tests OK (27 skipped, missing optional modules).

*Disclosure: written with AI assistance (Claude Code). I ran fail2ban-regex for both logtypes myself, confirmed the file format still matches, and checked the journal prefix convention against the lines upstream already added.*
