### PR TITLE
paths-arch: define default banactions

### DIFF
--- a/config/paths-arch.conf
+++ b/config/paths-arch.conf
@@ -8,6 +8,8 @@ after  = paths-overrides.local
 
 
 [DEFAULT]
+banaction = iptables-multiport
+banaction_allports = iptables-allports
 
 apache_error_log = /var/log/httpd/*error_log
 


### PR DESCRIPTION
jail.conf no longer defines active banaction defaults since 1.1.1, and paths-debian.conf now supplies Debian’s nftables defaults. Arch packaging switches jail.conf to paths-arch.conf, which currently leaves %(banaction)s undefined and breaks stock jail parsing/tests. This restores the historical iptables defaults for the Arch path file.

Before submitting your PR, please review the following checklist:

- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves or describe the approach in detail
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      (and `# failJSON`) within `fail2ban/tests/files/logs/X` file
- [ ] **PROVIDE ChangeLog** entry describing the pull request
