### PR TITLE
paths-opensuse.conf: specify default banactions

### DIFF
--- a/config/paths-opensuse.conf
+++ b/config/paths-opensuse.conf
@@ -9,11 +9,26 @@ after  = paths-overrides.local
 
 [DEFAULT]
 
+banaction = nftables
+banaction_allports = nftables[type=allports]
+
+syslog_local0  = /var/log/messages
+
 syslog_mail = /var/log/mail
 
 syslog_mail_warn = %(syslog_mail)s
 
 syslog_authpriv = %(syslog_local0)s
+
+syslog_user =  %(syslog_local0)s
+
+syslog_ftp  = %(syslog_local0)s
+
+syslog_daemon  = %(syslog_local0)s
+
+apache_error_log = /var/log/apache2/*error_log
+
+apache_access_log = /var/log/apache2/*access_log
 
 pureftpd_log = %(syslog_local0)s
 


### PR DESCRIPTION
Since 1.1.1 default banactions need to be specified. Take the opportunity to also synchronize the paths with current Factory settings.

Before submitting your PR, please review the following checklist:

- [ ] **CONSIDER adding a unit test** if your PR resolves an issue
- [ ] **LIST ISSUES** this PR resolves or describe the approach in detail
- [X] **MAKE SURE** this PR doesn't break existing tests
- [X] **KEEP PR small** so it could be easily reviewed
- [X] **AVOID** making unnecessary stylistic changes in unrelated code
- [ ] **ACCOMPANY** each new `failregex` for filter `X` with sample log lines
      (and `# failJSON`) within `fail2ban/tests/files/logs/X` file
- [ ] **PROVIDE ChangeLog** entry describing the pull request
