### PR TITLE
Fix systemd socket activation being broken

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ ver. 1.1.2-dev-1 (20??/??/??) - development nightly edition
 * `filter.d/nginx-botsearch.conf` - error-log regex extended with support of journal format (gh-3732)
 * `filter.d/apache-noscript.conf` - match a request for the `cgi-bin` directory itself (no script name after it),
   the `cgi-bin` alternative required a following path segment so `/cgi-bin/` and `/cgi-bin` were not matched (gh-4217)
+* sockets passed via `systemd` socket activation (`sd_listen_fds(3)`) are not shut down anymore
 
 ### New Features and Enhancements
 * `filter.d/cowrie.conf` - new filter and jail for Cowrie SSH/Telnet honeypot JSON log output (gh-4216)

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,7 +14,7 @@ ver. 1.1.2-dev-1 (20??/??/??) - development nightly edition
 * `filter.d/nginx-botsearch.conf` - error-log regex extended with support of journal format (gh-3732)
 * `filter.d/apache-noscript.conf` - match a request for the `cgi-bin` directory itself (no script name after it),
   the `cgi-bin` alternative required a following path segment so `/cgi-bin/` and `/cgi-bin` were not matched (gh-4217)
-* sockets passed via `systemd` socket activation (`sd_listen_fds(3)`) are not shut down or removed anymore
+* sockets passed via `systemd` socket activation (`sd_listen_fds(3)`) are not shut down or removed anymore (gh-4225)
 
 ### New Features and Enhancements
 * `filter.d/cowrie.conf` - new filter and jail for Cowrie SSH/Telnet honeypot JSON log output (gh-4216)

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,7 +14,7 @@ ver. 1.1.2-dev-1 (20??/??/??) - development nightly edition
 * `filter.d/nginx-botsearch.conf` - error-log regex extended with support of journal format (gh-3732)
 * `filter.d/apache-noscript.conf` - match a request for the `cgi-bin` directory itself (no script name after it),
   the `cgi-bin` alternative required a following path segment so `/cgi-bin/` and `/cgi-bin` were not matched (gh-4217)
-* sockets passed via `systemd` socket activation (`sd_listen_fds(3)`) are not shut down anymore
+* sockets passed via `systemd` socket activation (`sd_listen_fds(3)`) are not shut down or removed anymore
 
 ### New Features and Enhancements
 * `filter.d/cowrie.conf` - new filter and jail for Cowrie SSH/Telnet honeypot JSON log output (gh-4216)

--- a/fail2ban/server/asyncserver.py
+++ b/fail2ban/server/asyncserver.py
@@ -201,6 +201,7 @@ class AsyncServer(asyncore.dispatcher):
 		asyncore.dispatcher.__init__(self)
 		self.__transmitter = transmitter
 		self.__sock = "/var/run/fail2ban/fail2ban.sock"
+		self.__shutdown_socket = True
 		self.__init = False
 		self.__active = False
 		self.__errCount = {'accept': 0, 'listen': 0}
@@ -249,6 +250,8 @@ class AsyncServer(asyncore.dispatcher):
 			os.environ.pop("LISTEN_FDS", None)
 			os.environ.pop("LISTEN_FDNAMES", None)
 			logSys.info("Using socket activation, inherited socket %r", sock)
+			# prevent socket from being shut down on close
+			self.__shutdown_socket = False
 			self.set_socket(socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, fileno=3 + idx))
 			self.socket.setblocking(False)
 			self.accepting = True
@@ -298,7 +301,7 @@ class AsyncServer(asyncore.dispatcher):
 		if self.__active:
 			self.__loop = False
 			# shutdown socket here:
-			if self.socket:
+			if self.__shutdown_socket and self.socket:
 				try:
 					self.socket.shutdown(socket.SHUT_RDWR)
 				except socket.error: # pragma: no cover - normally unreachable

--- a/fail2ban/tests/sockettestcase.py
+++ b/fail2ban/tests/sockettestcase.py
@@ -213,9 +213,10 @@ class Socket(LogCaptureTestCase):
 		presock.listen(5)
 		# dup to a fresh fd first (presock.fileno() might already be 3):
 		fd = os.dup(presock.fileno())
+		# keep backup fd to allow for shutdown test
+		self.addCleanup(os.close, fd)
 		presock.close()
 		os.dup2(fd, 3)
-		os.close(fd)
 
 		self.addCleanup(os.environ.pop, "LISTEN_PID", None)
 		self.addCleanup(os.environ.pop, "LISTEN_FDS", None)
@@ -237,6 +238,10 @@ class Socket(LogCaptureTestCase):
 		self.assertFalse(serverThread.is_alive())
 		# socket file is owned by the service manager, must not be removed:
 		self.assertTrue(os.path.exists(self.sock_name))
+
+		# socket is owned by the service manager, must not be shut down:
+		with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as csock:
+			csock.connect(self.sock_name)
 
 	def testSocketForce(self):
 		open(self.sock_name, 'w').close() # Create sock file

--- a/files/fail2ban.service.in
+++ b/files/fail2ban.service.in
@@ -8,6 +8,8 @@ PartOf=iptables.service firewalld.service ip6tables.service ipset.service nftabl
 Type=simple
 Environment="PYTHONNOUSERSITE=1"
 RuntimeDirectory=fail2ban
+# prevents socket created by fail2ban.socket from being removed
+RuntimeDirectoryPreserve=yes
 StateDirectory=fail2ban
 ExecStart=@BINDIR@/fail2ban-server -xf start
 # if should be logged in systemd journal, use following line or set logtarget to sysout in fail2ban.local


### PR DESCRIPTION
Before submitting your PR, please review the following checklist:

- [x] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves or describe the approach in detail
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      (and `# failJSON`) within `fail2ban/tests/files/logs/X` file
- [x] **PROVIDE ChangeLog** entry describing the pull request

---

While trying to use fail2ban with the provided `fail2ban.socket` file I noticed that the resulting socket activation is broken in two ways:
1. the socket passed to fail2ban is shut down (by fail2ban) when fail2ban is stopped, resulting in systemd logging errors since it can no longer listen on it
2. the socket is created in the runtime directory of `fail2ban.service`, resulting in its removal (by systemd) when the service is stopped

This PR solves them as follows:
1. remember whether the socket was passed via systemd and skip shutdown in this case
2. instruct systemd to preserve the runtime directory (fail2ban still performs some cleanup, for example removing the pid file)