### PR TITLE
gitlab: add json mode for application_json.log

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,8 @@ ver. 1.1.2-dev-1 (20??/??/??) - development nightly edition
 
 ### New Features and Enhancements
 * `filter.d/cowrie.conf` - new filter and jail for Cowrie SSH/Telnet honeypot JSON log output (gh-4216)
+* `filter.d/gitlab.conf` - new `mode` option adding support for the `application_json.log` format that
+  superseded the deprecated `application.log`; default mode `text` keeps the previous behaviour (gh-3566)
 
 
 ver. 1.1.1 (2026/08/15) - triple-one-win

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,8 +20,8 @@ ver. 1.1.2-dev-1 (20??/??/??) - development nightly edition
 
 ### New Features and Enhancements
 * `filter.d/cowrie.conf` - new filter and jail for Cowrie SSH/Telnet honeypot JSON log output (gh-4216)
-* `filter.d/gitlab.conf` - new `mode` option adding support for the `application_json.log` format that
-  superseded the deprecated `application.log`; default mode `text` keeps the previous behaviour (gh-3566)
+* `filter.d/gitlab.conf` - `logtype` option `json` adding support for the `application_json.log` format that
+  superseded the deprecated `application.log`; default type `file` keeps the previous behaviour (gh-3566, gh-4230)
 
 
 ver. 1.1.1 (2026/08/15) - triple-one-win

--- a/config/filter.d/gitlab.conf
+++ b/config/filter.d/gitlab.conf
@@ -1,6 +1,32 @@
 # Fail2Ban filter for Gitlab
 # Detecting unauthorized access to the Gitlab Web portal
-# typically logged in /var/log/gitlab/gitlab-rails/application.log
+#
+# Mode "text" (default) reads the legacy application.log, typically logged in
+# /var/log/gitlab/gitlab-rails/application.log
+#
+# Mode "json" reads the structured application_json.log that superseded it
+# (application.log was deprecated by Gitlab in 15.10), typically logged in
+# /var/log/gitlab/gitlab-rails/application_json.log
 
 [Definition]
+
+# Log format: "text" (application.log) or "json" (application_json.log)
+mode = text
+
+failregex = <<mode>/failregex>
+datepattern = <<mode>/datepattern>
+ignoreregex =
+
+[text]
+
 failregex = ^: Failed Login: username=<F-USER>.+</F-USER> ip=<HOST>$
+datepattern = {^LN-BEG}%%ExY(?P<_sep>[-/.])%%m(?P=_sep)%%d[T ]%%H:%%M:%%S(?:[.,]%%f)?(?:\s*%%z)?
+
+[json]
+
+# bounded run of "key":value pairs, used to skip over fields we don't care
+# about (order of tags in the message is significant, so relative positions
+# of time, meta.remote_ip and message are anchored below)
+_groupre = (?:\s*"(?!(?:time|meta\.remote_ip|message)\b)\w[^"]+"\s*:\s*(?:"[^"]+"|\w+)\s*[,\}])
+failregex = ^%(_groupre)s*"meta\.remote_ip":"<ADDR>"\s*,\s*%(_groupre)s*"message":"Failed Login: username=<F-USER>(?:\S*|[^"]*?)(?= ip=)</F-USER>
+datepattern = ^\{%(_groupre)s*"time":"%%Y-%%m-%%dT%%H:%%M:%%S\.%%f%%z"\s*,\s*

--- a/config/filter.d/gitlab.conf
+++ b/config/filter.d/gitlab.conf
@@ -1,28 +1,28 @@
 # Fail2Ban filter for Gitlab
 # Detecting unauthorized access to the Gitlab Web portal
 #
-# Mode "text" (default) reads the legacy application.log, typically logged in
+# logtype "file" (default) reads the legacy application.log, typically logged in
 # /var/log/gitlab/gitlab-rails/application.log
 #
-# Mode "json" reads the structured application_json.log that superseded it
+# logtype "json" reads the structured application_json.log that superseded it
 # (application.log was deprecated by Gitlab in 15.10), typically logged in
 # /var/log/gitlab/gitlab-rails/application_json.log
 
 [Definition]
 
-# Log format: "text" (application.log) or "json" (application_json.log)
-mode = text
+# Log format: "file" (application.log) or "json" (application_json.log)
+logtype = file
 
-failregex = <<mode>/failregex>
-datepattern = <<mode>/datepattern>
+failregex = <lt_<logtype>/failregex>
+datepattern = <lt_<logtype>/datepattern>
 ignoreregex =
 
-[text]
+[lt_file]
 
 failregex = ^: Failed Login: username=<F-USER>.+</F-USER> ip=<HOST>$
 datepattern = {^LN-BEG}%%ExY(?P<_sep>[-/.])%%m(?P=_sep)%%d[T ]%%H:%%M:%%S(?:[.,]%%f)?(?:\s*%%z)?
 
-[json]
+[lt_json]
 
 # bounded run of "key":value pairs, used to skip over fields we don't care
 # about (order of tags in the message is significant, so relative positions

--- a/config/jail.conf
+++ b/config/jail.conf
@@ -865,6 +865,7 @@ protocol = udp
 logpath  = /usr/local/vpnserver/security_log/*/sec.log
 
 [gitlab]
+# for the newer application_json.log set: filter = gitlab[mode=json]
 port    = http,https
 logpath = /var/log/gitlab/gitlab-rails/application.log
 

--- a/fail2ban/tests/files/logs/gitlab
+++ b/fail2ban/tests/files/logs/gitlab
@@ -3,3 +3,14 @@
 2020-04-09T14:04:00.667Z: Failed Login: username=admin ip=80.10.11.12
 # failJSON: { "time": "2020-04-09T16:15:09", "match": true , "host": "80.10.11.12" }
 2020-04-09T14:15:09.344Z: Failed Login: username=user name ip=80.10.11.12
+
+# Access of unauthorized host in /var/log/gitlab/gitlab-rails/application_json.log
+# filterOptions: [{"mode": "json"}]
+
+# failJSON: { "time": "2023-08-25T13:25:19", "match": true , "host": "87.250.224.11" }
+{"severity":"INFO","time":"2023-08-25T11:25:19.979Z","correlation_id":"01H8P721YTW1YH5Q7YCSJPVJ5T","meta.caller_id":"SessionsController#new","meta.remote_ip":"87.250.224.11","meta.feature_category":"system_access","meta.client_id":"ip/87.250.224.11","message":"Failed Login: username=admin ip=87.250.224.11"}
+# failJSON: { "time": "2023-08-25T13:31:07", "match": true , "host": "2001:db8::1" }
+{"severity":"INFO","time":"2023-08-25T11:31:07.512Z","correlation_id":"01H8P73ABCDEF1234567890ABCD","meta.caller_id":"SessionsController#new","meta.remote_ip":"2001:db8::1","meta.feature_category":"system_access","meta.client_id":"ip/2001:db8::1","message":"Failed Login: username=git ip=2001:db8::1"}
+# a successful login must not match
+# failJSON: { "match": false }
+{"severity":"INFO","time":"2023-08-25T11:55:10.525Z","correlation_id":"01H8P8RPMVW53W0KWEN2H2DNF4","meta.caller_id":"SessionsController#create","meta.remote_ip":"203.0.113.9","meta.feature_category":"system_access","meta.user":"admin","meta.user_id":2,"meta.client_id":"user/2","message":"Successful Login: username=admin ip=203.0.113.9 method=standard admin=true"}

--- a/fail2ban/tests/files/logs/gitlab
+++ b/fail2ban/tests/files/logs/gitlab
@@ -5,7 +5,7 @@
 2020-04-09T14:15:09.344Z: Failed Login: username=user name ip=80.10.11.12
 
 # Access of unauthorized host in /var/log/gitlab/gitlab-rails/application_json.log
-# filterOptions: [{"mode": "json"}]
+# filterOptions: [{"logtype": "json"}]
 
 # failJSON: { "time": "2023-08-25T13:25:19", "match": true , "host": "87.250.224.11" }
 {"severity":"INFO","time":"2023-08-25T11:25:19.979Z","correlation_id":"01H8P721YTW1YH5Q7YCSJPVJ5T","meta.caller_id":"SessionsController#new","meta.remote_ip":"87.250.224.11","meta.feature_category":"system_access","meta.client_id":"ip/87.250.224.11","message":"Failed Login: username=admin ip=87.250.224.11"}


### PR DESCRIPTION
Closes #3566

GitLab deprecated `application.log` in 15.10 and moved failed logins into the structured `application_json.log`, so the current `gitlab` filter no longer matches on a modern install. This adds a `mode` option: `text` (default) keeps the old behaviour, `json` reads the new format.

The json failregex is the one @sebres worked out in the issue, which the reporter confirmed works against real logs. I wired it up the same way `guacamole.conf` selects a format, and set the per-mode `datepattern` the way `cowrie.conf` does for its JSON `timestamp`.

## Verification

Default `text` mode still matches the existing sample lines:

```
$ fail2ban-regex config/filter.d/gitlab.conf ... (text log)
Lines: 2 lines, 0 ignored, 2 matched, 0 missed
```

New `json` mode on the added sample lines, one failed login (v4 and v6) matches, a successful login does not:

```
$ fail2ban-regex fail2ban/tests/files/logs/gitlab config/filter.d/gitlab.conf[mode=json]
Lines: ... 2 matched (the failures), successful login missed
```

Sample lines for both cases are added to `fail2ban/tests/files/logs/gitlab` under `# filterOptions: [{"mode": "json"}]`, with the IPs filled in from the reporter's redacted examples. `fail2ban-testcases samplestestcase` and `clientreadertestcase` pass.
