### PR TITLE
Add default banactions

### DIFF
--- a/config/paths-opensuse.conf
+++ b/config/paths-opensuse.conf
@@ -9,6 +9,9 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
+banaction = nftables
+banaction_allports = nftables[type=allports]
+
 syslog_mail = /var/log/mail
 
 syslog_mail_warn = %(syslog_mail)s


### PR DESCRIPTION
According to the changelog for 1.1.1, default `banactions` need to be specified in paths-*.conf (maintainer level) now.

Before submitting your PR, please review the following checklist:

- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves or describe the approach in detail
- [x] **MAKE SURE** this PR doesn't break existing tests
- [x] **KEEP PR small** so it could be easily reviewed
- [x] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      (and `# failJSON`) within `fail2ban/tests/files/logs/X` file
- [ ] **PROVIDE ChangeLog** entry describing the pull request
